### PR TITLE
Fix React Native New Architecture version requirement

### DIFF
--- a/docs/partials/_system-requirements.mdx
+++ b/docs/partials/_system-requirements.mdx
@@ -92,7 +92,7 @@ These platforms are based on the native platforms and therefore the requirements
 | Capacitor       | - Capacitor 5.0.0<br/>- Swift 4.0+                   |
 | Cordova         | - cordova 12.0.0<br/>- cordova-android 10.0.0<br/>- cordova-ios 6.3.0<br/>- Swift 5.0+ |
 | Flutter         | - Flutter 3.22.0+ (Dart 3.4.0+)<br/>- Swift 5.0+      |
-| React Native    | - react-native 0.70+ (0.72+ recommended for modern toolchain support)<br/>- react-native 0.74.0+ required when using the New Architecture<br/>- Kotlin 1.9.25<br/>- Swift 5.0+ |
+| React Native    | - react-native 0.70+ (0.72+ recommended for modern toolchain support)<br/>- react-native 0.78+ required when the New Architecture is enabled<br/>- Kotlin 1.9.25<br/>- Swift 5.0+ |
 | Titanium        | - Titanium 13.0.0+                                |
 | .NET for iOS    | - .NET SDK 6.0.403+                                 |
 | .NET for Android| - .NET SDK 6.0.403+<br/>- Kotlin 1.9.25              |


### PR DESCRIPTION
## What

Correct the React Native New Architecture minimum version in the system requirements partial.

- Was: `react-native 0.74.0+ required when using the New Architecture`
- Now: `react-native 0.78+ required when the New Architecture is enabled`

RN 0.70+ baseline and 0.72+ recommended remain unchanged.

## Note

Change lives in the shared `docs/partials/_system-requirements.mdx`, so it renders on every SDK's System Requirements page. The RN row is RN-specific, so no cross-impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)