### PR TITLE
[SDC-29571] Add CocoaPods private repository setup to framework docs

### DIFF
--- a/docs/sdks/capacitor/add-sdk.md
+++ b/docs/sdks/capacitor/add-sdk.md
@@ -119,8 +119,7 @@ As of March 2025, the public CocoaPods trunk repository is becoming read-only. S
 
 **Troubleshooting**: If you encounter issues:
 - Verify the repo is added: `pod repo list | grep scandit-private-specs`
-- Update the repo: `pod repo update scandit-private-specs` 
-- For CI/CD, add the repo setup command before `pod install`
+- Update the repo: `pod repo update scandit-private-specs`
 :::
 
 ## Additional Information

--- a/docs/sdks/capacitor/add-sdk.md
+++ b/docs/sdks/capacitor/add-sdk.md
@@ -92,7 +92,18 @@ yarn add <path to scandit-capacitor-datacapture-id plugin>
 
 ### Update the project
 
-After adding the plugins, you’ll want to make sure they’re added to your project properly:
+After adding the plugins, you'll want to make sure they're added to your project properly.
+
+**For iOS, first set up Scandit's private CocoaPods repository:**
+
+**Important:** This project uses Scandit's private CocoaPods repository. First-time setup:
+
+```sh
+# Add Scandit's private CocoaPods repository (one-time setup)
+pod repo add scandit-private-specs https://github.com/Scandit/scandit-cocoapods-specs.git
+```
+
+Then sync your project:
 
 ```sh
 # iOS
@@ -102,6 +113,15 @@ npx cap sync
 npx cap update android
 npx cap sync
 ```
+
+:::note
+As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+
+**Troubleshooting**: If you encounter issues:
+- Verify the repo is added: `pod repo list | grep scandit-private-specs`
+- Update the repo: `pod repo update scandit-private-specs` 
+- For CI/CD, add the repo setup command before `pod install`
+:::
 
 ## Additional Information
 

--- a/docs/sdks/capacitor/add-sdk.md
+++ b/docs/sdks/capacitor/add-sdk.md
@@ -115,7 +115,7 @@ npx cap sync
 ```
 
 :::note
-As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+The public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
 
 **Troubleshooting**: If you encounter issues:
 - Verify the repo is added: `pod repo list | grep scandit-private-specs`

--- a/docs/sdks/cordova/add-sdk.md
+++ b/docs/sdks/cordova/add-sdk.md
@@ -132,6 +132,32 @@ cordova plugin remove <id of the plugin being updated>
 cordova plugin add <local path, id or GitHub repo url of the plugin being updated>
 ```
 
+### iOS Setup
+
+For iOS development, Cordova uses CocoaPods to manage native dependencies. You'll need to set up Scandit's private CocoaPods repository:
+
+**Important:** This project uses Scandit's private CocoaPods repository. First-time setup:
+
+```sh
+# Add Scandit's private CocoaPods repository (one-time setup)
+pod repo add scandit-private-specs https://github.com/Scandit/scandit-cocoapods-specs.git
+```
+
+After adding plugins, build your iOS project to install the CocoaPods dependencies:
+
+```sh
+cordova build ios
+```
+
+:::note
+As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+
+**Troubleshooting**: If you encounter issues:
+- Verify the repo is added: `pod repo list | grep scandit-private-specs`
+- Update the repo: `pod repo update scandit-private-specs` 
+- For CI/CD, add the repo setup command before `pod install`
+:::
+
 ## Additional Information
 
 ### Android Configuration

--- a/docs/sdks/cordova/add-sdk.md
+++ b/docs/sdks/cordova/add-sdk.md
@@ -154,8 +154,7 @@ As of March 2025, the public CocoaPods trunk repository is becoming read-only. S
 
 **Troubleshooting**: If you encounter issues:
 - Verify the repo is added: `pod repo list | grep scandit-private-specs`
-- Update the repo: `pod repo update scandit-private-specs` 
-- For CI/CD, add the repo setup command before `pod install`
+- Update the repo: `pod repo update scandit-private-specs`
 :::
 
 ## Additional Information

--- a/docs/sdks/cordova/add-sdk.md
+++ b/docs/sdks/cordova/add-sdk.md
@@ -150,7 +150,7 @@ cordova build ios
 ```
 
 :::note
-As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+The public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
 
 **Troubleshooting**: If you encounter issues:
 - Verify the repo is added: `pod repo list | grep scandit-private-specs`

--- a/docs/sdks/flutter/add-sdk.md
+++ b/docs/sdks/flutter/add-sdk.md
@@ -113,7 +113,7 @@ cd ios && pod install && cd ..
 ```
 
 :::note
-As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+The public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
 
 **Troubleshooting**: If you encounter issues:
 - Verify the repo is added: `pod repo list | grep scandit-private-specs`

--- a/docs/sdks/flutter/add-sdk.md
+++ b/docs/sdks/flutter/add-sdk.md
@@ -98,6 +98,29 @@ Run from terminal:
 flutter pub get
 ```
 
+### iOS Setup
+
+For iOS development, Flutter uses CocoaPods to manage native dependencies. You'll need to set up Scandit's private CocoaPods repository:
+
+**Important:** This project uses Scandit's private CocoaPods repository. First-time setup:
+
+```sh
+# Add Scandit's private CocoaPods repository (one-time setup)
+pod repo add scandit-private-specs https://github.com/Scandit/scandit-cocoapods-specs.git
+
+# Navigate to iOS directory and install dependencies
+cd ios && pod install && cd ..
+```
+
+:::note
+As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+
+**Troubleshooting**: If you encounter issues:
+- Verify the repo is added: `pod repo list | grep scandit-private-specs`
+- Update the repo: `pod repo update scandit-private-specs` 
+- For CI/CD, add the repo setup command before `pod install`
+:::
+
 ## Additional Information
 
 ### Android Configuration

--- a/docs/sdks/flutter/add-sdk.md
+++ b/docs/sdks/flutter/add-sdk.md
@@ -117,8 +117,7 @@ As of March 2025, the public CocoaPods trunk repository is becoming read-only. S
 
 **Troubleshooting**: If you encounter issues:
 - Verify the repo is added: `pod repo list | grep scandit-private-specs`
-- Update the repo: `pod repo update scandit-private-specs` 
-- For CI/CD, add the repo setup command before `pod install`
+- Update the repo: `pod repo update scandit-private-specs`
 :::
 
 ## Additional Information

--- a/docs/sdks/react-native/add-sdk.md
+++ b/docs/sdks/react-native/add-sdk.md
@@ -238,8 +238,7 @@ Navigate to your React Native project root directory and install the plugins usi
 
    **Troubleshooting**: If you encounter issues:
    - Verify the repo is added: `pod repo list | grep scandit-private-specs`
-   - Update the repo: `pod repo update scandit-private-specs` 
-   - For CI/CD, add the repo setup command before `pod install`
+   - Update the repo: `pod repo update scandit-private-specs`
    :::
 
 ## Additional Information

--- a/docs/sdks/react-native/add-sdk.md
+++ b/docs/sdks/react-native/add-sdk.md
@@ -218,11 +218,29 @@ Navigate to your React Native project root directory and install the plugins usi
 
 ![Info file](./img/info-file.png)
 
-2. Then, install the iOS Cocoapods after installing the React Native `node_modules`:
+2. Then, install the iOS CocoaPods after installing the React Native `node_modules`.
 
-```sh
-cd ios && pod install && cd ..
-```
+   **Important:** This project uses Scandit's private CocoaPods repository. First-time setup:
+
+   ```sh
+   # Add Scandit's private CocoaPods repository (one-time setup)
+   pod repo add scandit-private-specs https://github.com/Scandit/scandit-cocoapods-specs.git
+   ```
+
+   Then, install the CocoaPods dependencies:
+
+   ```sh
+   cd ios && pod install && cd ..
+   ```
+
+   :::note
+   As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+
+   **Troubleshooting**: If you encounter issues:
+   - Verify the repo is added: `pod repo list | grep scandit-private-specs`
+   - Update the repo: `pod repo update scandit-private-specs` 
+   - For CI/CD, add the repo setup command before `pod install`
+   :::
 
 ## Additional Information
 

--- a/docs/sdks/react-native/add-sdk.md
+++ b/docs/sdks/react-native/add-sdk.md
@@ -234,7 +234,7 @@ Navigate to your React Native project root directory and install the plugins usi
    ```
 
    :::note
-   As of March 2025, the public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
+   The public CocoaPods trunk repository is becoming read-only. Scandit has migrated to a private CocoaPods specs repository to ensure continued support and updates for iOS framework integrations. The repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs.
 
    **Troubleshooting**: If you encounter issues:
    - Verify the repo is added: `pod repo list | grep scandit-private-specs`


### PR DESCRIPTION
- Add CocoaPods private repository setup instructions to all iOS frameworks
- Update React Native, Flutter, Capacitor, and Cordova installation guides
- Include inline troubleshooting tips for common issues
- Address migration from public CocoaPods trunk becoming read-only
- Repository is publicly accessible at https://github.com/Scandit/scandit-cocoapods-specs