### PR TITLE
Add Codex install tab to skills callout

### DIFF
--- a/src/components/SkillsCallout/InstallTabs.tsx
+++ b/src/components/SkillsCallout/InstallTabs.tsx
@@ -4,12 +4,15 @@ import skillsData from '@site/src/data/skills.json';
 import { capturePostHogEvent } from './analytics';
 import styles from './styles.module.css';
 
-type TabKey = 'any' | 'claude-code' | 'cursor';
+type TabKey = 'any' | 'claude-code' | 'codex' | 'cursor';
 
 const CURSOR_INSTALL_URL = 'https://cursor.com/marketplace/scandit';
 
 const CLAUDE_CODE_MARKETPLACE_COMMAND = '/plugin marketplace add scandit/skills';
 const CLAUDE_CODE_INSTALL_COMMAND = '/plugin install scandit-sdk@scandit-plugins';
+
+const CODEX_MARKETPLACE_COMMAND = 'codex plugin marketplace add scandit/skills';
+const CODEX_INSTALL_COMMAND = 'codex plugin add scandit-sdk@scandit-plugins';
 
 const CopyIcon: React.FC = () => (
   <svg
@@ -109,6 +112,7 @@ const InstallTabs: React.FC<InstallTabsProps> = ({ skillSlug, product, framework
   const tabs: { key: TabKey; label: string }[] = [
     { key: 'any', label: 'Any AI coding agent' },
     { key: 'claude-code', label: 'Claude Code' },
+    { key: 'codex', label: 'Codex' },
     { key: 'cursor', label: 'Cursor' },
   ];
 
@@ -160,6 +164,24 @@ const InstallTabs: React.FC<InstallTabsProps> = ({ skillSlug, product, framework
             {skillSlug && (
               <p className={styles.tabHint}>
                 The plugin bundles every Scandit skill. Claude Code picks the
+                right one automatically based on your prompt; to invoke this
+                one explicitly, call <code>/{skillSlug}</code> followed by
+                your task.
+              </p>
+            )}
+          </>
+        )}
+        {tab === 'codex' && (
+          <>
+            <p className={styles.tabHint}>
+              Run these commands in your terminal, one at a time, to install
+              the Scandit plugin in Codex.
+            </p>
+            <CommandBlock command={CODEX_MARKETPLACE_COMMAND} trackingId="codex-marketplace" product={product} framework={framework} />
+            <CommandBlock command={CODEX_INSTALL_COMMAND} trackingId="codex-plugin" product={product} framework={framework} />
+            {skillSlug && (
+              <p className={styles.tabHint}>
+                The plugin bundles every Scandit skill. Codex picks the
                 right one automatically based on your prompt; to invoke this
                 one explicitly, call <code>/{skillSlug}</code> followed by
                 your task.


### PR DESCRIPTION
## Summary

Two related changes to the skills install UI (`InstallTabs`):

### 1. Codex install tab

Mirrors [scandit/skills#68](https://github.com/Scandit/skills/pull/68), which packaged the Scandit skills as a native [OpenAI Codex plugin](https://developers.openai.com/codex/plugins). Adds a dedicated **Codex** tab to the shared install component (rendered on the agent-skills page and the inline skills callouts), modeled on the existing Claude Code tab:

- `codex plugin marketplace add scandit/skills`
- `codex plugin add scandit-sdk@scandit-plugins`

Tab order is Any → Claude Code → Codex → Cursor, matching the agent ordering already used in the page lede.

### 2. Fix framework casing in install analytics

The `skills_command_copied` PostHog event was reporting the `framework` property with two conventions:

- `SkillsCallout` (inline callouts) sent the URL slug — `ios`, `android`, `web`, `react-native`, …
- `SkillsPage` (the `/agent-skills` pages) passed the MDX display name straight through — `iOS`, `Android`, `Web`, `Cordova`, `React Native`.

This split each platform across two buckets in the dashboard's "copies by framework" insight (last 30 days: `ios`=26 + `iOS`=14, `Android`=23 + `android`=6, `Web`=10 + `web`=6).

Fix: added an idempotent `frameworkToSlug()` helper in `utils/frameworks.ts` (derived from the existing `FRAMEWORK_MAPPING`) and canonicalize to the slug at the `InstallTabs` chokepoint, so every caller — current and future — reports one consistent value. The Codex tab inherits this automatically.

## Notes for reviewers

- The Codex hint reads **"Run these commands in your terminal, one at a time"** since `codex plugin …` are CLI invocations — in contrast to the Claude Code tab's "Paste directly in Claude Code." Tweak if Codex's plugin commands are meant to be typed inside the Codex TUI instead.
- The analytics fix only affects events going forward; historical data in the dashboard remains split across casings. The "copies by framework" insight can be reconciled separately if a merged historical view is needed.
- `npx tsc --noEmit` passes clean.