### PR TITLE
Adjust wording about server headers when delivering resources

### DIFF
--- a/docs/sdks/web/add-sdk.md
+++ b/docs/sdks/web/add-sdk.md
@@ -452,8 +452,8 @@ await configure({
 ```
 
 :::note
-We suggest serving the library files with the proper headers `Content-Length` and `Content-Encoding` if any compression is present.
-In case of totally missing information, we show an estimated progress.
+The library files should be served with the proper header `Content-Length`. `Content-Encoding` should also be set if any compression is used.
+In case of missing information, the progress bar tries to show an estimated value, but can also not report progress at all for a while.
 :::
 
 ## Additional Information


### PR DESCRIPTION
Added the fact that in some cases the progress bar may also not report any progress for a while until the file has been fully loaded.