### PR TITLE
Make SparkScan customization partial reusable across platforms

### DIFF
--- a/docs/partials/advanced/_sparkscan-customization.mdx
+++ b/docs/partials/advanced/_sparkscan-customization.mdx
@@ -1,64 +1,84 @@
-You can customize many aspects of the default SparkScan UI and UX to suit your needs and particular use case. These customizations include the:
+import CodeBlock from '@theme/CodeBlock';
+import Heading from '@theme/Heading';
 
-* Colors of all items (i.e. icons, buttons, toolbar)
-* Trigger button icon
-* All toast messages
-* Size of the preview
-* Visibility of any/all icons
-* Trigger button
+export default function SparkScanCustomization({
+  triggerButtonApi = "sparkScanView.isTriggerButtonVisible",
+  showHardwareTrigger = true,
+  labelCaptureButtonApi = "sparkScanView.isLabelCaptureButtonVisible",
+  barcodeFindButtonApi = "sparkScanView.isBarcodeFindButtonVisible",
+  barcodeCountButtonApi = "sparkScanView.isBarcodeCountButtonVisible",
+  showBarcodeCountButton = true,
+  codeLanguage = "sh",
+  uiDelegateApi = "SparkScanView.uiDelegate",
+}) {
+  const advancedModesText = showBarcodeCountButton
+    ? "MatrixScan Find or MatrixScan Count"
+    : "MatrixScan Find or Label Capture";
+  const uiDelegateCallbacks = showBarcodeCountButton
+    ? "the MatrixScan Find button or MatrixScan Count button"
+    : "the MatrixScan Find button or Label Capture button";
+  const toolbarCaption = showBarcodeCountButton
+    ? "The toolbar with MatrixScan Find and MatrixScan Count buttons."
+    : "The toolbar with MatrixScan Find and Label Capture buttons.";
+  const codeComment = showBarcodeCountButton
+    ? "// Show the Label Capture, MatrixScan Count, and MatrixScan Find buttons"
+    : "// Show the Label Capture and MatrixScan Find buttons";
+  const codeLines = [
+    codeComment,
+    `${labelCaptureButtonApi} = true`,
+    showBarcodeCountButton ? `${barcodeCountButtonApi} = true` : null,
+    `${barcodeFindButtonApi} = true`,
+  ].filter(Boolean).join('\n');
 
-### Trigger button
+  return <>
+    <p>You can customize many aspects of the default SparkScan UI and UX to suit your needs and particular use case. These customizations include the:</p>
+    <ul>
+      <li>Colors of all items (i.e. icons, buttons, toolbar)</li>
+      <li>Trigger button icon</li>
+      <li>All toast messages</li>
+      <li>Size of the preview</li>
+      <li>Visibility of any/all icons</li>
+      <li>Trigger button</li>
+    </ul>
 
-The default trigger button in SparkScan has been designed based on our experience and feedback received to be generally suited across a multitude of industry use cases, custom trigger implementations are still supported.
+    <Heading as="h3">Trigger button</Heading>
 
-This is achieved by hiding the default trigger button (via `sparkScanView.isTriggerButtonVisible`), and then controlling the scanning process as best suits your needs:
+    <p>The default trigger button in SparkScan has been designed based on our experience and feedback received to be generally suited across a multitude of industry use cases, custom trigger implementations are still supported.</p>
+    <p>This is achieved by hiding the default trigger button (via <code>{triggerButtonApi}</code>), and then controlling the scanning process as best suits your needs:</p>
+    <ul>
+      <li>Using a custom button embedded in you app to call <code>sparkScanView.startScanning()</code> to start scanning. You can adapt the trigger button to the state changes using the SparkScanViewUiListener.</li>
+      <li>Using the mini-preview close button (via <code>sparkScanView.previewCloseControlVisible</code>) or your desired button (via <code>sparkScanView.pauseScanning()</code>) to stop scanning.</li>
+    </ul>
+    {showHardwareTrigger && <p>Alternatively, you can rely entirely on a hardware button, if you have enabled that feature (via <code>sparkScanViewSettings.hardwareTriggerEnabled</code>).</p>}
+    <p>Some example customizations:</p>
+    <p align="center">
+      <img src="/img/sparkscan/SparkScanSelfScanning.png" alt="SparkScan Customized on Mobile" /><br/>Customized Self-Scanning application with custom FAB button and preview expanded by default
+    </p>
+    <p align="center">
+      <img src="/img/sparkscan/SparkScanmPOS.png" alt="SparkScan Customized on Tablet" /><br/>Customized mPOS application using the existing scan button to trigger the scanner
+    </p>
 
-* Using a custom button embedded in you app to call `sparkScanView.startScanning()` to start scanning. You can adapt the trigger button to the state changes using the SparkScanViewUiListener.
-* Using the mini-preview close button (via `sparkScanView.previewCloseControlVisible`) or your desired button (via `sparkScanView.pauseScanning()`) to stop scanning.
+    <Heading as="h3">Settings Toolbar</Heading>
 
-Alternatively, you can rely entirely on a hardware button, if you have enabled that feature (via sparkScanViewSettings.hardwareTriggerEnabled).
+    <p>The Settings Toolbar is hidden by default in SparkScan, as the most relevant controls are already visible in the camera preview. However, additional advanced controls can be made available, such as:</p>
+    <ul>
+      <li>Target Mode</li>
+      <li>Continuos Mode</li>
+    </ul>
+    <p>By enabling the visibility of these buttons, the Settings Toolbar will appear at the bottom of the camera preview.</p>
 
-Some example customizations:
+    <Heading as="h3">Add Advanced Scanning Modes to the Toolbar</Heading>
 
-<p align="center">
-  <img src="/img/sparkscan/SparkScanSelfScanning.png" alt="SparkScan Customized on Mobile" /><br></br>Customized Self-Scanning application with custom FAB button and preview expanded by default
-</p>
-
-<p align="center">
-  <img src="/img/sparkscan/SparkScanmPOS.png" alt="SparkScan Customized on Tablet" /><br></br>Customized mPOS application using the existing scan button to trigger the scanner
-</p>
-
-### Settings Toolbar
-
-The Settings Toolbar is hidden by default in SparkScan, as the most relevant controls are already visible in the camera preview.
-However, additional advanced controls can be made available, such as:
-
-* Target Mode
-* Continuos Mode
-
-By enabling the visibility of these buttons, the Settings Toolbar will appear at the bottom of the camera preview.
-
-### Add Advanced Scanning Modes to the Toolbar
-
-SparkScan is our best solution for high-speed single scanning and scan-intensive workflows. Depending on your use case, you can use SparkScan in conjunction with other Scandit advanced scanning modes, such as MatrixScan Find or MatrixScan Count, to speed up your workflows.
-
-SparkScan offers pre-build buttons you can add to the setting toolbar to easily move to different scan modes from within the SparkScan UI.
-
-First you will need to show these buttons:
-
-```sh
-// Show the Label Capture, MatrixScan Count, and MatrixScan Find buttons
-sparkScanView.isLabelCaptureButtonVisible = true
-sparkScanView.isBarcodeCountButtonVisible = true
-sparkScanView.isBarcodeFindButtonVisible = true
-```
-
-<p align="center">
-  <img src="/img/sparkscan/toolbar.png" alt="Toolbar without Scanning Modes" /><br></br>The standard toolbar without additional scanning modes added.
-</p>
-
-<p align="center">
-  <img src="/img/sparkscan/toolbar-buttons.png" alt="Toolbar with Scanning Modes" /><br></br>The toolbar with MatrixScan Find and MatrixScan Count buttons.
-</p>
-
-In addition you have to add a delegate to the `SparkScanView` via `SparkScanView.uiDelegate`. You will then receive callbacks when the MatrixScan Find button or MatrixScan Count button is tapped from the toolbar.
+    <p>SparkScan is our best solution for high-speed single scanning and scan-intensive workflows. Depending on your use case, you can use SparkScan in conjunction with other Scandit advanced scanning modes, such as {advancedModesText}, to speed up your workflows.</p>
+    <p>SparkScan offers pre-build buttons you can add to the setting toolbar to easily move to different scan modes from within the SparkScan UI.</p>
+    <p>First you will need to show these buttons:</p>
+    <CodeBlock language={codeLanguage}>{codeLines}</CodeBlock>
+    <p align="center">
+      <img src="/img/sparkscan/toolbar.png" alt="Toolbar without Scanning Modes" /><br/>The standard toolbar without additional scanning modes added.
+    </p>
+    <p align="center">
+      <img src="/img/sparkscan/toolbar-buttons.png" alt="Toolbar with Scanning Modes" /><br/>{toolbarCaption}
+    </p>
+    <p>In addition you have to add a delegate to the <code>SparkScanView</code> via <code>{uiDelegateApi}</code>. You will then receive callbacks when {uiDelegateCallbacks} is tapped from the toolbar.</p>
+  </>;
+}

--- a/docs/sdks/web/sparkscan/advanced.md
+++ b/docs/sdks/web/sparkscan/advanced.md
@@ -76,7 +76,15 @@ Please refer to [SparkScanView](https://docs.scandit.com/data-capture-sdk/web/ba
 
 import Customization from '../../../partials/advanced/_sparkscan-customization.mdx';
 
-<Customization/>
+<Customization
+  triggerButtonApi="sparkScanView.triggerButtonVisible"
+  showHardwareTrigger={false}
+  labelCaptureButtonApi="sparkScanView.labelCaptureButtonVisible"
+  barcodeFindButtonApi="sparkScanView.barcodeFindButtonVisible"
+  showBarcodeCountButton={false}
+  codeLanguage="js"
+  uiDelegateApi="sparkScanView.setListener()"
+/>
 
 ## Workflow Options
 

--- a/versioned_docs/version-7.6.13/partials/advanced/_sparkscan-customization.mdx
+++ b/versioned_docs/version-7.6.13/partials/advanced/_sparkscan-customization.mdx
@@ -1,64 +1,84 @@
-You can customize many aspects of the default SparkScan UI and UX to suit your needs and particular use case. These customizations include the:
+import CodeBlock from '@theme/CodeBlock';
+import Heading from '@theme/Heading';
 
-* Colors of all items (i.e. icons, buttons, toolbar)
-* Trigger button icon
-* All toast messages
-* Size of the preview
-* Visibility of any/all icons
-* Trigger button
+export default function SparkScanCustomization({
+  triggerButtonApi = "sparkScanView.isTriggerButtonVisible",
+  showHardwareTrigger = true,
+  labelCaptureButtonApi = "sparkScanView.isLabelCaptureButtonVisible",
+  barcodeFindButtonApi = "sparkScanView.isBarcodeFindButtonVisible",
+  barcodeCountButtonApi = "sparkScanView.isBarcodeCountButtonVisible",
+  showBarcodeCountButton = true,
+  codeLanguage = "sh",
+  uiDelegateApi = "SparkScanView.uiDelegate",
+}) {
+  const advancedModesText = showBarcodeCountButton
+    ? "MatrixScan Find or MatrixScan Count"
+    : "MatrixScan Find or Label Capture";
+  const uiDelegateCallbacks = showBarcodeCountButton
+    ? "the MatrixScan Find button or MatrixScan Count button"
+    : "the MatrixScan Find button or Label Capture button";
+  const toolbarCaption = showBarcodeCountButton
+    ? "The toolbar with MatrixScan Find and MatrixScan Count buttons."
+    : "The toolbar with MatrixScan Find and Label Capture buttons.";
+  const codeComment = showBarcodeCountButton
+    ? "// Show the Label Capture, MatrixScan Count, and MatrixScan Find buttons"
+    : "// Show the Label Capture and MatrixScan Find buttons";
+  const codeLines = [
+    codeComment,
+    `${labelCaptureButtonApi} = true`,
+    showBarcodeCountButton ? `${barcodeCountButtonApi} = true` : null,
+    `${barcodeFindButtonApi} = true`,
+  ].filter(Boolean).join('\n');
 
-### Trigger button
+  return <>
+    <p>You can customize many aspects of the default SparkScan UI and UX to suit your needs and particular use case. These customizations include the:</p>
+    <ul>
+      <li>Colors of all items (i.e. icons, buttons, toolbar)</li>
+      <li>Trigger button icon</li>
+      <li>All toast messages</li>
+      <li>Size of the preview</li>
+      <li>Visibility of any/all icons</li>
+      <li>Trigger button</li>
+    </ul>
 
-The default trigger button in SparkScan has been designed based on our experience and feedback received to be generally suited across a multitude of industry use cases, custom trigger implementations are still supported.
+    <Heading as="h3">Trigger button</Heading>
 
-This is achieved by hiding the default trigger button (via `sparkScanView.isTriggerButtonVisible`), and then controlling the scanning process as best suits your needs:
+    <p>The default trigger button in SparkScan has been designed based on our experience and feedback received to be generally suited across a multitude of industry use cases, custom trigger implementations are still supported.</p>
+    <p>This is achieved by hiding the default trigger button (via <code>{triggerButtonApi}</code>), and then controlling the scanning process as best suits your needs:</p>
+    <ul>
+      <li>Using a custom button embedded in you app to call <code>sparkScanView.startScanning()</code> to start scanning. You can adapt the trigger button to the state changes using the SparkScanViewUiListener.</li>
+      <li>Using the mini-preview close button (via <code>sparkScanView.previewCloseControlVisible</code>) or your desired button (via <code>sparkScanView.pauseScanning()</code>) to stop scanning.</li>
+    </ul>
+    {showHardwareTrigger && <p>Alternatively, you can rely entirely on a hardware button, if you have enabled that feature (via <code>sparkScanViewSettings.hardwareTriggerEnabled</code>).</p>}
+    <p>Some example customizations:</p>
+    <p align="center">
+      <img src="/img/sparkscan/SparkScanSelfScanning.png" alt="SparkScan Customized on Mobile" /><br/>Customized Self-Scanning application with custom FAB button and preview expanded by default
+    </p>
+    <p align="center">
+      <img src="/img/sparkscan/SparkScanmPOS.png" alt="SparkScan Customized on Tablet" /><br/>Customized mPOS application using the existing scan button to trigger the scanner
+    </p>
 
-* Using a custom button embedded in you app to call `sparkScanView.startScanning()` to start scanning. You can adapt the trigger button to the state changes using the SparkScanViewUiListener.
-* Using the mini-preview close button (via `sparkScanView.previewCloseControlVisible`) or your desired button (via `sparkScanView.pauseScanning()`) to stop scanning.
+    <Heading as="h3">Settings Toolbar</Heading>
 
-Alternatively, you can rely entirely on a hardware button, if you have enabled that feature (via sparkScanViewSettings.hardwareTriggerEnabled).
+    <p>The Settings Toolbar is hidden by default in SparkScan, as the most relevant controls are already visible in the camera preview. However, additional advanced controls can be made available, such as:</p>
+    <ul>
+      <li>Target Mode</li>
+      <li>Continuos Mode</li>
+    </ul>
+    <p>By enabling the visibility of these buttons, the Settings Toolbar will appear at the bottom of the camera preview.</p>
 
-Some example customizations:
+    <Heading as="h3">Add Advanced Scanning Modes to the Toolbar</Heading>
 
-<p align="center">
-  <img src="/img/sparkscan/SparkScanSelfScanning.png" alt="SparkScan Customized on Mobile" /><br></br>Customized Self-Scanning application with custom FAB button and preview expanded by default
-</p>
-
-<p align="center">
-  <img src="/img/sparkscan/SparkScanmPOS.png" alt="SparkScan Customized on Tablet" /><br></br>Customized mPOS application using the existing scan button to trigger the scanner
-</p>
-
-### Settings Toolbar
-
-The Settings Toolbar is hidden by default in SparkScan, as the most relevant controls are already visible in the camera preview.
-However, additional advanced controls can be made available, such as:
-
-* Target Mode
-* Continuos Mode
-
-By enabling the visibility of these buttons, the Settings Toolbar will appear at the bottom of the camera preview.
-
-### Add Advanced Scanning Modes to the Toolbar
-
-SparkScan is our best solution for high-speed single scanning and scan-intensive workflows. Depending on your use case, you can use SparkScan in conjunction with other Scandit advanced scanning modes, such as MatrixScan Find or MatrixScan Count, to speed up your workflows.
-
-SparkScan offers pre-build buttons you can add to the setting toolbar to easily move to different scan modes from within the SparkScan UI.
-
-First you will need to show these buttons:
-
-```sh
-// Show the Label Capture, MatrixScan Count, and MatrixScan Find buttons
-sparkScanView.isLabelCaptureButtonVisible = true
-sparkScanView.isBarcodeCountButtonVisible = true
-sparkScanView.isBarcodeFindButtonVisible = true
-```
-
-<p align="center">
-  <img src="/img/sparkscan/toolbar.png" alt="Toolbar without Scanning Modes" /><br></br>The standard toolbar without additional scanning modes added.
-</p>
-
-<p align="center">
-  <img src="/img/sparkscan/toolbar-buttons.png" alt="Toolbar with Scanning Modes" /><br></br>The toolbar with MatrixScan Find and MatrixScan Count buttons.
-</p>
-
-In addition you have to add a delegate to the `SparkScanView` via `SparkScanView.uiDelegate`. You will then receive callbacks when the MatrixScan Find button or MatrixScan Count button is tapped from the toolbar.
+    <p>SparkScan is our best solution for high-speed single scanning and scan-intensive workflows. Depending on your use case, you can use SparkScan in conjunction with other Scandit advanced scanning modes, such as {advancedModesText}, to speed up your workflows.</p>
+    <p>SparkScan offers pre-build buttons you can add to the setting toolbar to easily move to different scan modes from within the SparkScan UI.</p>
+    <p>First you will need to show these buttons:</p>
+    <CodeBlock language={codeLanguage}>{codeLines}</CodeBlock>
+    <p align="center">
+      <img src="/img/sparkscan/toolbar.png" alt="Toolbar without Scanning Modes" /><br/>The standard toolbar without additional scanning modes added.
+    </p>
+    <p align="center">
+      <img src="/img/sparkscan/toolbar-buttons.png" alt="Toolbar with Scanning Modes" /><br/>{toolbarCaption}
+    </p>
+    <p>In addition you have to add a delegate to the <code>SparkScanView</code> via <code>{uiDelegateApi}</code>. You will then receive callbacks when {uiDelegateCallbacks} is tapped from the toolbar.</p>
+  </>;
+}

--- a/versioned_docs/version-7.6.13/sdks/web/sparkscan/advanced.md
+++ b/versioned_docs/version-7.6.13/sdks/web/sparkscan/advanced.md
@@ -76,4 +76,12 @@ Please refer to [SparkScanView](https://docs.scandit.com/7.6/data-capture-sdk/we
 
 import Customization from '../../../partials/advanced/_sparkscan-customization.mdx';
 
-<Customization/>
+<Customization
+  triggerButtonApi="sparkScanView.triggerButtonVisible"
+  showHardwareTrigger={false}
+  labelCaptureButtonApi="sparkScanView.labelCaptureButtonVisible"
+  barcodeFindButtonApi="sparkScanView.barcodeFindButtonVisible"
+  showBarcodeCountButton={false}
+  codeLanguage="js"
+  uiDelegateApi="sparkScanView.setListener()"
+/>

--- a/versioned_docs/version-8.3.1/partials/advanced/_sparkscan-customization.mdx
+++ b/versioned_docs/version-8.3.1/partials/advanced/_sparkscan-customization.mdx
@@ -1,64 +1,84 @@
-You can customize many aspects of the default SparkScan UI and UX to suit your needs and particular use case. These customizations include the:
+import CodeBlock from '@theme/CodeBlock';
+import Heading from '@theme/Heading';
 
-* Colors of all items (i.e. icons, buttons, toolbar)
-* Trigger button icon
-* All toast messages
-* Size of the preview
-* Visibility of any/all icons
-* Trigger button
+export default function SparkScanCustomization({
+  triggerButtonApi = "sparkScanView.isTriggerButtonVisible",
+  showHardwareTrigger = true,
+  labelCaptureButtonApi = "sparkScanView.isLabelCaptureButtonVisible",
+  barcodeFindButtonApi = "sparkScanView.isBarcodeFindButtonVisible",
+  barcodeCountButtonApi = "sparkScanView.isBarcodeCountButtonVisible",
+  showBarcodeCountButton = true,
+  codeLanguage = "sh",
+  uiDelegateApi = "SparkScanView.uiDelegate",
+}) {
+  const advancedModesText = showBarcodeCountButton
+    ? "MatrixScan Find or MatrixScan Count"
+    : "MatrixScan Find or Label Capture";
+  const uiDelegateCallbacks = showBarcodeCountButton
+    ? "the MatrixScan Find button or MatrixScan Count button"
+    : "the MatrixScan Find button or Label Capture button";
+  const toolbarCaption = showBarcodeCountButton
+    ? "The toolbar with MatrixScan Find and MatrixScan Count buttons."
+    : "The toolbar with MatrixScan Find and Label Capture buttons.";
+  const codeComment = showBarcodeCountButton
+    ? "// Show the Label Capture, MatrixScan Count, and MatrixScan Find buttons"
+    : "// Show the Label Capture and MatrixScan Find buttons";
+  const codeLines = [
+    codeComment,
+    `${labelCaptureButtonApi} = true`,
+    showBarcodeCountButton ? `${barcodeCountButtonApi} = true` : null,
+    `${barcodeFindButtonApi} = true`,
+  ].filter(Boolean).join('\n');
 
-### Trigger button
+  return <>
+    <p>You can customize many aspects of the default SparkScan UI and UX to suit your needs and particular use case. These customizations include the:</p>
+    <ul>
+      <li>Colors of all items (i.e. icons, buttons, toolbar)</li>
+      <li>Trigger button icon</li>
+      <li>All toast messages</li>
+      <li>Size of the preview</li>
+      <li>Visibility of any/all icons</li>
+      <li>Trigger button</li>
+    </ul>
 
-The default trigger button in SparkScan has been designed based on our experience and feedback received to be generally suited across a multitude of industry use cases, custom trigger implementations are still supported.
+    <Heading as="h3">Trigger button</Heading>
 
-This is achieved by hiding the default trigger button (via `sparkScanView.isTriggerButtonVisible`), and then controlling the scanning process as best suits your needs:
+    <p>The default trigger button in SparkScan has been designed based on our experience and feedback received to be generally suited across a multitude of industry use cases, custom trigger implementations are still supported.</p>
+    <p>This is achieved by hiding the default trigger button (via <code>{triggerButtonApi}</code>), and then controlling the scanning process as best suits your needs:</p>
+    <ul>
+      <li>Using a custom button embedded in you app to call <code>sparkScanView.startScanning()</code> to start scanning. You can adapt the trigger button to the state changes using the SparkScanViewUiListener.</li>
+      <li>Using the mini-preview close button (via <code>sparkScanView.previewCloseControlVisible</code>) or your desired button (via <code>sparkScanView.pauseScanning()</code>) to stop scanning.</li>
+    </ul>
+    {showHardwareTrigger && <p>Alternatively, you can rely entirely on a hardware button, if you have enabled that feature (via <code>sparkScanViewSettings.hardwareTriggerEnabled</code>).</p>}
+    <p>Some example customizations:</p>
+    <p align="center">
+      <img src="/img/sparkscan/SparkScanSelfScanning.png" alt="SparkScan Customized on Mobile" /><br/>Customized Self-Scanning application with custom FAB button and preview expanded by default
+    </p>
+    <p align="center">
+      <img src="/img/sparkscan/SparkScanmPOS.png" alt="SparkScan Customized on Tablet" /><br/>Customized mPOS application using the existing scan button to trigger the scanner
+    </p>
 
-* Using a custom button embedded in you app to call `sparkScanView.startScanning()` to start scanning. You can adapt the trigger button to the state changes using the SparkScanViewUiListener.
-* Using the mini-preview close button (via `sparkScanView.previewCloseControlVisible`) or your desired button (via `sparkScanView.pauseScanning()`) to stop scanning.
+    <Heading as="h3">Settings Toolbar</Heading>
 
-Alternatively, you can rely entirely on a hardware button, if you have enabled that feature (via sparkScanViewSettings.hardwareTriggerEnabled).
+    <p>The Settings Toolbar is hidden by default in SparkScan, as the most relevant controls are already visible in the camera preview. However, additional advanced controls can be made available, such as:</p>
+    <ul>
+      <li>Target Mode</li>
+      <li>Continuos Mode</li>
+    </ul>
+    <p>By enabling the visibility of these buttons, the Settings Toolbar will appear at the bottom of the camera preview.</p>
 
-Some example customizations:
+    <Heading as="h3">Add Advanced Scanning Modes to the Toolbar</Heading>
 
-<p align="center">
-  <img src="/img/sparkscan/SparkScanSelfScanning.png" alt="SparkScan Customized on Mobile" /><br></br>Customized Self-Scanning application with custom FAB button and preview expanded by default
-</p>
-
-<p align="center">
-  <img src="/img/sparkscan/SparkScanmPOS.png" alt="SparkScan Customized on Tablet" /><br></br>Customized mPOS application using the existing scan button to trigger the scanner
-</p>
-
-### Settings Toolbar
-
-The Settings Toolbar is hidden by default in SparkScan, as the most relevant controls are already visible in the camera preview.
-However, additional advanced controls can be made available, such as:
-
-* Target Mode
-* Continuos Mode
-
-By enabling the visibility of these buttons, the Settings Toolbar will appear at the bottom of the camera preview.
-
-### Add Advanced Scanning Modes to the Toolbar
-
-SparkScan is our best solution for high-speed single scanning and scan-intensive workflows. Depending on your use case, you can use SparkScan in conjunction with other Scandit advanced scanning modes, such as MatrixScan Find or MatrixScan Count, to speed up your workflows.
-
-SparkScan offers pre-build buttons you can add to the setting toolbar to easily move to different scan modes from within the SparkScan UI.
-
-First you will need to show these buttons:
-
-```sh
-// Show the Label Capture, MatrixScan Count, and MatrixScan Find buttons
-sparkScanView.isLabelCaptureButtonVisible = true
-sparkScanView.isBarcodeCountButtonVisible = true
-sparkScanView.isBarcodeFindButtonVisible = true
-```
-
-<p align="center">
-  <img src="/img/sparkscan/toolbar.png" alt="Toolbar without Scanning Modes" /><br></br>The standard toolbar without additional scanning modes added.
-</p>
-
-<p align="center">
-  <img src="/img/sparkscan/toolbar-buttons.png" alt="Toolbar with Scanning Modes" /><br></br>The toolbar with MatrixScan Find and MatrixScan Count buttons.
-</p>
-
-In addition you have to add a delegate to the `SparkScanView` via `SparkScanView.uiDelegate`. You will then receive callbacks when the MatrixScan Find button or MatrixScan Count button is tapped from the toolbar.
+    <p>SparkScan is our best solution for high-speed single scanning and scan-intensive workflows. Depending on your use case, you can use SparkScan in conjunction with other Scandit advanced scanning modes, such as {advancedModesText}, to speed up your workflows.</p>
+    <p>SparkScan offers pre-build buttons you can add to the setting toolbar to easily move to different scan modes from within the SparkScan UI.</p>
+    <p>First you will need to show these buttons:</p>
+    <CodeBlock language={codeLanguage}>{codeLines}</CodeBlock>
+    <p align="center">
+      <img src="/img/sparkscan/toolbar.png" alt="Toolbar without Scanning Modes" /><br/>The standard toolbar without additional scanning modes added.
+    </p>
+    <p align="center">
+      <img src="/img/sparkscan/toolbar-buttons.png" alt="Toolbar with Scanning Modes" /><br/>{toolbarCaption}
+    </p>
+    <p>In addition you have to add a delegate to the <code>SparkScanView</code> via <code>{uiDelegateApi}</code>. You will then receive callbacks when {uiDelegateCallbacks} is tapped from the toolbar.</p>
+  </>;
+}

--- a/versioned_docs/version-8.3.1/sdks/web/sparkscan/advanced.md
+++ b/versioned_docs/version-8.3.1/sdks/web/sparkscan/advanced.md
@@ -76,7 +76,15 @@ Please refer to [SparkScanView](https://docs.scandit.com/data-capture-sdk/web/ba
 
 import Customization from '../../../partials/advanced/_sparkscan-customization.mdx';
 
-<Customization/>
+<Customization
+  triggerButtonApi="sparkScanView.triggerButtonVisible"
+  showHardwareTrigger={false}
+  labelCaptureButtonApi="sparkScanView.labelCaptureButtonVisible"
+  barcodeFindButtonApi="sparkScanView.barcodeFindButtonVisible"
+  showBarcodeCountButton={false}
+  codeLanguage="js"
+  uiDelegateApi="sparkScanView.setListener()"
+/>
 
 ## Workflow Options
 


### PR DESCRIPTION
Convert the static markdown partial into a parameterized React component that accepts platform-specific API names and features. Pass Web SDK parameters to customize the output for JavaScript differences (property names, delegate API, code language) and hide platform-specific features like hardware trigger and MatrixScan Count that aren't available in Web.

Update all versions (current, 7.6.13, 8.3.1) consistently.