### PR TITLE
Collapse Agent Skills callouts by default and add product-disambiguation fallback

### DIFF
--- a/docs/partials/intro/_about-smart-label-capture.mdx
+++ b/docs/partials/intro/_about-smart-label-capture.mdx
@@ -2,11 +2,6 @@ Smart Label Capture enables the simultaneous scanning of multiple barcodes and p
 
 This technology is particularly beneficial in scenarios where labels contain various data points, such as serial numbers, weights, or expiry dates.
 
-<p align="center">
-  <img src="/img/batch-scanning/SLC-smart-devices.jpg" width="650px" alt="Label Capture result for scanning smart device labels" />
-  <br/>Capturing multiple barcodes and text data from labels in a single scan
-</p>
-
 ## Understanding Labels in Smart Label Capture
 
 The first step to using Smart Label Capture is to [define the labels](../label-definitions) that you want to capture.

--- a/src/components/SkillsCallout/InstallTabs.tsx
+++ b/src/components/SkillsCallout/InstallTabs.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import skillsData from '@site/src/data/skills.json';
+import { capturePostHogEvent } from './analytics';
 import styles from './styles.module.css';
 
 type TabKey = 'any' | 'claude-code' | 'cursor';
@@ -48,14 +49,6 @@ interface CommandBlockProps {
   trackingId: string;
   product?: string;
   framework?: string;
-}
-
-type PostHogCapture = (event: string, props?: Record<string, unknown>) => void;
-
-function capturePostHogEvent(event: string, props?: Record<string, unknown>): void {
-  if (typeof window === 'undefined') return;
-  const ph = (window as unknown as { posthog?: { capture?: PostHogCapture } }).posthog;
-  ph?.capture?.(event, props);
 }
 
 const CommandBlock: React.FC<CommandBlockProps> = ({ command, trackingId, product, framework }) => {

--- a/src/components/SkillsCallout/analytics.ts
+++ b/src/components/SkillsCallout/analytics.ts
@@ -1,0 +1,7 @@
+type PostHogCapture = (event: string, props?: Record<string, unknown>) => void;
+
+export function capturePostHogEvent(event: string, props?: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  const ph = (window as unknown as { posthog?: { capture?: PostHogCapture } }).posthog;
+  ph?.capture?.(event, props);
+}

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -119,8 +119,8 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
 
   if (variant === 'fallback') {
     return (
-      <details className={styles.fallbackDetails}>
-        <summary className={styles.fallbackSummary}>
+      <details className={`${styles.callout} ${styles.fallbackDetails}`}>
+        <summary className={`${styles.title} ${styles.fallbackSummary}`}>
           {PRODUCT_DISAMBIGUATION_HEADING}
         </summary>
         <div className={styles.fallbackBody}>

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -10,7 +10,7 @@ import styles from './styles.module.css';
 interface SkillsCalloutProps {
   product?: string;
   framework?: string;
-  variant?: 'product' | 'shared';
+  variant?: 'product' | 'shared' | 'fallback';
   banner?: boolean;
 }
 
@@ -68,6 +68,30 @@ function getSharedMoreInfoUrl(search: string): string {
   return `/sdks/${path}/agent-skills`;
 }
 
+interface SharedBodyProps {
+  sharedFrameworkSlug: string;
+  sharedMoreInfoUrl: string;
+}
+
+const SharedBody: React.FC<SharedBodyProps> = ({
+  sharedFrameworkSlug,
+  sharedMoreInfoUrl,
+}) => (
+  <>
+    <p className={styles.description}>
+      Install our <code>{skillsData.shared}</code> skill so your coding
+      agent can answer questions about Scandit products and recommend
+      the right one for your use case, directly from your editor.{' '}
+      <a href={sharedMoreInfoUrl}>More info →</a>
+    </p>
+    <InstallTabs
+      skillSlug={skillsData.shared}
+      product="shared"
+      framework={sharedFrameworkSlug}
+    />
+  </>
+);
+
 const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, variant = 'product', banner = false }) => {
   const { pathname, search } = useLocation();
 
@@ -81,19 +105,30 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
       <aside className={calloutClass} aria-label="Install Scandit Agent Skills">
         <div className={contentClass}>
           <h3 className={styles.title}>Not sure which Scandit product fits your use case?</h3>
-          <p className={styles.description}>
-            Install our <code>{skillsData.shared}</code> skill so your coding
-            agent can answer questions about Scandit products and recommend
-            the right one for your use case, directly from your editor.{' '}
-            <a href={sharedMoreInfoUrl}>More info →</a>
-          </p>
-          <InstallTabs
-            skillSlug={skillsData.shared}
-            product="shared"
-            framework={sharedFrameworkSlug}
+          <SharedBody
+            sharedFrameworkSlug={sharedFrameworkSlug}
+            sharedMoreInfoUrl={sharedMoreInfoUrl}
           />
         </div>
       </aside>
+    );
+  }
+
+  if (variant === 'fallback') {
+    const sharedFrameworkSlug = getSharedFrameworkSlug(search);
+    const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
+    return (
+      <details className={styles.fallbackDetails}>
+        <summary className={styles.fallbackSummary}>
+          Not sure which Scandit product fits your use case?
+        </summary>
+        <div className={styles.fallbackBody}>
+          <SharedBody
+            sharedFrameworkSlug={sharedFrameworkSlug}
+            sharedMoreInfoUrl={sharedMoreInfoUrl}
+          />
+        </div>
+      </details>
     );
   }
 

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -90,8 +90,17 @@ const CalloutDetails: React.FC<CalloutDetailsProps> = ({
     if (!e.currentTarget.open) return;
     capturePostHogEvent('skills_callout_expanded', trackingProps);
   };
+  // Cursor-follow spotlight: write the mouse position into CSS variables on
+  // the element so the radial-gradient ::before can read them. Only meaningful
+  // while collapsed; once expanded we let the user read in peace.
+  const handleMouseMove: React.MouseEventHandler<HTMLDetailsElement> = (e) => {
+    if (e.currentTarget.open) return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    e.currentTarget.style.setProperty('--callout-mx', `${e.clientX - rect.left}px`);
+    e.currentTarget.style.setProperty('--callout-my', `${e.clientY - rect.top}px`);
+  };
   return (
-    <details className={className} onToggle={handleToggle}>
+    <details className={className} onToggle={handleToggle} onMouseMove={handleMouseMove}>
       <summary
         className={`${styles.title} ${styles.calloutSummary}`}
         aria-label="Install Scandit Agent Skills"

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from '@docusaurus/router';
 import skillsData from '@site/src/data/skills.json';
 import productsData from '@site/src/data/products.json';
 import { parseSdksRoute } from '../utils/frameworks';
+import { capturePostHogEvent } from './analytics';
 import InstallTabs from './InstallTabs';
 import styles from './styles.module.css';
 
@@ -13,7 +14,7 @@ const PRODUCT_DISAMBIGUATION_HEADING =
 interface SkillsCalloutProps {
   product?: string;
   framework?: string;
-  variant?: 'product' | 'shared' | 'fallback';
+  variant?: 'product' | 'shared';
   banner?: boolean;
 }
 
@@ -71,6 +72,37 @@ function getSharedMoreInfoUrl(search: string): string {
   return `/sdks/${path}/agent-skills`;
 }
 
+interface CalloutDetailsProps {
+  heading: string;
+  banner?: boolean;
+  trackingProps: Record<string, unknown>;
+  children: React.ReactNode;
+}
+
+const CalloutDetails: React.FC<CalloutDetailsProps> = ({
+  heading,
+  banner = false,
+  trackingProps,
+  children,
+}) => {
+  const className = banner ? `${styles.callout} ${styles.banner}` : styles.callout;
+  const handleToggle: React.ReactEventHandler<HTMLDetailsElement> = (e) => {
+    if (!e.currentTarget.open) return;
+    capturePostHogEvent('skills_callout_expanded', trackingProps);
+  };
+  return (
+    <details className={className} onToggle={handleToggle}>
+      <summary
+        className={`${styles.title} ${styles.calloutSummary}`}
+        aria-label="Install Scandit Agent Skills"
+      >
+        {heading}
+      </summary>
+      <div className={styles.calloutBody}>{children}</div>
+    </details>
+  );
+};
+
 interface SharedBodyProps {
   sharedFrameworkSlug: string;
   sharedMoreInfoUrl: string;
@@ -98,38 +130,24 @@ const SharedBody: React.FC<SharedBodyProps> = ({
 const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, variant = 'product', banner = false }) => {
   const { pathname, search } = useLocation();
 
-  const calloutClass = banner ? `${styles.callout} ${styles.banner}` : styles.callout;
-  const contentClass = banner ? styles.bannerContent : undefined;
-  const sharedFrameworkSlug = getSharedFrameworkSlug(search);
-  const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
-
   if (variant === 'shared') {
+    const sharedFrameworkSlug = getSharedFrameworkSlug(search);
+    const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
     return (
-      <aside className={calloutClass} aria-label="Install Scandit Agent Skills">
-        <div className={contentClass}>
-          <h3 className={styles.title}>{PRODUCT_DISAMBIGUATION_HEADING}</h3>
-          <SharedBody
-            sharedFrameworkSlug={sharedFrameworkSlug}
-            sharedMoreInfoUrl={sharedMoreInfoUrl}
-          />
-        </div>
-      </aside>
-    );
-  }
-
-  if (variant === 'fallback') {
-    return (
-      <details className={`${styles.callout} ${styles.fallbackDetails}`}>
-        <summary className={`${styles.title} ${styles.fallbackSummary}`}>
-          {PRODUCT_DISAMBIGUATION_HEADING}
-        </summary>
-        <div className={styles.fallbackBody}>
-          <SharedBody
-            sharedFrameworkSlug={sharedFrameworkSlug}
-            sharedMoreInfoUrl={sharedMoreInfoUrl}
-          />
-        </div>
-      </details>
+      <CalloutDetails
+        heading={PRODUCT_DISAMBIGUATION_HEADING}
+        banner={banner}
+        trackingProps={{
+          variant: 'shared',
+          pathname,
+          framework: sharedFrameworkSlug,
+        }}
+      >
+        <SharedBody
+          sharedFrameworkSlug={sharedFrameworkSlug}
+          sharedMoreInfoUrl={sharedMoreInfoUrl}
+        />
+      </CalloutDetails>
     );
   }
 
@@ -153,8 +171,15 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
   const moreInfoUrl = frameworkPath ? `/sdks/${frameworkPath}/agent-skills` : null;
 
   return (
-    <aside className={styles.callout} aria-label="Install Scandit Agent Skills">
-      <h3 className={styles.title}>Speed up {productName} integration with Agent Skills</h3>
+    <CalloutDetails
+      heading={`Speed up ${productName} integration with Agent Skills`}
+      trackingProps={{
+        variant: 'product',
+        pathname,
+        product: resolvedProduct,
+        framework: frameworkSlug,
+      }}
+    >
       <p className={styles.description}>
         Install the official skill to help your coding agent (Claude Code,
         Codex, Cursor, etc.) integrate, debug, and customize{' '}
@@ -172,7 +197,7 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
         product={resolvedProduct}
         framework={frameworkSlug}
       />
-    </aside>
+    </CalloutDetails>
   );
 };
 

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -96,7 +96,11 @@ const CalloutDetails: React.FC<CalloutDetailsProps> = ({
         className={`${styles.title} ${styles.calloutSummary}`}
         aria-label="Install Scandit Agent Skills"
       >
-        {heading}
+        <span className={styles.calloutHeading}>{heading}</span>
+        <span className={styles.calloutHint} aria-hidden="true">
+          <span className={styles.calloutHintText} />
+          <span className={styles.calloutChevron}>›</span>
+        </span>
       </summary>
       <div className={styles.calloutBody}>{children}</div>
     </details>

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -7,6 +7,9 @@ import { parseSdksRoute } from '../utils/frameworks';
 import InstallTabs from './InstallTabs';
 import styles from './styles.module.css';
 
+const PRODUCT_DISAMBIGUATION_HEADING =
+  'Not sure which Scandit product fits your use case?';
+
 interface SkillsCalloutProps {
   product?: string;
   framework?: string;
@@ -97,14 +100,14 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
 
   const calloutClass = banner ? `${styles.callout} ${styles.banner}` : styles.callout;
   const contentClass = banner ? styles.bannerContent : undefined;
+  const sharedFrameworkSlug = getSharedFrameworkSlug(search);
+  const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
 
   if (variant === 'shared') {
-    const sharedFrameworkSlug = getSharedFrameworkSlug(search);
-    const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
     return (
       <aside className={calloutClass} aria-label="Install Scandit Agent Skills">
         <div className={contentClass}>
-          <h3 className={styles.title}>Not sure which Scandit product fits your use case?</h3>
+          <h3 className={styles.title}>{PRODUCT_DISAMBIGUATION_HEADING}</h3>
           <SharedBody
             sharedFrameworkSlug={sharedFrameworkSlug}
             sharedMoreInfoUrl={sharedMoreInfoUrl}
@@ -115,12 +118,10 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
   }
 
   if (variant === 'fallback') {
-    const sharedFrameworkSlug = getSharedFrameworkSlug(search);
-    const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
     return (
       <details className={styles.fallbackDetails}>
         <summary className={styles.fallbackSummary}>
-          Not sure which Scandit product fits your use case?
+          {PRODUCT_DISAMBIGUATION_HEADING}
         </summary>
         <div className={styles.fallbackBody}>
           <SharedBody

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -91,10 +91,8 @@ const CalloutDetails: React.FC<CalloutDetailsProps> = ({
     capturePostHogEvent('skills_callout_expanded', trackingProps);
   };
   // Cursor-follow spotlight: write the mouse position into CSS variables on
-  // the element so the radial-gradient ::before can read them. Only meaningful
-  // while collapsed; once expanded we let the user read in peace.
+  // the element so the radial-gradient ::before can read them.
   const handleMouseMove: React.MouseEventHandler<HTMLDetailsElement> = (e) => {
-    if (e.currentTarget.open) return;
     const rect = e.currentTarget.getBoundingClientRect();
     e.currentTarget.style.setProperty('--callout-mx', `${e.clientX - rect.left}px`);
     e.currentTarget.style.setProperty('--callout-my', `${e.clientY - rect.top}px`);

--- a/src/components/SkillsCallout/routes.ts
+++ b/src/components/SkillsCallout/routes.ts
@@ -1,0 +1,14 @@
+// Returns true when the page should NOT show the fallback
+// "Not sure which Scandit product fits your use case?" disclosure.
+//
+// The rule is anchored to the final non-empty path segment so unrelated
+// paths like /foo/migrate-tool/bar are not caught.
+export function isOnFallbackDenylist(pathname: string): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+  const last = segments[segments.length - 1];
+  if (!last) return false;
+  if (last === 'release-notes') return true;
+  if (last === 'agent-skills') return true;
+  if (last.startsWith('migrate-')) return true;
+  return false;
+}

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -65,7 +65,7 @@
   inset: 0;
   background: radial-gradient(
     480px circle at var(--callout-mx) var(--callout-my),
-    rgba(35, 133, 236, 0.22),
+    rgba(35, 133, 236, 0.12),
     rgba(35, 133, 236, 0) 55%
   );
   opacity: 0;
@@ -81,7 +81,7 @@ details.callout:hover::before {
 html[data-theme='dark'] .callout::before {
   background: radial-gradient(
     480px circle at var(--callout-mx) var(--callout-my),
-    rgba(35, 133, 236, 0.32),
+    rgba(35, 133, 236, 0.18),
     rgba(35, 133, 236, 0) 55%
   );
 }
@@ -323,8 +323,8 @@ html[data-theme='dark'] details.callout {
   transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.calloutSummary:hover .calloutHint,
-.calloutSummary:focus-visible .calloutHint {
+details.callout:not([open]) .calloutSummary:hover .calloutHint,
+details.callout:not([open]) .calloutSummary:focus-visible .calloutHint {
   transform: translateX(4px);
 }
 
@@ -357,7 +357,7 @@ details.callout[open] .calloutChevron {
 /* Focus state for keyboard users — the spotlight does the visual work
    for hover, so we only need an explicit focus indicator here. */
 
-details.callout:not([open]) .calloutSummary:focus-visible {
+.calloutSummary:focus-visible {
   outline: 2px solid var(--light-blue-100, #2385ec);
   outline-offset: 2px;
   border-radius: 4px;

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -15,6 +15,45 @@
   /* Default spotlight origin (centered) before the first mousemove. */
   --callout-mx: 50%;
   --callout-my: 50%;
+  /* Enable height: auto ↔ 0 transitions on the ::details-content
+     pseudo-element below (Chrome 129+, Safari 18+). Older browsers
+     gracefully snap open with no animation. */
+  interpolate-size: allow-keywords;
+}
+
+/* Smooth open/close animation. ::details-content is the pseudo-element
+   the browser provides for the disclosure body; transitioning its height
+   and opacity (with content-visibility transitioning as a discrete
+   property so the content is rendered during the animation) gives a
+   clean slide-and-fade. @starting-style defines the "entering" state.
+   Longhand transition syntax — the shorthand with `allow-discrete` is
+   stripped by the build's CSS minifier. */
+.callout::details-content {
+  overflow-y: clip;
+  height: 0;
+  opacity: 0;
+  transition-property: height, opacity, content-visibility;
+  transition-duration: 280ms, 220ms, 280ms;
+  transition-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
+  transition-behavior: allow-discrete;
+}
+
+.callout[open]::details-content {
+  height: auto;
+  opacity: 1;
+}
+
+@starting-style {
+  .callout[open]::details-content {
+    height: 0;
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .callout::details-content {
+    transition: none;
+  }
 }
 
 /* Cursor-follow spotlight. Sits above the background, below the content.
@@ -65,7 +104,7 @@ details.callout[open] {
 .description {
   margin: 0 0 0.75rem 0;
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.65;
   color: var(--ifm-color-content-secondary, #444);
 }
 
@@ -82,7 +121,9 @@ details.callout[open] {
   border: 1px solid var(--light-blue-80, #c2cce3);
   border-radius: 6px;
   font-family: var(--third-family, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
-  font-size: 1rem;
+  /* Monospace at 1rem optically reads larger than proportional body text;
+     scaling to 0.9375rem matches the body visually. */
+  font-size: 0.9375rem;
   line-height: 1.5;
   overflow-x: auto;
   white-space: pre-wrap;
@@ -179,7 +220,7 @@ html[data-theme='dark'] .copyButton:hover {
 .tabHint {
   margin: 0 0 0.5rem 0;
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.65;
   color: var(--ifm-color-content-secondary, #444);
 }
 
@@ -282,7 +323,7 @@ html[data-theme='dark'] details.callout {
   transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-details.callout:not([open]):hover .calloutHint {
+details.callout:hover .calloutHint {
   transform: translateX(4px);
 }
 

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -206,23 +206,10 @@ html[data-theme='dark'] .tabActive {
   color: var(--dark-blue-accent, #2385ec);
 }
 
-.fallbackDetails {
-  display: block;
-  margin: 0 0 2rem 0;
-  padding: 0.75rem 1rem;
-  border-radius: 8px;
-  background: var(--ifm-background-surface-color, #f7f8fa);
-  border: 1px solid rgba(35, 133, 236, 0.15);
-  font-family: var(--font-family, inherit);
-}
-
 .fallbackSummary {
+  margin: 0;
   list-style: none;
   cursor: pointer;
-  font-size: 1rem;
-  font-weight: 500;
-  color: var(--ifm-color-content, #1a1a1a);
-  padding: 0.25rem 0;
 }
 
 .fallbackSummary::-webkit-details-marker {
@@ -242,27 +229,9 @@ html[data-theme='dark'] .tabActive {
 }
 
 .fallbackBody {
-  padding: 0.75rem 0 0.25rem 0;
-}
-
-.fallbackDetails a {
-  color: var(--light-blue-100, #2385ec);
-  text-decoration: underline;
-}
-
-html[data-theme='dark'] .fallbackDetails {
-  background: rgba(255, 255, 255, 0.04);
-  border-color: rgba(35, 133, 236, 0.25);
-}
-
-html[data-theme='dark'] .fallbackSummary {
-  color: var(--ifm-color-content, #f5f5f5);
+  padding: 0.75rem 0 0;
 }
 
 html[data-theme='dark'] .fallbackSummary::before {
-  color: var(--dark-blue-accent, #2385ec);
-}
-
-html[data-theme='dark'] .fallbackDetails a {
   color: var(--dark-blue-accent, #2385ec);
 }

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -1,7 +1,11 @@
 .callout {
   display: block;
   margin: 0 0 2rem 0;
-  padding: 1.25rem 1.5rem;
+  /* Asymmetric vertical padding compensates for the font line box being
+     taller than the visible glyphs (cap-height/descender asymmetry).
+     The [open] selector below restores symmetric padding once the body
+     content is visible and provides its own visual balance. */
+  padding: 1.3rem 1.5rem 1.05rem;
   border-radius: 8px;
   background: var(--light-blue-60, #f0f5ff);
   border-left: 4px solid var(--light-blue-100, #2385ec);
@@ -9,6 +13,11 @@
   border-right: 1px solid rgba(35, 133, 236, 0.15);
   border-bottom: 1px solid rgba(35, 133, 236, 0.15);
   font-family: var(--font-family, inherit);
+}
+
+details.callout[open] {
+  padding-top: 1.25rem;
+  padding-bottom: 1.25rem;
 }
 
 .banner {

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -206,17 +206,27 @@ html[data-theme='dark'] .tabActive {
   color: var(--dark-blue-accent, #2385ec);
 }
 
-.fallbackSummary {
+/* Beat Docusaurus's "#__docusaurus [class^=docMainContainer_] details { background-color: transparent }"
+   override that would otherwise wipe the blue callout background on doc pages. */
+details.callout {
+  background: var(--light-blue-60, #f0f5ff) !important;
+}
+
+html[data-theme='dark'] details.callout {
+  background: rgba(35, 133, 236, 0.08) !important;
+}
+
+.calloutSummary {
   margin: 0;
   list-style: none;
   cursor: pointer;
 }
 
-.fallbackSummary::-webkit-details-marker {
+.calloutSummary::-webkit-details-marker {
   display: none;
 }
 
-.fallbackSummary::before {
+.calloutSummary::before {
   content: '▸';
   display: inline-block;
   margin-right: 0.5rem;
@@ -224,14 +234,14 @@ html[data-theme='dark'] .tabActive {
   color: var(--light-blue-100, #2385ec);
 }
 
-.fallbackDetails[open] .fallbackSummary::before {
+details.callout[open] .calloutSummary::before {
   transform: rotate(90deg);
 }
 
-.fallbackBody {
+.calloutBody {
   padding: 0.75rem 0 0;
 }
 
-html[data-theme='dark'] .fallbackSummary::before {
+html[data-theme='dark'] .calloutSummary::before {
   color: var(--dark-blue-accent, #2385ec);
 }

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -205,3 +205,55 @@ html[data-theme='dark'] .tab:hover,
 html[data-theme='dark'] .tabActive {
   color: var(--dark-blue-accent, #2385ec);
 }
+
+.fallbackDetails {
+  display: block;
+  margin: 0 0 2rem 0;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color, #f7f8fa);
+  border: 1px solid rgba(35, 133, 236, 0.15);
+  font-family: var(--font-family, inherit);
+}
+
+.fallbackSummary {
+  list-style: none;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--ifm-color-content, #1a1a1a);
+  padding: 0.25rem 0;
+}
+
+.fallbackSummary::-webkit-details-marker {
+  display: none;
+}
+
+.fallbackSummary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform 120ms ease;
+  color: var(--light-blue-100, #2385ec);
+}
+
+.fallbackDetails[open] .fallbackSummary::before {
+  transform: rotate(90deg);
+}
+
+.fallbackBody {
+  padding: 0.75rem 0 0.25rem 0;
+}
+
+html[data-theme='dark'] .fallbackDetails {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(35, 133, 236, 0.25);
+}
+
+html[data-theme='dark'] .fallbackSummary {
+  color: var(--ifm-color-content, #f5f5f5);
+}
+
+html[data-theme='dark'] .fallbackSummary::before {
+  color: var(--dark-blue-accent, #2385ec);
+}

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -323,7 +323,8 @@ html[data-theme='dark'] details.callout {
   transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-details.callout:hover .calloutHint {
+.calloutSummary:hover .calloutHint,
+.calloutSummary:focus-visible .calloutHint {
   transform: translateX(4px);
 }
 

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -1,32 +1,24 @@
 .callout {
   display: block;
   margin: 0 0 2rem 0;
-  /* Asymmetric vertical padding compensates for the font line box being
-     taller than the visible glyphs (cap-height/descender asymmetry).
-     The [open] selector below restores symmetric padding once the body
-     content is visible and provides its own visual balance. */
+  /* padding-top is constant across collapsed/open so the title doesn't
+     shift vertically when expanding. padding-bottom flexes via [open]
+     below: tighter in the collapsed state for optical centering of the
+     single summary line, restored when there's body content beneath. */
   padding: 1.3rem 1.5rem 1.05rem;
   border-radius: 8px;
   background: var(--light-blue-60, #f0f5ff);
-  border-left: 4px solid var(--light-blue-100, #2385ec);
-  border-top: 1px solid rgba(35, 133, 236, 0.15);
-  border-right: 1px solid rgba(35, 133, 236, 0.15);
-  border-bottom: 1px solid rgba(35, 133, 236, 0.15);
+  border: 1px solid rgba(35, 133, 236, 0.18);
   font-family: var(--font-family, inherit);
+  transition: background 120ms ease;
 }
 
 details.callout[open] {
-  padding-top: 1.25rem;
   padding-bottom: 1.25rem;
 }
 
 .banner {
   margin: 0;
-  padding: 1.75rem 2rem;
-}
-
-.bannerContent {
-  max-width: 100%;
 }
 
 .title {
@@ -186,10 +178,7 @@ html[data-theme='dark'] .copyButton:hover {
 
 html[data-theme='dark'] .callout {
   background: rgba(35, 133, 236, 0.08);
-  border-left-color: var(--dark-blue-accent, #2385ec);
-  border-top-color: rgba(35, 133, 236, 0.2);
-  border-right-color: rgba(35, 133, 236, 0.2);
-  border-bottom-color: rgba(35, 133, 236, 0.2);
+  border-color: rgba(35, 133, 236, 0.22);
 }
 
 html[data-theme='dark'] .title {
@@ -229,28 +218,74 @@ html[data-theme='dark'] details.callout {
   margin: 0;
   list-style: none;
   cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
 .calloutSummary::-webkit-details-marker {
   display: none;
 }
 
-.calloutSummary::before {
-  content: '▸';
-  display: inline-block;
-  margin-right: 0.5rem;
-  transition: transform 120ms ease;
+.calloutHeading {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.calloutHint {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--light-blue-100, #2385ec);
 }
 
-details.callout[open] .calloutSummary::before {
+.calloutHintText::before {
+  content: 'Show';
+}
+
+details.callout[open] .calloutHintText::before {
+  content: 'Hide';
+}
+
+.calloutChevron {
+  display: inline-block;
+  font-size: 1rem;
+  line-height: 1;
   transform: rotate(90deg);
+  transition: transform 160ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+details.callout[open] .calloutChevron {
+  transform: rotate(-90deg);
 }
 
 .calloutBody {
   padding: 0.75rem 0 0;
 }
 
-html[data-theme='dark'] .calloutSummary::before {
+/* Button-like hover/focus on the collapsed callout so the whole banner
+   reads as a single interactive surface. Skipped when open: once content
+   is visible, the user is reading, not clicking. */
+details.callout:not([open]):hover {
+  background: var(--light-blue-80, #d9e6ff) !important;
+}
+
+details.callout:not([open]) .calloutSummary:focus-visible {
+  outline: 2px solid var(--light-blue-100, #2385ec);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+html[data-theme='dark'] .calloutHint {
   color: var(--dark-blue-accent, #2385ec);
+}
+
+html[data-theme='dark'] details.callout:not([open]):hover {
+  background: rgba(35, 133, 236, 0.16) !important;
 }

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -245,6 +245,11 @@ html[data-theme='dark'] .tabActive {
   padding: 0.75rem 0 0.25rem 0;
 }
 
+.fallbackDetails a {
+  color: var(--light-blue-100, #2385ec);
+  text-decoration: underline;
+}
+
 html[data-theme='dark'] .fallbackDetails {
   background: rgba(255, 255, 255, 0.04);
   border-color: rgba(35, 133, 236, 0.25);
@@ -255,5 +260,9 @@ html[data-theme='dark'] .fallbackSummary {
 }
 
 html[data-theme='dark'] .fallbackSummary::before {
+  color: var(--dark-blue-accent, #2385ec);
+}
+
+html[data-theme='dark'] .fallbackDetails a {
   color: var(--dark-blue-accent, #2385ec);
 }

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -74,7 +74,7 @@
   z-index: 0;
 }
 
-details.callout:not([open]):hover::before {
+details.callout:hover::before {
   opacity: 1;
 }
 

--- a/src/components/SkillsCallout/styles.module.css
+++ b/src/components/SkillsCallout/styles.module.css
@@ -1,5 +1,7 @@
 .callout {
   display: block;
+  position: relative;
+  overflow: hidden;
   margin: 0 0 2rem 0;
   /* padding-top is constant across collapsed/open so the title doesn't
      shift vertically when expanding. padding-bottom flexes via [open]
@@ -10,7 +12,39 @@
   background: var(--light-blue-60, #f0f5ff);
   border: 1px solid rgba(35, 133, 236, 0.18);
   font-family: var(--font-family, inherit);
-  transition: background 120ms ease;
+  /* Default spotlight origin (centered) before the first mousemove. */
+  --callout-mx: 50%;
+  --callout-my: 50%;
+}
+
+/* Cursor-follow spotlight. Sits above the background, below the content.
+   Only revealed when collapsed + hovered — once expanded, the user is
+   reading and we don't want chrome competing with content. */
+.callout::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(
+    480px circle at var(--callout-mx) var(--callout-my),
+    rgba(35, 133, 236, 0.22),
+    rgba(35, 133, 236, 0) 55%
+  );
+  opacity: 0;
+  transition: opacity 220ms cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
+  z-index: 0;
+}
+
+details.callout:not([open]):hover::before {
+  opacity: 1;
+}
+
+html[data-theme='dark'] .callout::before {
+  background: radial-gradient(
+    480px circle at var(--callout-mx) var(--callout-my),
+    rgba(35, 133, 236, 0.32),
+    rgba(35, 133, 236, 0) 55%
+  );
 }
 
 details.callout[open] {
@@ -215,6 +249,8 @@ html[data-theme='dark'] details.callout {
 }
 
 .calloutSummary {
+  position: relative;
+  z-index: 1;
   margin: 0;
   list-style: none;
   cursor: pointer;
@@ -243,6 +279,11 @@ html[data-theme='dark'] details.callout {
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--light-blue-100, #2385ec);
+  transition: transform 240ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+details.callout:not([open]):hover .calloutHint {
+  transform: translateX(4px);
 }
 
 .calloutHintText::before {
@@ -266,15 +307,13 @@ details.callout[open] .calloutChevron {
 }
 
 .calloutBody {
+  position: relative;
+  z-index: 1;
   padding: 0.75rem 0 0;
 }
 
-/* Button-like hover/focus on the collapsed callout so the whole banner
-   reads as a single interactive surface. Skipped when open: once content
-   is visible, the user is reading, not clicking. */
-details.callout:not([open]):hover {
-  background: var(--light-blue-80, #d9e6ff) !important;
-}
+/* Focus state for keyboard users — the spotlight does the visual work
+   for hover, so we only need an explicit focus indicator here. */
 
 details.callout:not([open]) .calloutSummary:focus-visible {
   outline: 2px solid var(--light-blue-100, #2385ec);
@@ -284,8 +323,4 @@ details.callout:not([open]) .calloutSummary:focus-visible {
 
 html[data-theme='dark'] .calloutHint {
   color: var(--dark-blue-accent, #2385ec);
-}
-
-html[data-theme='dark'] details.callout:not([open]):hover {
-  background: rgba(35, 133, 236, 0.16) !important;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,10 +25,6 @@ export default function HomePage() {
     <div className={style.homeWrapper}>
       <Header></Header>
       <div className={`${style.body} ${isFlashing ? style.flash : ""}`}>
-        <div className={style.skillsCalloutWrapper}>
-          <SkillsCallout variant="shared" banner />
-        </div>
-
         <Slogan></Slogan>
 
         <div className={style.frameworksMobile}>
@@ -37,6 +33,10 @@ export default function HomePage() {
 
         <div className={style.frameworksDesktop}>
           <Frameworks handleFrameworkClick={handleFrameworkClick}></Frameworks>
+        </div>
+
+        <div className={style.skillsCalloutWrapper}>
+          <SkillsCallout variant="shared" banner />
         </div>
 
         <CardsPart></CardsPart>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -25,6 +25,10 @@ export default function HomePage() {
     <div className={style.homeWrapper}>
       <Header></Header>
       <div className={`${style.body} ${isFlashing ? style.flash : ""}`}>
+        <div className={style.skillsCalloutWrapper}>
+          <SkillsCallout variant="shared" banner />
+        </div>
+
         <Slogan></Slogan>
 
         <div className={style.frameworksMobile}>
@@ -36,10 +40,6 @@ export default function HomePage() {
         </div>
 
         <CardsPart></CardsPart>
-
-        <div className={style.skillsCalloutWrapper}>
-          <SkillsCallout variant="shared" banner />
-        </div>
 
         <DataCapture></DataCapture>
       </div>

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -5,17 +5,21 @@ import type ContentType from '@theme/DocItem/Content';
 import type { WrapperProps } from '@docusaurus/types';
 
 import SkillsCallout from '@site/src/components/SkillsCallout';
+import skillsData from '@site/src/data/skills.json';
 import { parseSdksRoute } from '@site/src/components/utils/frameworks';
 import { isOnFallbackDenylist } from '@site/src/components/SkillsCallout/routes';
 
 type Props = WrapperProps<typeof ContentType>;
 
+const KNOWN_PRODUCTS = new Set(Object.keys(skillsData.products));
+
 export default function ContentWrapper(props: Props): JSX.Element {
   const { pathname } = useLocation();
   const route = parseSdksRoute(pathname);
+  const isKnownProductPage = !!route.product && KNOWN_PRODUCTS.has(route.product);
 
   let callout: JSX.Element | null;
-  if (route.product) {
+  if (isKnownProductPage) {
     callout = <SkillsCallout variant="product" />;
   } else if (isOnFallbackDenylist(pathname)) {
     callout = null;

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -1,16 +1,31 @@
 import React from 'react';
+import { useLocation } from '@docusaurus/router';
 import Content from '@theme-original/DocItem/Content';
 import type ContentType from '@theme/DocItem/Content';
 import type { WrapperProps } from '@docusaurus/types';
 
 import SkillsCallout from '@site/src/components/SkillsCallout';
+import { parseSdksRoute } from '@site/src/components/utils/frameworks';
+import { isOnFallbackDenylist } from '@site/src/components/SkillsCallout/routes';
 
 type Props = WrapperProps<typeof ContentType>;
 
 export default function ContentWrapper(props: Props): JSX.Element {
+  const { pathname } = useLocation();
+  const route = parseSdksRoute(pathname);
+
+  let callout: JSX.Element | null;
+  if (route.product) {
+    callout = <SkillsCallout variant="product" />;
+  } else if (isOnFallbackDenylist(pathname)) {
+    callout = null;
+  } else {
+    callout = <SkillsCallout variant="fallback" />;
+  }
+
   return (
     <>
-      <SkillsCallout />
+      {callout}
       <Content {...props} />
     </>
   );

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -24,7 +24,7 @@ export default function ContentWrapper(props: Props): JSX.Element {
   } else if (isOnFallbackDenylist(pathname)) {
     callout = null;
   } else {
-    callout = <SkillsCallout variant="fallback" />;
+    callout = <SkillsCallout variant="shared" />;
   }
 
   return (


### PR DESCRIPTION
## Summary

- Adds a product-disambiguation fallback callout on doc pages where the existing product-specific `SkillsCallout` doesn't fire (top-level concept pages, framework landings, etc.), so visitors who haven't picked a product still get a path into the `data-capture-sdk` agent skill. A small URL denylist excludes release notes, migration guides, and the agent-skills page itself.
- Collapses **all** callouts (product + shared) by default behind a native `<details>` with the existing blue chrome. Right-aligned `Show ›` / `Hide ‹` micro-label, button-like hover with a cursor-follow spotlight, and a smooth slide-and-fade open/close animation in browsers that support `::details-content` + `interpolate-size` (Chrome/Edge 131+; Firefox/Safari snap as today).
- Fires a new PostHog event `skills_callout_expanded` on every open with `{ variant, pathname, product?, framework? }`. Dashboard 693119 has four new tiles wired to it: total expansions, expansions by variant, expansions by page (top 25), and an **expand → copy** funnel against the existing `skills_command_copied` event.
- Removes the 4px blue `border-left` accent on the callout in favor of a uniform 1px border. Drops the homepage banner's larger padding so the callout height matches docs.
- Drives the variant choice from the swizzle at \`src/theme/DocItem/Content/index.tsx\`: product → shared → null based on the URL, gated on a \`KNOWN_PRODUCTS\` set so URL segments like \`/sdks/ios/add-sdk\` don't get incorrectly treated as products.
- Small unrelated cleanup: removes an unused image block from the Smart Label Capture intro partial.