### PR TITLE
Fill in Scandit copyright in LICENSE appendix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright © Scandit AG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Replace the Apache 2.0 appendix placeholder (`Copyright [yyyy] [name of copyright owner]`) with `Copyright © Scandit AG` so the LICENSE clearly attributes the work.

## Test plan
- [x] `git show 51c89440` — confirms the only change is the one-line copyright update in `LICENSE`.