### PR TITLE
Align sidebar title for ID Capture across platforms

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -226,7 +226,7 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
-      label: "ID Scanning and Validation",
+      label: "ID Capture and Validation",
       collapsed: false,
       items: [
         "sdks/ios/id-capture/intro",
@@ -417,7 +417,7 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: "category",
-      label: "ID Scanning and Validation",
+      label: "ID Capture and Validation",
       collapsed: false,
       items: [
           "sdks/android/id-capture/intro",


### PR DESCRIPTION
Fixing a minor inconsistency that I introduced in the recent ID Capture supported docs refactoring