### PR TITLE
Add WebView integration guide for Web SDK

### DIFF
--- a/docs/sdks/web/add-sdk.md
+++ b/docs/sdks/web/add-sdk.md
@@ -475,6 +475,8 @@ For information on how to improve runtime performance, see [Improve Runtime Perf
 When using the Scandit Data Capture SDK you will likely want to set the camera as the frame source for various capture modes.
 The camera permissions are handled by the browser, and can only be granted if a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) is used and have been accepted by the user explicitly.
 
+If you are embedding the Web SDK inside a native WebView (Android or iOS), the host application must request and delegate camera permissions to the web content. See the [WebView Integration](./webview.md) guide for step-by-step instructions.
+
 ### Progressive Web App (PWA)
 
 You can configure the scanner to work offline making the web app progressive (Progressive Web App). There are some settings to consider. If you use Workbox, a tool that uses workbox under the hood like [Vite PWA](https://vite-pwa-org.netlify.app/) plugin, you must also set these options:

--- a/docs/sdks/web/webview.md
+++ b/docs/sdks/web/webview.md
@@ -47,11 +47,11 @@ Add the `CAMERA` permission to your `AndroidManifest.xml`:
 Request the OS-level camera permission before loading the WebView. Using the Activity Result Contracts API:
 
 ```kotlin
-import android.Manifest
-import android.content.pm.PackageManager
-import android.os.Bundle
-import androidx.activity.result.contract.ActivityResultContracts
-import androidx.core.content.ContextCompat
+# import android.Manifest
+# import android.content.pm.PackageManager
+# import android.os.Bundle
+# import androidx.activity.result.contract.ActivityResultContracts
+# import androidx.core.content.ContextCompat
 
 private val cameraPermission = registerForActivityResult(
     ActivityResultContracts.RequestPermission()
@@ -79,8 +79,8 @@ override fun onCreate(savedInstanceState: Bundle?) {
 When the web SDK calls `getUserMedia`, the WebView triggers `WebChromeClient.onPermissionRequest`. Override this method to forward the permission to the web content. It is safe to grant automatically here because the native app has already received the OS camera permission in the previous step:
 
 ```kotlin
-import android.webkit.PermissionRequest
-import android.webkit.WebChromeClient
+# import android.webkit.PermissionRequest
+# import android.webkit.WebChromeClient
 
 webView.webChromeClient = object : WebChromeClient() {
     override fun onPermissionRequest(request: PermissionRequest) {
@@ -97,8 +97,8 @@ webView.webChromeClient = object : WebChromeClient() {
 Enable JavaScript and allow media autoplay so the SDK can start the camera without requiring a user gesture:
 
 ```kotlin
-import android.webkit.WebSettings
-import android.webkit.WebView
+# import android.webkit.WebSettings
+# import android.webkit.WebView
 
 webView.settings.apply {
     javaScriptEnabled = true
@@ -112,7 +112,7 @@ webView.settings.apply {
 Load the web app from a local server to satisfy the secure context requirement:
 
 ```kotlin
-import android.webkit.WebView
+# import android.webkit.WebView
 
 webView.loadUrl("http://localhost:$port/")
 ```

--- a/docs/sdks/web/webview.md
+++ b/docs/sdks/web/webview.md
@@ -47,6 +47,12 @@ Add the `CAMERA` permission to your `AndroidManifest.xml`:
 Request the OS-level camera permission before loading the WebView. Using the Activity Result Contracts API:
 
 ```kotlin
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+
 private val cameraPermission = registerForActivityResult(
     ActivityResultContracts.RequestPermission()
 ) { granted ->
@@ -73,6 +79,9 @@ override fun onCreate(savedInstanceState: Bundle?) {
 When the web SDK calls `getUserMedia`, the WebView triggers `WebChromeClient.onPermissionRequest`. Override this method to forward the permission to the web content. It is safe to grant automatically here because the native app has already received the OS camera permission in the previous step:
 
 ```kotlin
+import android.webkit.PermissionRequest
+import android.webkit.WebChromeClient
+
 webView.webChromeClient = object : WebChromeClient() {
     override fun onPermissionRequest(request: PermissionRequest) {
         val cameraResources = request.resources.filter {
@@ -88,6 +97,9 @@ webView.webChromeClient = object : WebChromeClient() {
 Enable JavaScript and allow media autoplay so the SDK can start the camera without requiring a user gesture:
 
 ```kotlin
+import android.webkit.WebSettings
+import android.webkit.WebView
+
 webView.settings.apply {
     javaScriptEnabled = true
     domStorageEnabled = true
@@ -100,6 +112,8 @@ webView.settings.apply {
 Load the web app from a local server to satisfy the secure context requirement:
 
 ```kotlin
+import android.webkit.WebView
+
 webView.loadUrl("http://localhost:$port/")
 ```
 

--- a/docs/sdks/web/webview.md
+++ b/docs/sdks/web/webview.md
@@ -1,0 +1,191 @@
+---
+description: "Learn how to use the Scandit Web SDK inside a native WebView on Android and iOS, including how to correctly handle camera permissions."
+sidebar_position: 2
+framework: web
+keywords:
+  - web
+  - webview
+  - android
+  - ios
+  - camera
+  - permissions
+displayed_sidebar: webSidebar
+toc_max_heading_level: 3
+---
+
+# WebView Integration
+
+The Scandit Web SDK can run inside a native WebView on Android and iOS. Because WebViews do not have direct access to device APIs, the native host application is responsible for requesting and delegating camera permissions to the web content.
+
+## Secure Context Requirement
+
+Browsers — including WebView runtimes — only allow camera access in a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). This means the web content must be served over HTTPS or from `localhost`. A plain `file://` URL is not a secure context and `getUserMedia` will fail.
+
+The recommended approach is to embed a lightweight local HTTP server in the native app and load the web content from `http://localhost:<port>/`. This satisfies the secure context requirement without requiring a remote server.
+
+## Android
+
+:::warning
+Android WebView does not support `SharedArrayBuffer` because its process model cannot provide the OS-level process isolation required to be [cross-origin isolated](https://developer.mozilla.org/en-US/docs/Web/API/crossOriginIsolated). This is an Android-specific limitation — iOS WKWebView supports cross-origin isolation since iOS 15.2. As a result, multithreading is unavailable on Android WebView and performance-intensive capture modes such as MatrixScan Batch and MatrixScan AR will run significantly slower than in a standard browser. See [Improve Runtime Performance by Enabling Browser Multithreading](./matrixscan/get-started.md#improve-runtime-performance-by-enabling-browser-multithreading) for context on what multithreading provides.
+
+If scanning performance is critical for your use case, consider these alternatives:
+- **Progressive Web App (PWA)**: a PWA runs in the device browser, which does support cross-origin isolation and multithreading, while still offering an app-like experience.
+- **Native Android SDK**: the [Scandit Android SDK](/sdks/android/add-sdk.md) runs entirely in native code and is not subject to any WebView or browser limitations.
+:::
+
+### 1. Declare the Camera Permission
+
+Add the `CAMERA` permission to your `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+<uses-feature android:name="android.hardware.camera" android:required="true" />
+```
+
+### 2. Request Camera Permission at Runtime
+
+Request the OS-level camera permission before loading the WebView. Using the Activity Result Contracts API:
+
+```kotlin
+private val cameraPermission = registerForActivityResult(
+    ActivityResultContracts.RequestPermission()
+) { granted ->
+    if (granted) {
+        loadWebView()
+    } else {
+        // Handle denial — the web content cannot access the camera
+    }
+}
+
+override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+            == PackageManager.PERMISSION_GRANTED) {
+        loadWebView()
+    } else {
+        cameraPermission.launch(Manifest.permission.CAMERA)
+    }
+}
+```
+
+### 3. Grant Camera Access to Web Content
+
+When the web SDK calls `getUserMedia`, the WebView triggers `WebChromeClient.onPermissionRequest`. Override this method to forward the permission to the web content. It is safe to grant automatically here because the native app has already received the OS camera permission in the previous step:
+
+```kotlin
+webView.webChromeClient = object : WebChromeClient() {
+    override fun onPermissionRequest(request: PermissionRequest) {
+        val cameraResources = request.resources.filter {
+            it == PermissionRequest.RESOURCE_VIDEO_CAPTURE
+        }.toTypedArray()
+        request.grant(cameraResources)
+    }
+}
+```
+
+### 4. Configure the WebView
+
+Enable JavaScript and allow media autoplay so the SDK can start the camera without requiring a user gesture:
+
+```kotlin
+webView.settings.apply {
+    javaScriptEnabled = true
+    domStorageEnabled = true
+    mediaPlaybackRequiresUserGesture = false
+}
+```
+
+### 5. Serve Content from Localhost
+
+Load the web app from a local server to satisfy the secure context requirement:
+
+```kotlin
+webView.loadUrl("http://localhost:$port/")
+```
+
+A minimal implementation using [NanoHTTPD](https://github.com/NanoHttpd/nanohttpd) can serve static files from the APK's `assets/` folder. Make sure to include the correct MIME type for `.wasm` files (`application/wasm`) — without it, the browser will reject the Scandit engine files. For general guidance on serving the SDK's engine files, see [Hosting the `sdc-lib` files](./add-sdk.md#hosting-the-sdc-lib-files).
+
+## iOS
+
+### 1. Add the Camera Usage Description
+
+Add a camera usage description to your `Info.plist`:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>Camera access is required for barcode scanning.</string>
+```
+
+### 2. Configure the WKWebView
+
+Enable inline media playback and allow media to start without a user gesture:
+
+```swift
+import WebKit
+
+let configuration = WKWebViewConfiguration()
+configuration.allowsInlineMediaPlayback = true
+configuration.mediaTypesRequiringUserActionForPlayback = []
+
+let webView = WKWebView(frame: .zero, configuration: configuration)
+webView.uiDelegate = self
+```
+
+### 3. Handle the Media Capture Permission Request
+
+Implement `WKUIDelegate` to respond when the web SDK requests camera access. Tie the decision to the current `AVCaptureDevice` authorization status:
+
+```swift
+import AVFoundation
+import WebKit
+
+func webView(
+    _ webView: WKWebView,
+    requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+    initiatedByFrame frame: WKFrameInfo,
+    type: WKMediaCaptureType,
+    decisionHandler: @escaping (WKPermissionDecision) -> Void
+) {
+    AVCaptureDevice.requestAccess(for: .video) { granted in
+        DispatchQueue.main.async {
+            decisionHandler(granted ? .grant : .deny)
+        }
+    }
+}
+```
+
+This delegate method is called every time the web content requests camera access. Calling `AVCaptureDevice.requestAccess` here triggers the system permission prompt on first launch, and returns immediately on subsequent calls based on the stored authorization status.
+
+### 4. Pre-request the Camera Permission (Recommended)
+
+Requesting the native camera permission before loading the page results in a smoother user experience, because the system prompt appears immediately at app launch rather than mid-scan:
+
+```swift
+override func viewDidLoad() {
+    super.viewDidLoad()
+    setupWebView()
+    requestCameraPermission()
+    loadContent()
+}
+
+private func requestCameraPermission() {
+    AVCaptureDevice.requestAccess(for: .video) { _ in }
+}
+```
+
+### 5. Load the Web Content
+
+Load a bundled HTML file or a local server URL. For bundled files, use `loadFileURL(_:allowingReadAccessTo:)` — note that `file://` URLs are not a secure context, so you must either serve from a local HTTP server or load the file with the SDK already initialized for a non-camera use-case.
+
+The simplest approach is to bundle the web app and load it directly:
+
+```swift
+if let path = Bundle.main.path(forResource: "index", ofType: "html") {
+    let url = URL(fileURLWithPath: path)
+    webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+}
+```
+
+:::note
+`loadFileURL` grants the web content a secure context on iOS, so `getUserMedia` works even for `file://` URLs when loaded this way.
+:::

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -654,6 +654,7 @@ const sidebars: SidebarsConfig = {
           href: "https://support.scandit.com/hc/en-us",
         },
         'sdks/web/add-sdk',
+        'sdks/web/webview',
         'sdks/web/agent-skills',
         {
           type: "link",

--- a/validation/baselines/baseline-kotlin.json
+++ b/validation/baselines/baseline-kotlin.json
@@ -563,5 +563,25 @@
     "hash": "b355d727130f8eba029d33570b91a31e611db7cd192bf90044f4eddb9ac40ae9",
     "file": "docs/sdks/android/sparkscan/get-started.md",
     "snippet": 7
+  },
+  {
+    "hash": "8ce77fa476ed30aa74a85005228071ced297e697bbc66e36313d843071740dec",
+    "file": "docs/sdks/web/webview.md",
+    "snippet": 0
+  },
+  {
+    "hash": "59f6c48f6c6515608ba7bb761ebfe296fea58ba194150a74fb63e670f2dfa347",
+    "file": "docs/sdks/web/webview.md",
+    "snippet": 1
+  },
+  {
+    "hash": "fd2dc9d98539d25869f068147437224d4b45abede071ed8afb49444d36fa198b",
+    "file": "docs/sdks/web/webview.md",
+    "snippet": 2
+  },
+  {
+    "hash": "7aa7cc2a4af4b2e166c00b04fba1372956eca6705471ad1b61dbdd46af22a17f",
+    "file": "docs/sdks/web/webview.md",
+    "snippet": 3
   }
 ]


### PR DESCRIPTION
## Summary
- Adds a new `webview.md` page documenting how to integrate the Scandit Web SDK inside a native WebView on Android and iOS
- Covers camera permission setup for both platforms (Android `WebChromeClient.onPermissionRequest`, iOS `WKUIDelegate`)
- Warns about the Android WebView multithreading limitation (no `SharedArrayBuffer`/cross-origin isolation) and recommends PWA or the native Android SDK for performance-critical use cases
- Links the `sdc-lib` hosting guide and the multithreading docs for context
- Updates the "Camera Permissions" section in `add-sdk.md` to reference the new page
- Adds the new page to the web SDK sidebar

## Test Plan
- [x] Verify the new page renders correctly in Docusaurus
- [x] Check all internal links resolve (`add-sdk.md#hosting-the-sdc-lib-files`, `matrixscan/get-started.md#improve-runtime-performance-by-enabling-browser-multithreading`, `/sdks/android/add-sdk.md`)
- [x] Confirm the page appears in the sidebar under "Data Capture SDK"