### PR TITLE
Link to skills update instructions in install tabs

### DIFF
--- a/src/components/SkillsCallout/InstallTabs.tsx
+++ b/src/components/SkillsCallout/InstallTabs.tsx
@@ -222,6 +222,13 @@ const InstallTabs: React.FC<InstallTabsProps> = ({ skillSlug, product, framework
           </>
         )}
       </div>
+      <p className={styles.tabHint}>
+        Already installed? Update steps differ by agent — see{' '}
+        <a href={skillsData.repo} target="_blank" rel="noopener noreferrer">
+          how to keep your skills up to date
+        </a>
+        .
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Problem

The skills callout and the `/sdks/{framework}/agent-skills` page explain how to **install** skills, but never how to **update** them after install — a gap that came up in feedback.

## Approach

Update steps genuinely differ per agent:
- npx: `npx skills update scandit/skills`
- Codex: `codex plugin marketplace upgrade scandit-plugins`
- Claude Code: re-run the marketplace/install commands
- Cursor: auto-updates

Rather than re-document all of these inline, add a single note in the shared `InstallTabs` component linking to the [scandit/skills](https://github.com/scandit/skills) repo where the steps are described one by one.

Because `InstallTabs` is embedded in both the compact product-page callout (`SkillsCallout`) and the full agent-skills page (`SkillsPage`), the link now appears right under the install commands everywhere — one edit, no duplication.

> Already installed? Update steps differ by agent — see [how to keep your skills up to date](https://github.com/scandit/skills).

## Notes

- Reuses the existing `tabHint` style (muted, dark-mode covered) and the same external-link pattern used elsewhere.
- Links to `skillsData.repo` (the URL already used by the npx command and the "Learn more" link).
- `tsc --noEmit` passes.