### PR TITLE
Add 7.4.3 release notes for all SDKs

### DIFF
--- a/docs/sdks/android/release-notes.md
+++ b/docs/sdks/android/release-notes.md
@@ -123,6 +123,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/capacitor/release-notes.md
+++ b/docs/sdks/capacitor/release-notes.md
@@ -95,6 +95,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/cordova/release-notes.md
+++ b/docs/sdks/cordova/release-notes.md
@@ -92,6 +92,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/flutter/release-notes.md
+++ b/docs/sdks/flutter/release-notes.md
@@ -104,6 +104,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/ios/release-notes.md
+++ b/docs/sdks/ios/release-notes.md
@@ -126,6 +126,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/linux/release-notes.md
+++ b/docs/sdks/linux/release-notes.md
@@ -43,6 +43,12 @@ keywords:
 * Improved Code128 and EAN13/UPCA scanning performance.
 * Reduced incorrect EAN13/UPCA, EAN8 and UPCE scans in cases of low resolution and out-of-focus.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/net/android/release-notes.md
+++ b/docs/sdks/net/android/release-notes.md
@@ -86,6 +86,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/net/ios/release-notes.md
+++ b/docs/sdks/net/ios/release-notes.md
@@ -90,6 +90,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/react-native/release-notes.md
+++ b/docs/sdks/react-native/release-notes.md
@@ -121,6 +121,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/titanium/release-notes.md
+++ b/docs/sdks/titanium/release-notes.md
@@ -27,6 +27,12 @@ keywords:
 * Improved support for non-standard GS1 AI codes.
 * The `Barcode` class now exposes a module count.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/web/release-notes.md
+++ b/docs/sdks/web/release-notes.md
@@ -116,6 +116,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/xamarin/android/release-notes.md
+++ b/docs/sdks/xamarin/android/release-notes.md
@@ -73,6 +73,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/xamarin/forms/release-notes.md
+++ b/docs/sdks/xamarin/forms/release-notes.md
@@ -73,6 +73,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/docs/sdks/xamarin/ios/release-notes.md
+++ b/docs/sdks/xamarin/ios/release-notes.md
@@ -73,6 +73,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/android/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/android/release-notes.md
@@ -66,6 +66,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/capacitor/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/capacitor/release-notes.md
@@ -41,6 +41,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/cordova/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/cordova/release-notes.md
@@ -42,6 +42,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/flutter/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/flutter/release-notes.md
@@ -46,6 +46,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/ios/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/ios/release-notes.md
@@ -71,6 +71,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/linux/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/linux/release-notes.md
@@ -24,6 +24,12 @@ keywords:
 * Improved Code128 and EAN13/UPCA scanning performance.
 * Reduced incorrect EAN13/UPCA, EAN8 and UPCE scans in cases of low resolution and out-of-focus.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/net/android/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/net/android/release-notes.md
@@ -44,6 +44,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/net/ios/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/net/ios/release-notes.md
@@ -44,6 +44,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/react-native/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/react-native/release-notes.md
@@ -66,6 +66,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/titanium/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/titanium/release-notes.md
@@ -19,6 +19,12 @@ keywords:
 * Improved support for non-standard GS1 AI codes.
 * The `Barcode` class now exposes a module count.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/web/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/web/release-notes.md
@@ -47,6 +47,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/xamarin/android/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/xamarin/android/release-notes.md
@@ -39,6 +39,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/xamarin/forms/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/xamarin/forms/release-notes.md
@@ -39,6 +39,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025

--- a/versioned_docs/version-7.5.0/sdks/xamarin/ios/release-notes.md
+++ b/versioned_docs/version-7.5.0/sdks/xamarin/ios/release-notes.md
@@ -39,6 +39,12 @@ keywords:
 
 * Deprecated `BarcodeCaptureOverlayStyle`.
 
+## 7.4.3
+
+**Released**: August 29, 2025
+
+No updates for this framework in this release.
+
 ## 7.4.2
 
 **Released**: August 15, 2025


### PR DESCRIPTION
Added entries for version 7.4.3, released August 29, 2025, to the release notes of all SDKs. Noted that there are no updates for any framework in this release.