### PR TITLE
[SDC-32793] Clarify Web SDK 8.4.1 SIMD mitigation scope and add detec…

### DIFF
--- a/docs/sdks/web/release-notes.md
+++ b/docs/sdks/web/release-notes.md
@@ -117,7 +117,17 @@ SDK 8.5.0 has a known issue that causes ID Capture to silently fail to scan any 
 
 #### Core
 
-* Fixed WebKit 26.x bugs causing pthreads WASM crashes (WebKit bug #303387) and SIMD corruption in barcode/ID scanning (Apple Radar 176035764) by pinning memory and disabling SIMD on affected versions.
+* Fixed WebKit 26.x bugs causing pthreads WASM crashes (WebKit bug #303387) and SIMD corruption on affected versions (Apple Radar 176035764) by pinning memory and disabling SIMD engine-wide. This slows compute-heavy scanning on those versions, most noticeably Label Capture OCR.
+
+To detect affected devices and warn your users, you can check `BrowserHelper.isSIMDBroken()`:
+
+```ts
+import { BrowserHelper } from "@scandit/web-datacapture-core";
+
+if (BrowserHelper.isSIMDBroken()) {
+  // warn the user about slower scanning, or prompt them to update to iOS 27
+}
+```
 
 ## 8.4.0
 


### PR DESCRIPTION
## Summary

Corrects the Web SDK 8.4.1 release note for the WebKit 26 SIMD mitigation. The note said the SIMD-corruption fix applied to "barcode/ID scanning", which implied Label Capture was unaffected. In fact SIMD is disabled **engine-wide** on affected WebKit, so Label Capture OCR is slower on those versions too.

## Changes
- Reword the 8.4.1 Core entry: SIMD is disabled engine-wide, and note the perf impact on compute-heavy scanning (most visibly Label Capture OCR).
- Add a short snippet showing how to detect affected devices via `BrowserHelper.isSIMDBroken()` and warn users.

## Notes
- Docs-only, single file, current release notes (8.x) only — no backport needed (no 8.x versioned snapshot; the note was added in the 8.4.1 release commit).