### PR TITLE
SparkScan advanced: add default-scanning-mode code example (4 frameworks)

### DIFF
--- a/docs/sdks/capacitor/sparkscan/advanced.md
+++ b/docs/sdks/capacitor/sparkscan/advanced.md
@@ -120,3 +120,21 @@ The preview behavior determines how the camera preview behaves when the scanner 
 | -------------- | -------------------------- |
 | **Default**    | Preview fades away when the scanner is off. This lets the user check important information displayed by the app and reduces battery consumption.                 |
 | **Persistent** | Preview remains visible, but darkened, even when the scanner is off. This is useful for scenarios where you want to select a barcode (among many) or need to look through the preview at all times (to ensure the right scan) - especially if used in conjunction with the target mode. |
+
+### Configuring the default scanning mode
+
+Combine a scanning mode, scanning behavior, and preview behavior and assign it to
+[`SparkScanViewSettings.defaultScanningMode`](https://docs.scandit.com/data-capture-sdk/capacitor/barcode-capture/api/spark-scan-view-settings.html). For example, to start in continuous scanning with the preview always visible:
+
+```ts
+const viewSettings = new SparkScanViewSettings();
+viewSettings.defaultScanningMode = new SparkScanScanningModeDefault(
+  SparkScanScanningBehavior.Continuous, // or .Single
+  SparkScanPreviewBehavior.Persistent,  // or .Default
+);
+```
+
+Pass both arguments — the single-argument constructor is deprecated. Use
+`SparkScanScanningModeTarget` instead of `SparkScanScanningModeDefault` to force the
+aimer (target mode).
+

--- a/docs/sdks/cordova/sparkscan/advanced.md
+++ b/docs/sdks/cordova/sparkscan/advanced.md
@@ -122,3 +122,22 @@ The preview behavior determines how the camera preview behaves when the scanner 
 | -------------- | -------------------------- |
 | **Default**    | Preview fades away when the scanner is off. This lets the user check important information displayed by the app and reduces battery consumption.                 |
 | **Persistent** | Preview remains visible, but darkened, even when the scanner is off. This is useful for scenarios where you want to select a barcode (among many) or need to look through the preview at all times (to ensure the right scan) - especially if used in conjunction with the target mode. |
+
+### Configuring the default scanning mode
+
+Combine a scanning mode, scanning behavior, and preview behavior and assign it to
+`SparkScanViewSettings.defaultScanningMode`. For example, to start in continuous
+scanning with the preview always visible:
+
+```js
+const sparkScanViewSettings = new Scandit.SparkScanViewSettings();
+sparkScanViewSettings.defaultScanningMode = new Scandit.SparkScanScanningModeDefault(
+  Scandit.SparkScanScanningBehavior.Continuous, // or .Single
+  Scandit.SparkScanPreviewBehavior.Persistent,  // or .Default
+);
+```
+
+Pass both arguments — the single-argument constructor is deprecated. Use
+`Scandit.SparkScanScanningModeTarget` instead of `SparkScanScanningModeDefault` to force
+the aimer (target mode).
+

--- a/docs/sdks/flutter/sparkscan/advanced.md
+++ b/docs/sdks/flutter/sparkscan/advanced.md
@@ -120,3 +120,20 @@ The preview behavior determines how the camera preview behaves when the scanner 
 | -------------- | -------------------------- |
 | **Default**    | Preview fades away when the scanner is off. This lets the user check important information displayed by the app and reduces battery consumption.                 |
 | **Persistent** | Preview remains visible, but darkened, even when the scanner is off. This is useful for scenarios where you want to select a barcode (among many) or need to look through the preview at all times (to ensure the right scan) - especially if used in conjunction with the target mode. |
+
+### Configuring the default scanning mode
+
+Combine a scanning mode, scanning behavior, and preview behavior and assign it to
+[`SparkScanViewSettings.defaultScanningMode`](https://docs.scandit.com/data-capture-sdk/flutter/barcode-capture/api/spark-scan-view-settings.html). For example, to start in continuous scanning with the preview always visible:
+
+```dart
+final viewSettings = SparkScanViewSettings();
+viewSettings.defaultScanningMode = SparkScanScanningModeDefault.fromPreviewBehavior(
+  SparkScanScanningBehavior.continuous, // or .single
+  SparkScanPreviewBehavior.persistent,  // or .defaultBehaviour
+);
+```
+
+Use `SparkScanScanningModeTarget.fromPreviewBehavior(...)` instead of
+`SparkScanScanningModeDefault` to force the aimer (target mode).
+

--- a/docs/sdks/react-native/sparkscan/advanced.md
+++ b/docs/sdks/react-native/sparkscan/advanced.md
@@ -157,3 +157,20 @@ The preview behavior determines how the camera preview behaves when the scanner 
 | -------------- | -------------------------- |
 | **Default**    | Preview fades away when the scanner is off. This lets the user check important information displayed by the app and reduces battery consumption.                 |
 | **Persistent** | Preview remains visible, but darkened, even when the scanner is off. This is useful for scenarios where you want to select a barcode (among many) or need to look through the preview at all times (to ensure the right scan) - especially if used in conjunction with the target mode. |
+
+### Configuring the default scanning mode
+
+Combine a scanning mode, scanning behavior, and preview behavior and assign it to
+[`SparkScanViewSettings.defaultScanningMode`](https://docs.scandit.com/data-capture-sdk/react-native/barcode-capture/api/spark-scan-view-settings.html). For example, to start in continuous scanning with the preview always visible:
+
+```ts
+const viewSettings = new SparkScanViewSettings();
+viewSettings.defaultScanningMode = new SparkScanScanningModeDefault(
+  SparkScanScanningBehavior.Continuous, // or .Single
+  SparkScanPreviewBehavior.Persistent,  // or .Default
+);
+```
+
+Pass both arguments — the single-argument constructor is deprecated. Use
+`SparkScanScanningModeTarget` instead of `SparkScanScanningModeDefault` to force the
+aimer (target mode).


### PR DESCRIPTION
## What

The SparkScan **Advanced Configurations** page documents scanning mode, scanning behavior, and preview behavior in prose tables, but shows **no code** for how to set `SparkScanViewSettings.defaultScanningMode`. Anyone following the page has to guess the constructor signature — and the per-platform signatures differ (Dart uses a `fromPreviewBehavior` factory; the JS/TS frameworks use a two-argument constructor; the single-arg form is deprecated).

This adds a short "Configuring the default scanning mode" code example to the **flutter, react-native, capacitor, and cordova** pages, with the verified per-platform API.

## Why / evidence

Found while testing whether our integration skills need to bundle this snippet or can rely on fetching the docs. A doc-fetching agent generating "continuous scanning + persistent preview" code scored:

- **29/31** against the current pages (missed the exact constructor on flutter + cordova — it isn't in the docs)
- **31/31** against these updated pages, with no other change

So the gap was in the docs, not the SDK or the consumer.

## Scope

iOS / Android / Web have the same prose-only gap but are **intentionally not touched here**: the iOS native headers deprecate `SparkScanScanningModeDefault`/`Target` in favor of `SparkScanSettings.selectionMode` (removed in 9.0), so those pages need separate API verification before getting an example. Tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)