### PR TITLE
Rename "About MatrixScan" to "About MatrixScan Batch"

### DIFF
--- a/docs/partials/intro/_about-matrixscan.mdx
+++ b/docs/partials/intro/_about-matrixscan.mdx
@@ -1,12 +1,12 @@
-MatrixScan enables you to build applications and workflows involving highlighting and/or interacting with multiple barcodes within the same frame.
+MatrixScan Batch enables you to build applications and workflows involving highlighting and/or interacting with multiple barcodes within the same frame.
 
 <ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanBatch.mp4" />
 
-MatrixScan is powered by the `BarcodeBatch` functionality of the Scandit Smart Data Capture SDK.
+MatrixScan Batch is powered by the `BarcodeBatch` functionality of the Scandit Smart Data Capture SDK.
 
 ## Limitations
 
-MatrixScan does not support the following symbologies:
+MatrixScan Batch does not support the following symbologies:
 
 * DotCode
 * MaxiCode

--- a/docs/sdks/android/matrixscan/intro.md
+++ b/docs/sdks/android/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - android
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/capacitor/matrixscan/intro.md
+++ b/docs/sdks/capacitor/matrixscan/intro.md
@@ -6,7 +6,7 @@ keywords:
   - capacitor
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/cordova/matrixscan/intro.md
+++ b/docs/sdks/cordova/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - cordova
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/flutter/matrixscan/intro.md
+++ b/docs/sdks/flutter/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - flutter
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/ios/matrixscan/intro.md
+++ b/docs/sdks/ios/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - ios
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/net/android/matrixscan/intro.md
+++ b/docs/sdks/net/android/matrixscan/intro.md
@@ -6,7 +6,7 @@ keywords:
   - netAndroid
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/net/ios/matrixscan/intro.md
+++ b/docs/sdks/net/ios/matrixscan/intro.md
@@ -6,7 +6,7 @@ keywords:
   - netIos
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/react-native/matrixscan/intro.md
+++ b/docs/sdks/react-native/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - react
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/docs/sdks/web/matrixscan/intro.md
+++ b/docs/sdks/web/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - web
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/partials/intro/_about-matrixscan.mdx
+++ b/versioned_docs/version-7.6.13/partials/intro/_about-matrixscan.mdx
@@ -1,12 +1,12 @@
-MatrixScan enables you to build applications and workflows involving highlighting and/or interacting with multiple barcodes within the same frame.
+MatrixScan Batch enables you to build applications and workflows involving highlighting and/or interacting with multiple barcodes within the same frame.
 
 <ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanBatch.mp4" />
 
-MatrixScan is powered by the `BarcodeBatch` functionality of the Scandit Smart Data Capture SDK.
+MatrixScan Batch is powered by the `BarcodeBatch` functionality of the Scandit Smart Data Capture SDK.
 
 ## Limitations
 
-MatrixScan does not support the following symbologies:
+MatrixScan Batch does not support the following symbologies:
 
 * DotCode
 * MaxiCode

--- a/versioned_docs/version-7.6.13/sdks/android/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/android/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - android
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/capacitor/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/capacitor/matrixscan/intro.md
@@ -6,7 +6,7 @@ keywords:
   - capacitor
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/cordova/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/cordova/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - cordova
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/flutter/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/flutter/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - flutter
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/ios/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/ios/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - ios
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/net/android/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/net/android/matrixscan/intro.md
@@ -6,7 +6,7 @@ keywords:
   - netAndroid
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/net/ios/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/net/ios/matrixscan/intro.md
@@ -6,7 +6,7 @@ keywords:
   - netIos
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/react-native/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/react-native/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - react
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/web/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/web/matrixscan/intro.md
@@ -8,7 +8,7 @@ keywords:
   - web
 ---
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/xamarin/android/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/xamarin/android/matrixscan/intro.md
@@ -12,7 +12,7 @@ import DeprecationNotice from '/versioned_docs/version-7.6.13/partials/_xamarin-
 <DeprecationNotice/>
 
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/xamarin/forms/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/xamarin/forms/matrixscan/intro.md
@@ -12,7 +12,7 @@ import DeprecationNotice from '/versioned_docs/version-7.6.13/partials/_xamarin-
 <DeprecationNotice/>
 
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 

--- a/versioned_docs/version-7.6.13/sdks/xamarin/ios/matrixscan/intro.md
+++ b/versioned_docs/version-7.6.13/sdks/xamarin/ios/matrixscan/intro.md
@@ -12,7 +12,7 @@ import DeprecationNotice from '/versioned_docs/version-7.6.13/partials/_xamarin-
 <DeprecationNotice/>
 
 
-# About MatrixScan
+# About MatrixScan Batch
 
 import AboutMatrixScan from '../../../../partials/intro/_about-matrixscan.mdx'
 


### PR DESCRIPTION
## Summary
- Aligns the intro page heading with the sidebar/breadcrumb label "MatrixScan Batch", matching the sibling pages (MatrixScan AR, Count, Find, Pick).
- Updates the shared `_about-matrixscan.mdx` partial body copy in `docs/` (8.x) and `versioned_docs/version-7.6.13/`.
- Renames the H1 from `# About MatrixScan` to `# About MatrixScan Batch` across 21 framework intros (android, capacitor, cordova, flutter, ios, net/{android,ios}, react-native, web in 8.x; same set + xamarin/{android,forms,ios} in 7.6.13).
- Skips Linux and Titanium intros, which are "Page Unavailable" placeholders. Leaves `version-6.28.9` untouched (uses the legacy `BarcodeTracking` API and predates the family rename).

## Test plan
- [ ] `npm run start` — confirm `/sdks/web/matrixscan/intro/` page heading reads "About MatrixScan Batch" and body copy uses "MatrixScan Batch" consistently.
- [ ] Spot-check at least one other framework (e.g. iOS, Android) and the 7.6.13 versioned page.
- [ ] Confirm sidebar/breadcrumb still resolves correctly.
- [ ] `npm run build` succeeds.