### PR TITLE
Normalize framework casing in skills install analytics

### DIFF
--- a/src/components/SkillsCallout/InstallTabs.tsx
+++ b/src/components/SkillsCallout/InstallTabs.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import skillsData from '@site/src/data/skills.json';
+import { frameworkToSlug } from '../utils/frameworks';
 import { capturePostHogEvent } from './analytics';
 import styles from './styles.module.css';
 
@@ -107,7 +108,11 @@ export interface InstallTabsProps {
   framework?: string;
 }
 
-const InstallTabs: React.FC<InstallTabsProps> = ({ skillSlug, product, framework }) => {
+const InstallTabs: React.FC<InstallTabsProps> = ({ skillSlug, product, framework: frameworkProp }) => {
+  // Canonicalize to the URL slug so analytics never splits one platform across
+  // casings — callers pass either a slug (SkillsCallout) or a display name
+  // (SkillsPage, from MDX). See frameworkToSlug.
+  const framework = frameworkToSlug(frameworkProp);
   const [tab, setTab] = useState<TabKey>('any');
   const tabs: { key: TabKey; label: string }[] = [
     { key: 'any', label: 'Any AI coding agent' },

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -16,6 +16,23 @@ export const URL_PRODUCT_MAPPING: { [urlSlug: string]: string } = {
   'matrixscan': 'matrixscan-batch',
 };
 
+// Inverse of FRAMEWORK_MAPPING: display name -> canonical URL slug.
+const FRAMEWORK_DISPLAY_TO_SLUG: { [displayName: string]: string } = Object.fromEntries(
+  Object.entries(FRAMEWORK_MAPPING).map(([slug, display]) => [display, slug]),
+);
+
+/**
+ * Canonicalizes a framework identifier to its URL slug (e.g. `iOS` -> `ios`,
+ * `.NET Android` -> `net-android`). Idempotent: an already-canonical slug is
+ * returned unchanged. Use this anywhere a framework is reported to analytics
+ * so the same platform isn't split across casings (`ios` vs `iOS`).
+ */
+export function frameworkToSlug(framework?: string): string | undefined {
+  if (!framework) return framework;
+  if (FRAMEWORK_MAPPING[framework]) return framework; // already a canonical slug
+  return FRAMEWORK_DISPLAY_TO_SLUG[framework] || framework.toLowerCase();
+}
+
 export interface SdksRouteInfo {
   framework?: string;
   product?: string;


### PR DESCRIPTION
## Summary

Follow-up to #369. That PR was merged before this commit existed, so the framework-casing fix never made it into `main` — it was left stranded on the `add-codex-install-tab` branch. This PR brings it in via a clean branch off `main`.

## The bug

The `skills_command_copied` PostHog event reports the `framework` property with two conventions:

- `SkillsCallout` (inline callouts) sends the URL slug — `ios`, `android`, `web`, `react-native`, …
- `SkillsPage` (the `/agent-skills` pages) passes the MDX display name straight through — `iOS`, `Android`, `Web`, `Cordova`, `React Native`.

This splits each platform across two breakdown buckets (e.g. `ios`=26 + `iOS`=14 for the same platform).

## Fix

Added an idempotent `frameworkToSlug()` helper in `utils/frameworks.ts` (derived from the existing `FRAMEWORK_MAPPING`) and canonicalize to the slug at the `InstallTabs` chokepoint, so every caller — current and future — reports one consistent value.

## Notes for reviewers

- This only affects events going forward. The dashboard's "copies by framework" insight was already reconciled separately with a HogQL breakdown (`replaceAll(replaceAll(lower(properties.framework), ' ', '-'), '.', '')`), so historical + future data already display merged there. This PR fixes the data **at the source** so the raw property is consistent for any other/future query that doesn't replicate that HogQL.
- `npx tsc --noEmit` passes clean.