### PR TITLE
Add 7.3.2 release notes for all SDKs

### DIFF
--- a/docs/sdks/android/release-notes.md
+++ b/docs/sdks/android/release-notes.md
@@ -48,6 +48,15 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+### Bug Fixes
+
+* Fixed an issue where the camera could be displayed 90 degrees sideways.
+* Fixed a typo in the `labelCaptureValidationFlowOverlay:didCaptureLabelWithFields:` method.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/capacitor/release-notes.md
+++ b/docs/sdks/capacitor/release-notes.md
@@ -35,6 +35,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/cordova/release-notes.md
+++ b/docs/sdks/cordova/release-notes.md
@@ -35,6 +35,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/flutter/label-capture/advanced.md
+++ b/docs/sdks/flutter/label-capture/advanced.md
@@ -98,7 +98,8 @@ advancedOverlay.addListener(LabelCaptureAdvancedOverlayListener(
   },
 ));
 ```
-<!-->
+<!--
+
 ## Validation Flow
 
 Implementing a validation flow in your Smart Label Capture application differs from the [Get Started](/sdks/flutter/label-capture/get-started.md) steps outlined earlier as follows:

--- a/docs/sdks/flutter/release-notes.md
+++ b/docs/sdks/flutter/release-notes.md
@@ -44,6 +44,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/ios/release-notes.md
+++ b/docs/sdks/ios/release-notes.md
@@ -46,6 +46,14 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+### Bug Fixes
+
+* Fixed a typo in the `labelCaptureValidationFlowOverlay:didCaptureLabelWithFields:` method.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/linux/release-notes.md
+++ b/docs/sdks/linux/release-notes.md
@@ -23,6 +23,12 @@ keywords:
 
 * Updated `sc_barcode_scanner_settings_new_from_json` function to return an error in case a given JSON string contains unrecognized properties.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/net/android/release-notes.md
+++ b/docs/sdks/net/android/release-notes.md
@@ -25,6 +25,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/net/ios/release-notes.md
+++ b/docs/sdks/net/ios/release-notes.md
@@ -25,6 +25,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/react-native/release-notes.md
+++ b/docs/sdks/react-native/release-notes.md
@@ -46,6 +46,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/titanium/release-notes.md
+++ b/docs/sdks/titanium/release-notes.md
@@ -17,6 +17,12 @@ keywords:
 
 * Updated ARM MbedTLS from 3.6.2 to 3.6.3.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/web/release-notes.md
+++ b/docs/sdks/web/release-notes.md
@@ -45,6 +45,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/xamarin/android/release-notes.md
+++ b/docs/sdks/xamarin/android/release-notes.md
@@ -33,6 +33,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/xamarin/forms/release-notes.md
+++ b/docs/sdks/xamarin/forms/release-notes.md
@@ -33,6 +33,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025

--- a/docs/sdks/xamarin/ios/release-notes.md
+++ b/docs/sdks/xamarin/ios/release-notes.md
@@ -33,6 +33,12 @@ keywords:
 
 * Fixed an issue where the middle name read from an AAMVA-compliant barcode would be at times returned as `NONE`.
 
+## 7.3.2
+
+**Released**: June 25, 2025
+
+No updates for this framework in this release.
+
 ## 7.3.1
 
 **Released**: June 13, 2025


### PR DESCRIPTION
Added release notes for version 7.3.2 across all SDK documentation. The Android SDK notes include camera orientation and typo bug fixes, and the iOS SDK notes include a typo fix. All other SDKs note that there are no updates for this release.