### PR TITLE
Label unreleased version as Beta instead of Legacy

### DIFF
--- a/src/theme/NavbarItem/DocsVersionDropdownNavbarItem/index.js
+++ b/src/theme/NavbarItem/DocsVersionDropdownNavbarItem/index.js
@@ -38,7 +38,10 @@ export default function DocsVersionDropdownNavbarItem({
 
   const getCategory = (version) => {
     if (version.isLast) return 'stable';
-    if (version.banner === 'unreleased') return 'beta';
+    // useVersions() returns global-data version objects, which don't carry the
+    // `banner` config field — only the in-development "current" version does, so
+    // key on its name to flag the unreleased docs as beta rather than legacy.
+    if (version.name === 'current') return 'beta';
     return 'legacy';
   };
 


### PR DESCRIPTION
## Problem

The SDK version dropdown showed the unreleased **8.5.0** (`current`) version tagged as **LEGACY**, even though #375 added a `getCategory()` branch intended to tag it as **Beta**:

```js
if (version.banner === 'unreleased') return 'beta';
```

That check never matched. `useVersions()` returns global-data version objects built by Docusaurus's `toGlobalDataVersion()`, which only expose `name`, `label`, `isLast`, `path`, `mainDocId`, `docs`, `draftIds`, and `sidebars` — **there is no `banner` field**. (`banner` lives on the per-page `PropVersionMetadata` from `useDocsVersion()`, not on the global version list.) So `version.banner` was always `undefined` and the unreleased version fell through to `legacy`.

## Fix

Key on `version.name === 'current'` instead. Docusaurus always names the in-development version `current`, which is exactly the one the config marks `banner: 'unreleased'`. The component already uses `version.name` for its Xamarin filter, so it's the consistent property to branch on.

| Version | Before | After |
|---------|--------|-------|
| 8.5.0 (`current`, unreleased) | ~~Legacy~~ | **Beta** |
| 8.4.1 (`isLast`) | Stable | Stable |
| 7.6.14 | Legacy | Legacy |
| 6.28.10 | Legacy | Legacy |

The `.version-tag-beta` styling already exists in `navbar.scss`, so no other changes are needed.