### PR TITLE
Fix Agent Skills callout framework linking and add ID scanning skills

### DIFF
--- a/src/components/HomePage/Frameworks/CardAdditional.tsx
+++ b/src/components/HomePage/Frameworks/CardAdditional.tsx
@@ -1,5 +1,6 @@
 import { FrameworksName } from "../../constants/frameworksName";
 import { FrameworkCardType } from "../../constants/types";
+import { FRAMEWORK_STORAGE_KEY } from "../../utils/frameworks";
 import style from "./CardAdditional.module.css";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 
@@ -25,7 +26,7 @@ export default function CardAdditional({
     );
     setSelectedFramework();
     handleFrameworkClick();
-    localStorage.setItem("framework", framework.framework);
+    localStorage.setItem(FRAMEWORK_STORAGE_KEY, framework.framework);
   }
 
   return (

--- a/src/components/HomePage/Frameworks/FrameworkCard.tsx
+++ b/src/components/HomePage/Frameworks/FrameworkCard.tsx
@@ -1,5 +1,6 @@
 import { ArrowDropDown } from "../../IconComponents";
 import { FrameworksName } from "../../constants/frameworksName";
+import { FRAMEWORK_STORAGE_KEY } from "../../utils/frameworks";
 import style from "./FrameworkCard.module.css";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 
@@ -26,7 +27,7 @@ export function FrameworkCard({
           new URLSearchParams(location.search)
         );
         const selectedFramework =
-          paramsURL.framework || localStorage.getItem("framework") || "web";
+          paramsURL.framework || localStorage.getItem(FRAMEWORK_STORAGE_KEY) || "web";
         const isSelected = framework.framework === selectedFramework;
 
         return (

--- a/src/components/HomePage/Frameworks/Frameworks.tsx
+++ b/src/components/HomePage/Frameworks/Frameworks.tsx
@@ -3,6 +3,7 @@ import { frameworkCards } from "../data/frameworkCardsArr";
 import { FrameworkCard } from "./FrameworkCard";
 import CardAdditional from "./CardAdditional";
 import { FrameworkCardType } from "../../constants/types";
+import { FRAMEWORK_STORAGE_KEY } from "../../utils/frameworks";
 import { useEffect, useState } from "react";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
@@ -16,7 +17,7 @@ export default function Frameworks({ handleFrameworkClick }: FrameworksProps) {
   function clickedFramework(framework: FrameworkCardType) {
     if (ExecutionEnvironment.canUseDOM) {
       window.history.pushState({}, "", `?framework=${framework.framework}`);
-      localStorage.setItem("framework", framework.framework);
+      localStorage.setItem(FRAMEWORK_STORAGE_KEY, framework.framework);
     }
     setSelectedFramework(framework.framework);
     framework.framework !== "xamarin" &&
@@ -31,13 +32,13 @@ export default function Frameworks({ handleFrameworkClick }: FrameworksProps) {
           new URLSearchParams(location.search)
         );
         const frameworkFromURL =
-          paramsURL.framework || localStorage.getItem("framework") || "web";
+          paramsURL.framework || localStorage.getItem(FRAMEWORK_STORAGE_KEY) || "web";
         window.history.pushState(
           {},
           "",
           `?framework=${
             new URLSearchParams(location.search).get("framework") ||
-            localStorage.getItem("framework") ||
+            localStorage.getItem(FRAMEWORK_STORAGE_KEY) ||
             "web"
           }`
         );

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -3,7 +3,7 @@ import { useLocation } from '@docusaurus/router';
 
 import skillsData from '@site/src/data/skills.json';
 import productsData from '@site/src/data/products.json';
-import { parseSdksRoute, frameworkToSlug } from '../utils/frameworks';
+import { parseSdksRoute, frameworkToSlug, FRAMEWORK_STORAGE_KEY } from '../utils/frameworks';
 import { capturePostHogEvent } from './analytics';
 import InstallTabs from './InstallTabs';
 import styles from './styles.module.css';
@@ -111,7 +111,7 @@ function resolveLiveBannerMoreInfoUrl(): string {
   const fromQuery = new URLSearchParams(window.location.search).get('framework');
   const fromStorage = (() => {
     try {
-      return window.localStorage.getItem('framework');
+      return window.localStorage.getItem(FRAMEWORK_STORAGE_KEY);
     } catch {
       return null;
     }
@@ -165,20 +165,42 @@ const CalloutDetails: React.FC<CalloutDetailsProps> = ({
 interface SharedBodyProps {
   sharedFrameworkSlug: string;
   sharedMoreInfoUrl: string;
-  onMoreInfoClick?: React.MouseEventHandler<HTMLAnchorElement>;
+  // On the homepage banner the framework is swapped via history.pushState (no
+  // router update), so the rendered href/useLocation are stale. When set, the
+  // "More info" target is resolved from the live URL: on plain left-click via
+  // the handler, and on middle/modifier/keyboard activations by refreshing the
+  // href just before the browser navigates (mousedown/focus both precede it).
+  liveBanner?: boolean;
 }
 
 const SharedBody: React.FC<SharedBodyProps> = ({
   sharedFrameworkSlug,
   sharedMoreInfoUrl,
-  onMoreInfoClick,
-}) => (
+  liveBanner = false,
+}) => {
+  const refreshHref: React.ReactEventHandler<HTMLAnchorElement> = (e) => {
+    e.currentTarget.href = resolveLiveBannerMoreInfoUrl();
+  };
+  const liveHandlers: React.HTMLAttributes<HTMLAnchorElement> = liveBanner
+    ? {
+        onClick: (e) => {
+          if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+            return;
+          }
+          e.preventDefault();
+          window.location.assign(resolveLiveBannerMoreInfoUrl());
+        },
+        onMouseDown: refreshHref,
+        onFocus: refreshHref,
+      }
+    : {};
+  return (
   <>
     <p className={styles.description}>
       Install our <code>{skillsData.shared}</code> skill so your coding
       agent can answer questions about Scandit products and recommend
       the right one for your use case, directly from your editor.{' '}
-      <a href={sharedMoreInfoUrl} onClick={onMoreInfoClick}>More info →</a>
+      <a href={sharedMoreInfoUrl} {...liveHandlers}>More info →</a>
     </p>
     <InstallTabs
       skillSlug={skillsData.shared}
@@ -186,7 +208,8 @@ const SharedBody: React.FC<SharedBodyProps> = ({
       framework={sharedFrameworkSlug}
     />
   </>
-);
+  );
+};
 
 const SkillsCallout: React.FC<SkillsCalloutProps> = ({
   product,
@@ -232,23 +255,6 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({
   if (variant === 'shared') {
     const sharedFrameworkSlug = getSharedFrameworkSlug(pathname, search);
     const sharedMoreInfoUrl = getSharedMoreInfoUrl(pathname, search);
-    // On the homepage banner, the framework is changed via history.pushState
-    // (no router update), so recompute the target from the live URL on click.
-    const onMoreInfoClick: React.MouseEventHandler<HTMLAnchorElement> | undefined = banner
-      ? (e) => {
-          if (
-            e.button !== 0 ||
-            e.metaKey ||
-            e.ctrlKey ||
-            e.shiftKey ||
-            e.altKey
-          ) {
-            return;
-          }
-          e.preventDefault();
-          window.location.assign(resolveLiveBannerMoreInfoUrl());
-        }
-      : undefined;
     return (
       <CalloutDetails
         heading={PRODUCT_DISAMBIGUATION_HEADING}
@@ -262,7 +268,7 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({
         <SharedBody
           sharedFrameworkSlug={sharedFrameworkSlug}
           sharedMoreInfoUrl={sharedMoreInfoUrl}
-          onMoreInfoClick={onMoreInfoClick}
+          liveBanner={banner}
         />
       </CalloutDetails>
     );

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -3,7 +3,7 @@ import { useLocation } from '@docusaurus/router';
 
 import skillsData from '@site/src/data/skills.json';
 import productsData from '@site/src/data/products.json';
-import { parseSdksRoute } from '../utils/frameworks';
+import { parseSdksRoute, frameworkToSlug } from '../utils/frameworks';
 import { capturePostHogEvent } from './analytics';
 import InstallTabs from './InstallTabs';
 import styles from './styles.module.css';
@@ -14,8 +14,15 @@ const PRODUCT_DISAMBIGUATION_HEADING =
 interface SkillsCalloutProps {
   product?: string;
   framework?: string;
-  variant?: 'product' | 'shared';
+  variant?: 'product' | 'shared' | 'skill';
   banner?: boolean;
+  // `skill` variant: render an install box for one explicit skill, bypassing
+  // the products/route lookup. Used for docs that live outside /sdks/ (e.g.
+  // the hosted ID Bolt section).
+  skillSlug?: string;
+  productName?: string;
+  frameworkSlug?: string;
+  moreInfoUrl?: string;
 }
 
 interface ProductEntry {
@@ -61,15 +68,56 @@ const QUERY_FRAMEWORK_TO_PATH: Record<string, string> = {
   'net-android': 'net/android',
 };
 
-function getSharedFrameworkSlug(search: string): string {
-  const params = new URLSearchParams(search);
-  const fw = params.get('framework') || '';
-  return QUERY_FRAMEWORK_TO_PATH[fw] ? fw : 'ios';
+// The homepage framework selector uses its own identifiers (see
+// frameworkCardsArr) that differ from the QUERY_FRAMEWORK_TO_PATH keys. Map
+// them so ?framework=react / netIos / netAndroid resolve correctly.
+const HOMEPAGE_FRAMEWORK_ALIASES: Record<string, string> = {
+  react: 'react-native',
+  netios: 'net-ios',
+  netandroid: 'net-android',
+};
+
+// Normalizes a raw ?framework= value to a QUERY_FRAMEWORK_TO_PATH key, or ''
+// when it maps to no agent-skills page.
+function normalizeFrameworkQuery(raw: string): string {
+  const lower = (raw || '').toLowerCase();
+  const aliased = HOMEPAGE_FRAMEWORK_ALIASES[lower] || lower;
+  return QUERY_FRAMEWORK_TO_PATH[aliased] ? aliased : '';
 }
 
-function getSharedMoreInfoUrl(search: string): string {
-  const path = QUERY_FRAMEWORK_TO_PATH[getSharedFrameworkSlug(search)];
+// Resolves the framework for the shared callout, preferring the framework in
+// the current path (so "More info" keeps the reader on the framework they are
+// already browsing), then the ?framework= query used by the homepage banner,
+// then iOS as a last resort.
+function getSharedFrameworkSlug(pathname: string, search: string): string {
+  const routeSlug = frameworkToSlug(parseSdksRoute(pathname).framework);
+  if (routeSlug && QUERY_FRAMEWORK_TO_PATH[routeSlug]) return routeSlug;
+
+  const params = new URLSearchParams(search);
+  return normalizeFrameworkQuery(params.get('framework') || '') || 'ios';
+}
+
+function getSharedMoreInfoUrl(pathname: string, search: string): string {
+  const path = QUERY_FRAMEWORK_TO_PATH[getSharedFrameworkSlug(pathname, search)];
   return `/sdks/${path}/agent-skills`;
+}
+
+// The homepage swaps frameworks with history.pushState, which does NOT update
+// React Router — so useLocation() (and any href derived from it) goes stale.
+// For the banner we therefore resolve the selected framework from the live URL
+// and localStorage at click time instead of trusting the rendered value.
+function resolveLiveBannerMoreInfoUrl(): string {
+  if (typeof window === 'undefined') return '/sdks/ios/agent-skills';
+  const fromQuery = new URLSearchParams(window.location.search).get('framework');
+  const fromStorage = (() => {
+    try {
+      return window.localStorage.getItem('framework');
+    } catch {
+      return null;
+    }
+  })();
+  const slug = normalizeFrameworkQuery(fromQuery || fromStorage || '') || 'ios';
+  return `/sdks/${QUERY_FRAMEWORK_TO_PATH[slug]}/agent-skills`;
 }
 
 interface CalloutDetailsProps {
@@ -117,18 +165,20 @@ const CalloutDetails: React.FC<CalloutDetailsProps> = ({
 interface SharedBodyProps {
   sharedFrameworkSlug: string;
   sharedMoreInfoUrl: string;
+  onMoreInfoClick?: React.MouseEventHandler<HTMLAnchorElement>;
 }
 
 const SharedBody: React.FC<SharedBodyProps> = ({
   sharedFrameworkSlug,
   sharedMoreInfoUrl,
+  onMoreInfoClick,
 }) => (
   <>
     <p className={styles.description}>
       Install our <code>{skillsData.shared}</code> skill so your coding
       agent can answer questions about Scandit products and recommend
       the right one for your use case, directly from your editor.{' '}
-      <a href={sharedMoreInfoUrl}>More info →</a>
+      <a href={sharedMoreInfoUrl} onClick={onMoreInfoClick}>More info →</a>
     </p>
     <InstallTabs
       skillSlug={skillsData.shared}
@@ -138,12 +188,67 @@ const SharedBody: React.FC<SharedBodyProps> = ({
   </>
 );
 
-const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, variant = 'product', banner = false }) => {
+const SkillsCallout: React.FC<SkillsCalloutProps> = ({
+  product,
+  framework,
+  variant = 'product',
+  banner = false,
+  skillSlug,
+  productName: productNameProp,
+  frameworkSlug: frameworkSlugProp,
+  moreInfoUrl: moreInfoUrlProp,
+}) => {
   const { pathname, search } = useLocation();
 
+  if (variant === 'skill') {
+    if (!skillSlug) return null;
+    const name = productNameProp || skillSlug;
+    return (
+      <CalloutDetails
+        heading={`Speed up ${name} integration with Agent Skills`}
+        banner={banner}
+        trackingProps={{
+          variant: 'skill',
+          pathname,
+          product: skillSlug,
+          framework: frameworkSlugProp,
+        }}
+      >
+        <p className={styles.description}>
+          Install the official skill to help your coding agent (Claude Code,
+          Codex, Cursor, etc.) integrate, debug, and customize{' '}
+          <strong>{name}</strong> following Scandit's recommended patterns.{' '}
+          {moreInfoUrlProp && <a href={moreInfoUrlProp}>More info →</a>}
+        </p>
+        <InstallTabs
+          skillSlug={skillSlug}
+          product={skillSlug}
+          framework={frameworkSlugProp}
+        />
+      </CalloutDetails>
+    );
+  }
+
   if (variant === 'shared') {
-    const sharedFrameworkSlug = getSharedFrameworkSlug(search);
-    const sharedMoreInfoUrl = getSharedMoreInfoUrl(search);
+    const sharedFrameworkSlug = getSharedFrameworkSlug(pathname, search);
+    const sharedMoreInfoUrl = getSharedMoreInfoUrl(pathname, search);
+    // On the homepage banner, the framework is changed via history.pushState
+    // (no router update), so recompute the target from the live URL on click.
+    const onMoreInfoClick: React.MouseEventHandler<HTMLAnchorElement> | undefined = banner
+      ? (e) => {
+          if (
+            e.button !== 0 ||
+            e.metaKey ||
+            e.ctrlKey ||
+            e.shiftKey ||
+            e.altKey
+          ) {
+            return;
+          }
+          e.preventDefault();
+          window.location.assign(resolveLiveBannerMoreInfoUrl());
+        }
+      : undefined;
     return (
       <CalloutDetails
         heading={PRODUCT_DISAMBIGUATION_HEADING}
@@ -157,6 +262,7 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({ product, framework, varia
         <SharedBody
           sharedFrameworkSlug={sharedFrameworkSlug}
           sharedMoreInfoUrl={sharedMoreInfoUrl}
+          onMoreInfoClick={onMoreInfoClick}
         />
       </CalloutDetails>
     );

--- a/src/components/SkillsPage/index.tsx
+++ b/src/components/SkillsPage/index.tsx
@@ -25,6 +25,10 @@ interface FrameworkSkillEntry {
   slug: string;
   product: string;
   label?: string;
+  /** Explicit "Covers" copy; overrides the per-product default description. */
+  description?: string;
+  /** Explicit docs URL; overrides the product's per-framework apiUrl. */
+  url?: string;
 }
 
 const REPO_URL = 'https://github.com/scandit/skills';
@@ -35,7 +39,9 @@ const SKILL_DESCRIPTIONS: Record<string, string> = {
   'matrixscan-ar': 'MatrixScan AR (Barcode AR) integration & migration.',
   'matrixscan-batch': 'MatrixScan Batch (BarcodeBatch) integration & migration.',
   'matrixscan-count': 'MatrixScan Count (BarcodeCount) integration & migration.',
+  'matrixscan-pick': 'MatrixScan Pick (BarcodePick) integration & migration.',
   'smart-label-capture': 'Smart Label Capture integration & migration.',
+  'id-capture': 'ID Capture (passport, driver’s license & ID document scanning) integration & migration.',
 };
 
 const SkillsPage: React.FC<SkillsPageProps> = ({ framework }) => {
@@ -115,12 +121,17 @@ const SkillsPage: React.FC<SkillsPageProps> = ({ framework }) => {
             </tr>
             {fwSkills.map((s) => {
               const product = productsByKey[s.product];
-              const apiUrl = product?.frameworks?.[framework]?.apiUrl;
+              const apiUrl = s.url || product?.frameworks?.[framework]?.apiUrl;
               const label = s.label || product?.name || s.product;
-              const baseDescription = SKILL_DESCRIPTIONS[s.product] || `${product?.name || s.product} integration & migration.`;
-              const description = s.label
-                ? `${baseDescription.replace(/\.$/, '')} — ${s.label.split('—')[1]?.trim() || s.label}.`
-                : baseDescription;
+              let description: string;
+              if (s.description) {
+                description = s.description;
+              } else {
+                const baseDescription = SKILL_DESCRIPTIONS[s.product] || `${product?.name || s.product} integration & migration.`;
+                description = s.label
+                  ? `${baseDescription.replace(/\.$/, '')} — ${s.label.split('—')[1]?.trim() || s.label}.`
+                  : baseDescription;
+              }
               return (
                 <tr key={s.slug}>
                   <td>

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -1,3 +1,8 @@
+// localStorage key the homepage framework selector writes and the shared
+// Agent Skills banner reads back. Both sides must use this constant so the
+// contract can't drift (a rename would otherwise silently fall back to iOS).
+export const FRAMEWORK_STORAGE_KEY = 'framework';
+
 export const FRAMEWORK_MAPPING: { [urlSlug: string]: string } = {
   'ios': 'iOS',
   'android': 'Android',

--- a/src/data/skills.json
+++ b/src/data/skills.json
@@ -9,9 +9,12 @@
       "Cordova": "sparkscan-cordova",
       "Capacitor": "sparkscan-capacitor",
       "Flutter": "sparkscan-flutter",
-      "React Native": "sparkscan-rn"
+      "React Native": "sparkscan-rn",
+      ".NET iOS": "sparkscan-net-ios",
+      ".NET Android": "sparkscan-net-android"
     },
     "barcode-capture": {
+      "iOS": "barcode-capture-ios",
       "Android": "barcode-capture-android",
       "Web": "barcode-capture-web",
       "Cordova": "barcode-capture-cordova",
@@ -28,7 +31,9 @@
       "Cordova": "label-capture-cordova",
       "Capacitor": "label-capture-capacitor",
       "Flutter": "label-capture-flutter",
-      "React Native": "label-capture-rn"
+      "React Native": "label-capture-rn",
+      ".NET iOS": "label-capture-net-ios",
+      ".NET Android": "label-capture-net-android"
     },
     "matrixscan-ar": {
       "iOS": "matrixscan-ar-ios",
@@ -37,7 +42,9 @@
       "Cordova": "matrixscan-ar-cordova",
       "Capacitor": "matrixscan-ar-capacitor",
       "Flutter": "matrixscan-ar-flutter",
-      "React Native": "matrixscan-ar-rn"
+      "React Native": "matrixscan-ar-rn",
+      ".NET iOS": "matrixscan-ar-net-ios",
+      ".NET Android": "matrixscan-ar-net-android"
     },
     "matrixscan-batch": {
       "iOS": "matrixscan-batch-ios",
@@ -46,37 +53,65 @@
       "Cordova": "matrixscan-batch-cordova",
       "Capacitor": "matrixscan-batch-capacitor",
       "Flutter": "matrixscan-batch-flutter",
-      "React Native": "matrixscan-batch-rn"
+      "React Native": "matrixscan-batch-rn",
+      ".NET iOS": "matrixscan-batch-net-ios",
+      ".NET Android": "matrixscan-batch-net-android"
     },
     "matrixscan-count": {
+      "iOS": "matrixscan-count-ios",
+      "Android": "matrixscan-count-android",
       "Cordova": "matrixscan-count-cordova",
       "Capacitor": "matrixscan-count-capacitor",
       "Flutter": "matrixscan-count-flutter",
-      "React Native": "matrixscan-count-rn"
+      "React Native": "matrixscan-count-rn",
+      ".NET iOS": "matrixscan-count-net-ios",
+      ".NET Android": "matrixscan-count-net-android"
+    },
+    "matrixscan-pick": {
+      "iOS": "matrixscan-pick-ios"
+    },
+    "id-capture": {
+      "iOS": "id-capture-ios",
+      "Android": "id-capture-android",
+      "Web": "id-capture-web",
+      "Cordova": "id-capture-cordova",
+      "Capacitor": "id-capture-capacitor",
+      "Flutter": "id-capture-flutter",
+      "React Native": "id-capture-rn",
+      ".NET iOS": "id-capture-net-ios",
+      ".NET Android": "id-capture-net-android"
     }
   },
   "frameworks": {
     "iOS": [
       { "slug": "sparkscan-ios", "product": "sparkscan" },
+      { "slug": "barcode-capture-ios", "product": "barcode-capture" },
       { "slug": "matrixscan-batch-ios", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-ios", "product": "matrixscan-ar" },
       { "slug": "matrixscan-ar-annotation-ios", "product": "matrixscan-ar", "label": "MatrixScan AR — Annotation overlay" },
       { "slug": "matrixscan-ar-highlight-ios", "product": "matrixscan-ar", "label": "MatrixScan AR — Highlight overlay" },
-      { "slug": "label-capture-ios", "product": "smart-label-capture" }
+      { "slug": "matrixscan-count-ios", "product": "matrixscan-count" },
+      { "slug": "matrixscan-pick-ios", "product": "matrixscan-pick" },
+      { "slug": "label-capture-ios", "product": "smart-label-capture" },
+      { "slug": "id-capture-ios", "product": "id-capture" }
     ],
     "Android": [
       { "slug": "sparkscan-android", "product": "sparkscan" },
       { "slug": "barcode-capture-android", "product": "barcode-capture" },
       { "slug": "matrixscan-batch-android", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-android", "product": "matrixscan-ar" },
-      { "slug": "label-capture-android", "product": "smart-label-capture" }
+      { "slug": "matrixscan-count-android", "product": "matrixscan-count" },
+      { "slug": "label-capture-android", "product": "smart-label-capture" },
+      { "slug": "id-capture-android", "product": "id-capture" }
     ],
     "Web": [
       { "slug": "sparkscan-web", "product": "sparkscan" },
       { "slug": "barcode-capture-web", "product": "barcode-capture" },
       { "slug": "matrixscan-batch-web", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-web", "product": "matrixscan-ar" },
-      { "slug": "label-capture-web", "product": "smart-label-capture" }
+      { "slug": "label-capture-web", "product": "smart-label-capture" },
+      { "slug": "id-capture-web", "product": "id-capture" },
+      { "slug": "id-bolt", "product": "id-capture", "label": "ID Bolt", "description": "ID Bolt — hosted, drop-in web ID scanning that runs in a Scandit-hosted pop-up (no camera UI to build).", "url": "/hosted/id-bolt/getting-started" }
     ],
     "Cordova": [
       { "slug": "sparkscan-cordova", "product": "sparkscan" },
@@ -84,7 +119,8 @@
       { "slug": "matrixscan-batch-cordova", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-cordova", "product": "matrixscan-ar" },
       { "slug": "matrixscan-count-cordova", "product": "matrixscan-count" },
-      { "slug": "label-capture-cordova", "product": "smart-label-capture" }
+      { "slug": "label-capture-cordova", "product": "smart-label-capture" },
+      { "slug": "id-capture-cordova", "product": "id-capture" }
     ],
     "Capacitor": [
       { "slug": "sparkscan-capacitor", "product": "sparkscan" },
@@ -92,7 +128,8 @@
       { "slug": "matrixscan-batch-capacitor", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-capacitor", "product": "matrixscan-ar" },
       { "slug": "matrixscan-count-capacitor", "product": "matrixscan-count" },
-      { "slug": "label-capture-capacitor", "product": "smart-label-capture" }
+      { "slug": "label-capture-capacitor", "product": "smart-label-capture" },
+      { "slug": "id-capture-capacitor", "product": "id-capture" }
     ],
     "Flutter": [
       { "slug": "sparkscan-flutter", "product": "sparkscan" },
@@ -100,7 +137,8 @@
       { "slug": "matrixscan-batch-flutter", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-flutter", "product": "matrixscan-ar" },
       { "slug": "matrixscan-count-flutter", "product": "matrixscan-count" },
-      { "slug": "label-capture-flutter", "product": "smart-label-capture" }
+      { "slug": "label-capture-flutter", "product": "smart-label-capture" },
+      { "slug": "id-capture-flutter", "product": "id-capture" }
     ],
     "React Native": [
       { "slug": "sparkscan-rn", "product": "sparkscan" },
@@ -108,15 +146,40 @@
       { "slug": "matrixscan-batch-rn", "product": "matrixscan-batch" },
       { "slug": "matrixscan-ar-rn", "product": "matrixscan-ar" },
       { "slug": "matrixscan-count-rn", "product": "matrixscan-count" },
-      { "slug": "label-capture-rn", "product": "smart-label-capture" }
+      { "slug": "label-capture-rn", "product": "smart-label-capture" },
+      { "slug": "id-capture-rn", "product": "id-capture" }
     ],
     ".NET iOS": [
+      { "slug": "sparkscan-net-ios", "product": "sparkscan" },
       { "slug": "barcode-capture-net-ios", "product": "barcode-capture" },
-      { "slug": "barcode-capture-maui", "product": "barcode-capture", "label": "Barcode Capture for .NET MAUI (cross-platform iOS + Android)" }
+      { "slug": "matrixscan-batch-net-ios", "product": "matrixscan-batch" },
+      { "slug": "matrixscan-ar-net-ios", "product": "matrixscan-ar" },
+      { "slug": "matrixscan-count-net-ios", "product": "matrixscan-count" },
+      { "slug": "label-capture-net-ios", "product": "smart-label-capture" },
+      { "slug": "id-capture-net-ios", "product": "id-capture" },
+      { "slug": "sparkscan-maui", "product": "sparkscan", "label": "SparkScan for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "barcode-capture-maui", "product": "barcode-capture", "label": "Barcode Capture for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "matrixscan-batch-maui", "product": "matrixscan-batch", "label": "MatrixScan Batch for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "matrixscan-ar-maui", "product": "matrixscan-ar", "label": "MatrixScan AR for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "matrixscan-count-maui", "product": "matrixscan-count", "label": "MatrixScan Count for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "label-capture-net-maui", "product": "smart-label-capture", "label": "Smart Label Capture for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "id-capture-net-maui", "product": "id-capture", "label": "ID Capture for .NET MAUI (cross-platform iOS + Android)" }
     ],
     ".NET Android": [
+      { "slug": "sparkscan-net-android", "product": "sparkscan" },
       { "slug": "barcode-capture-net-android", "product": "barcode-capture" },
-      { "slug": "barcode-capture-maui", "product": "barcode-capture", "label": "Barcode Capture for .NET MAUI (cross-platform iOS + Android)" }
+      { "slug": "matrixscan-batch-net-android", "product": "matrixscan-batch" },
+      { "slug": "matrixscan-ar-net-android", "product": "matrixscan-ar" },
+      { "slug": "matrixscan-count-net-android", "product": "matrixscan-count" },
+      { "slug": "label-capture-net-android", "product": "smart-label-capture" },
+      { "slug": "id-capture-net-android", "product": "id-capture" },
+      { "slug": "sparkscan-maui", "product": "sparkscan", "label": "SparkScan for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "barcode-capture-maui", "product": "barcode-capture", "label": "Barcode Capture for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "matrixscan-batch-maui", "product": "matrixscan-batch", "label": "MatrixScan Batch for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "matrixscan-ar-maui", "product": "matrixscan-ar", "label": "MatrixScan AR for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "matrixscan-count-maui", "product": "matrixscan-count", "label": "MatrixScan Count for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "label-capture-net-maui", "product": "smart-label-capture", "label": "Smart Label Capture for .NET MAUI (cross-platform iOS + Android)" },
+      { "slug": "id-capture-net-maui", "product": "id-capture", "label": "ID Capture for .NET MAUI (cross-platform iOS + Android)" }
     ]
   }
 }

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -13,13 +13,36 @@ type Props = WrapperProps<typeof ContentType>;
 
 const KNOWN_PRODUCTS = new Set(Object.keys(skillsData.products));
 
+// Frameworks with no Agent Skills at all — never show the callout there.
+const SKILL_LESS_FRAMEWORK_PREFIXES = ['/sdks/titanium/', '/sdks/linux/'];
+
 export default function ContentWrapper(props: Props): JSX.Element {
   const { pathname } = useLocation();
   const route = parseSdksRoute(pathname);
   const isKnownProductPage = !!route.product && KNOWN_PRODUCTS.has(route.product);
+  const isSkillLessFramework = SKILL_LESS_FRAMEWORK_PREFIXES.some((prefix) =>
+    pathname.startsWith(prefix),
+  );
+
+  // ID Bolt docs live under /hosted/, outside the /sdks/ product routes, so
+  // the route-driven callout never fires there. Surface its skill explicitly.
+  const isIdBoltPage =
+    pathname.startsWith('/hosted/id-bolt/') && !isOnFallbackDenylist(pathname);
 
   let callout: JSX.Element | null;
-  if (isKnownProductPage) {
+  if (isSkillLessFramework) {
+    callout = null;
+  } else if (isIdBoltPage) {
+    callout = (
+      <SkillsCallout
+        variant="skill"
+        skillSlug="id-bolt"
+        productName="ID Bolt"
+        frameworkSlug="web"
+        moreInfoUrl="/sdks/web/agent-skills"
+      />
+    );
+  } else if (isKnownProductPage) {
     callout = <SkillsCallout variant="product" />;
   } else if (isOnFallbackDenylist(pathname)) {
     callout = null;


### PR DESCRIPTION
## Summary

Addresses three issues with the Agent Skills callout/badge and fills a gap in the tracked skills catalog.

### 1. "More info" now keeps the framework
The callout's **More info →** link used to jump to iOS instead of staying on the framework the reader was on.

- **Shared callout (in-page):** now derives the framework from the current page path.
- **Homepage banner:** the homepage switches frameworks via `history.pushState`, which React Router never observes — so `useLocation()` stayed stale and the link kept its initial (iOS) value even for `?framework=web`. The banner now resolves the target **at click time** from the live URL / `localStorage`. Also added an alias map for the homepage's own identifiers (`react` → `react-native`, `netIos` → `net-ios`, `netAndroid` → `net-android`), which otherwise fell back to iOS.

### 2. Hide the badge on Titanium & Linux
No skills exist for those platforms, so the callout no longer renders under `/sdks/titanium/` or `/sdks/linux/`.

### 3. Track the ID scanning skills (and reconcile the whole catalog)
`skills.json` was significantly out of date vs. [`scandit/skills`](https://github.com/scandit/skills). Reconciled it so **every** published skill is tracked (verified bidirectionally — no missing, no dangling slugs):

- **ID Capture** across all 9 frameworks + the `.NET MAUI` variant.
- **ID Bolt** listed on the Web Agent Skills page, plus a **dedicated skill callout on the hosted ID Bolt docs** (`/hosted/id-bolt/*`), which live outside the `/sdks/` product routes and previously showed only the generic product-picker callout.
- Previously-missing entries now added: `barcode-capture-ios`, `matrixscan-pick`, the missing `.NET iOS/Android` skills for sparkscan/matrixscan-*/label-capture, and the full MAUI block.

## Files changed
- `src/data/skills.json` — full catalog reconciliation
- `src/components/SkillsCallout/index.tsx` — framework-keeping "More info" + new `skill` variant
- `src/components/SkillsPage/index.tsx` — id-capture/matrixscan-pick descriptions + `url`/`description` field support (for ID Bolt)
- `src/theme/DocItem/Content/index.tsx` — hide on titanium/linux + ID Bolt hosted-docs callout

## Testing
- `docusaurus build` passes.
- Verified in built HTML: ID Bolt callout renders on `/hosted/id-bolt/getting-started` (and is correctly absent on `release-notes`).
- Unit-tested the framework→URL resolution across all homepage identifiers (`web`, `react`, `netIos`, `netAndroid`, unknowns → iOS fallback).
- Confirmed the homepage `?framework=web` "More info" fix live in the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)