### PR TITLE
Route search by framework and version named in the query

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -96,12 +96,78 @@ const llmsIgnoreFiles: string[] = [
   ),
 ];
 
+// Single source of truth for docs versions (consumed by the preset below and by
+// the search widget's version-routing map). `current` is the live version; its
+// major comes from `label`. Frozen versions are keyed by their version string.
+const docsVersions: Record<
+  string,
+  { label?: string; banner: "none"; badge: boolean }
+> = {
+  current: {
+    label: "8.5.0",
+    banner: "none",
+    badge: false,
+  },
+  "7.6.14": {
+    banner: "none",
+    badge: false,
+  },
+  "6.28.11": {
+    banner: "none",
+    badge: false,
+  },
+};
+
+// Derive the search widget's "major version typed in a query -> docusaurus_tag"
+// map from docsVersions so it can never drift from the actual versions. The
+// crawler stamps docusaurus_tag as `docs-default-<versionName>` (current ->
+// docs-default-current). Newest patch wins per major, and `current` always
+// wins its own major. Exposed via customFields and read in SearchBar.
+function buildVersionTagByMajor(
+  versions: Record<string, { label?: string }>,
+): Record<string, string> {
+  const comparePatch = (a: string, b: string): number => {
+    const pa = a.split(".").map(Number);
+    const pb = b.split(".").map(Number);
+    for (let i = 0; i < 3; i += 1) {
+      if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+    }
+    return 0;
+  };
+  const best: Record<string, { label: string; isCurrent: boolean }> = {};
+  const out: Record<string, string> = {};
+  for (const [name, cfg] of Object.entries(versions)) {
+    const isCurrent = name === "current";
+    const label = isCurrent ? cfg.label || "" : name;
+    const major = label.split(".")[0];
+    if (!major) continue;
+    const cur = best[major];
+    if (
+      !cur ||
+      isCurrent ||
+      (!cur.isCurrent && comparePatch(label, cur.label) > 0)
+    ) {
+      best[major] = { label, isCurrent };
+      out[major] = `docs-default-${name}`;
+    }
+  }
+  return out;
+}
+
+const versionTagByMajor = buildVersionTagByMajor(docsVersions);
+
 const config: Config = {
   title: "Scandit Developer Documentation",
   tagline:
     "Developer Guides, API References, and Code Samples for building with Scandit Smart Data Capture",
   favicon: "img/sdk_icon.png",
   trailingSlash: true,
+
+  // Derived from docsVersions; read by the search widget (SearchBar) to route a
+  // version typed in a query to the right docusaurus_tag without a hardcoded map.
+  customFields: {
+    versionTagByMajor,
+  },
 
   // Set the production url of your site here
   url: "https://docs.scandit.com",
@@ -368,21 +434,7 @@ const config: Config = {
           showLastUpdateTime: false,
           includeCurrentVersion: true,
           lastVersion: "current",
-          versions: {
-            current: {
-              label: '8.5.0',
-              banner: 'none',
-              badge: false,
-            },
-            '7.6.14': {
-              banner: 'none',
-              badge: false,
-            },
-            '6.28.11': {
-              banner: 'none',
-              badge: false,
-            },
-          },
+          versions: docsVersions,
         },
         blog: false,
         googleTagManager: {

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -12,6 +12,11 @@ Usage: python scripts/update-version.py <new-version>
 Example: python scripts/update-version.py 8.1.1   # patch current
 Example: python scripts/update-version.py 7.6.7   # patch versioned
 Example: python scripts/update-version.py 8.2.0   # minor beta (from production) or minor production (from beta)
+
+Note: the docs search widget derives its version-routing map from the same
+`docsVersions` / `current.label` in docusaurus.config.ts that this script edits
+(see buildVersionTagByMajor + customFields.versionTagByMajor). Version bumps
+therefore flow into search automatically - no separate update is needed here.
 """
 
 import json

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -83,19 +83,16 @@ function frameworksInQuery(query) {
   return found;
 }
 // Major version typed in the query -> the newest docusaurus_tag on that line.
-// Update when a major version's newest patch changes or a new line ships.
-const VERSION_TAG_BY_MAJOR = {
-  "6": "docs-default-6.28.11",
-  "7": "docs-default-7.6.14",
-  "8": "docs-default-current",
-};
-function versionTagInQuery(query) {
+// The map is derived from docsVersions in docusaurus.config.ts and passed in via
+// customFields (versionTagByMajor), so it can never drift from the real versions.
+const EMPTY_VERSION_MAP = {};
+function versionTagInQuery(query, versionTagByMajor) {
   const q = (query || "").toLowerCase();
   // "version 6" / "ver 6" / "v6" / "sdk 6", or a dotted form like "6.28" / "6.x".
   const m =
     q.match(/\b(?:version|ver|v|sdk)\s*\.?\s*(\d+)\b/) ||
     q.match(/\b(\d+)\.(?:x|\d+)\b/);
-  return m ? VERSION_TAG_BY_MAJOR[m[1]] || null : null;
+  return m ? versionTagByMajor[m[1]] || null : null;
 }
 function rewriteVersionTag(facetFilters, targetTag) {
   const swap = (f) => {
@@ -165,7 +162,10 @@ function mergeFacetFilters(f1, f2) {
   return [...normalize(f1), ...normalize(f2)];
 }
 function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
-  const { siteMetadata } = useDocusaurusContext();
+  const { siteMetadata, siteConfig } = useDocusaurusContext();
+  // Version-routing map derived at build time from docsVersions (see config).
+  const versionTagByMajor =
+    siteConfig.customFields?.versionTagByMajor || EMPTY_VERSION_MAP;
   const processSearchResultUrl = useSearchResultUrlProcessor();
   const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
   const configFacetFilters = props.searchParameters?.facetFilters ?? [];
@@ -385,7 +385,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
         latestQueryRef.current = query || "";
         // A version typed in the query overrides the page's version: swap the
         // contextual docusaurus_tag filter to the newest tag for that major.
-        const targetTag = versionTagInQuery(query);
+        const targetTag = versionTagInQuery(query, versionTagByMajor);
         const effectiveRequests =
           targetTag && Array.isArray(requests)
             ? requests.map((r) => {
@@ -414,7 +414,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
       };
       return searchClient;
     },
-    [siteMetadata.docusaurusVersion, captureSearchDebounced]
+    [siteMetadata.docusaurusVersion, captureSearchDebounced, versionTagByMajor]
   );
   useDocSearchKeyboardEvents({
     isOpen,

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -69,7 +69,10 @@ const QUERY_FRAMEWORK_TOKENS = [
   { re: /\bcapacitor\b/, fw: "capacitor" },
   { re: /\bcordova\b/, fw: "cordova" },
   { re: /\btitanium\b/, fw: "titanium" },
-  { re: /\bweb\b/, fw: "web" },
+  // "web" needs stronger context ("web sdk", "on/for/in/using web"). Bare "web"
+  // is a common English word ("web view", "web socket") and would hijack
+  // routing on ordinary queries, so an accompanying cue is required.
+  { re: /\bweb\s+sdk\b|\b(?:on|for|in|using)\s+web\b/, fw: "web" },
 ];
 function frameworksInQuery(query) {
   let q = ` ${(query || "").toLowerCase()} `;
@@ -88,16 +91,20 @@ function frameworksInQuery(query) {
 const EMPTY_VERSION_MAP = {};
 function versionTagInQuery(query, versionTagByMajor) {
   const q = (query || "").toLowerCase();
-  // "version 6" / "ver 6" / "v6" / "sdk 6", or a dotted form like "6.28" / "6.x".
-  const m =
-    q.match(/\b(?:version|ver|v|sdk)\s*\.?\s*(\d+)\b/) ||
-    q.match(/\b(\d+)\.(?:x|\d+)\b/);
+  // Only an explicit version marker ("version 6", "ver 6", "v6", "sdk 6").
+  // A bare dotted number ("6.5", "7.1", "6.x") is too easily an incidental
+  // token in a normal query, so it must not silently switch the docs version.
+  const m = q.match(/\b(?:version|ver|v|sdk)\s*\.?\s*(\d+)\b/);
   return m ? versionTagByMajor[m[1]] || null : null;
 }
 function rewriteVersionTag(facetFilters, targetTag) {
   const swap = (f) => {
     if (typeof f === "string") {
-      return f.indexOf("docusaurus_tag:") === 0
+      // Swap only the versioned docs tag (docusaurus_tag:docs-*). Leave
+      // docusaurus_tag:default (framework-agnostic / non-doc pages) and any
+      // other entry untouched, so the contextual OR isn't collapsed and those
+      // pages still match when a version is typed.
+      return f.startsWith("docusaurus_tag:docs-")
         ? `docusaurus_tag:${targetTag}`
         : f;
     }
@@ -132,7 +139,12 @@ function ResultsFooter({ state, onClose, currentFramework, hasSearchPage }) {
   const hasApiResults = (state.collections || [])
     .flatMap((c) => c.items || [])
     .some((it) => (it.url || "").includes("/data-capture-sdk/"));
-  const showApiFallbackNote = !currentFramework && hasApiResults;
+  // Don't show the "web API reference" note when the user typed a framework:
+  // results are already narrowed to that framework, so the note would
+  // contradict what's shown.
+  const hasQueriedFramework = frameworksInQuery(state.query || "").length > 0;
+  const showApiFallbackNote =
+    !currentFramework && !hasQueriedFramework && hasApiResults;
   return (
     <>
       {showApiFallbackNote && (
@@ -312,17 +324,20 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
         if (apiMatch) {
           return apiFwTargets.includes(apiFrameworkToSdk(apiMatch[1]));
         }
-        if (guideSegments) {
-          return guideSegments.some((seg) => url.includes(seg));
-        }
-        if (currentFramework) {
-          return url.includes(currentFramework);
-        }
-        // Framework-less page: the most-used framework's guides only (not every
-        // framework's), plus pages tied to no framework so they stay findable.
+        // Framework-specific SDK guides (/sdks/<fw>/) are narrowed to the typed
+        // framework(s), else the page's framework, else the most-used framework
+        // (web) on a framework-less page.
         if (url.includes("/sdks/")) {
+          if (guideSegments) {
+            return guideSegments.some((seg) => url.includes(seg));
+          }
+          if (currentFramework) {
+            return url.includes(currentFramework);
+          }
           return url.includes(`/sdks/${API_FALLBACK_FRAMEWORK}/`);
         }
+        // Pages tied to no SDK (/hosted/, /id-documents/, concept pages) belong
+        // to no framework, so they stay findable from any framework context.
         return true;
       });
       return props.transformItems

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -55,6 +55,59 @@ function sdkFrameworkToApi(sdkToken) {
   const t = (sdkToken || "").toLowerCase();
   return SDK_TO_API_FRAMEWORK[t] || t;
 }
+// Frameworks a user may type in the query. An explicit framework in the query
+// overrides the page's framework (see transformItems). Two-segment .NET tokens
+// and multi-word "react native" are matched (and consumed) before the one-word
+// tokens so "net ios" isn't also counted as plain "ios".
+const QUERY_FRAMEWORK_TOKENS = [
+  { re: /\breact[\s-]?native\b/, fw: "react-native" },
+  { re: /\b(?:dot)?net[\s./]*ios\b/, fw: "net/ios" },
+  { re: /\b(?:dot)?net[\s./]*android\b/, fw: "net/android" },
+  { re: /\bios\b/, fw: "ios" },
+  { re: /\bandroid\b/, fw: "android" },
+  { re: /\bflutter\b/, fw: "flutter" },
+  { re: /\bcapacitor\b/, fw: "capacitor" },
+  { re: /\bcordova\b/, fw: "cordova" },
+  { re: /\btitanium\b/, fw: "titanium" },
+  { re: /\bweb\b/, fw: "web" },
+];
+function frameworksInQuery(query) {
+  let q = ` ${(query || "").toLowerCase()} `;
+  const found = [];
+  for (const { re, fw } of QUERY_FRAMEWORK_TOKENS) {
+    if (re.test(q)) {
+      if (!found.includes(fw)) found.push(fw);
+      q = q.replace(re, " "); // consume so a longer token isn't re-matched
+    }
+  }
+  return found;
+}
+// Major version typed in the query -> the newest docusaurus_tag on that line.
+// Update when a major version's newest patch changes or a new line ships.
+const VERSION_TAG_BY_MAJOR = {
+  "6": "docs-default-6.28.11",
+  "7": "docs-default-7.6.14",
+  "8": "docs-default-current",
+};
+function versionTagInQuery(query) {
+  const q = (query || "").toLowerCase();
+  // "version 6" / "ver 6" / "v6" / "sdk 6", or a dotted form like "6.28" / "6.x".
+  const m =
+    q.match(/\b(?:version|ver|v|sdk)\s*\.?\s*(\d+)\b/) ||
+    q.match(/\b(\d+)\.(?:x|\d+)\b/);
+  return m ? VERSION_TAG_BY_MAJOR[m[1]] || null : null;
+}
+function rewriteVersionTag(facetFilters, targetTag) {
+  const swap = (f) => {
+    if (typeof f === "string") {
+      return f.indexOf("docusaurus_tag:") === 0
+        ? `docusaurus_tag:${targetTag}`
+        : f;
+    }
+    return Array.isArray(f) ? f.map(swap) : f;
+  };
+  return swap(facetFilters);
+}
 function Hit({ hit, children }) {
   // Mouse clicks navigate through this Link directly and never reach the
   // modal's navigator (which only handles keyboard selection), so capture
@@ -118,6 +171,9 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   const configFacetFilters = props.searchParameters?.facetFilters ?? [];
   const [initialQuery, setInitialQuery] = useState(undefined);
   const [currentUrl, setCurrentUrl] = useState("");
+  // The live query text, updated on every search so transformItems (which only
+  // receives items) can route by a framework the user typed in the query.
+  const latestQueryRef = useRef("");
 
   useEffect(() => {
     const handleUrlChange = () => {
@@ -232,18 +288,42 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   const transformItems = useCallback(
     (items) => {
       // API pages live under /data-capture-sdk/<fw>/, not /sdks/<fw>/, so match
-      // them by their own framework segment (net.ios -> net/ios). On a
-      // framework-less page (home, /hosted/, concept pages) fall back to the
-      // most-used framework so API results aren't duplicated across all SDKs.
-      const fwToken = currentFramework.replace(/^\/sdks\//, "");
-      const apiFwTarget = (fwToken || API_FALLBACK_FRAMEWORK).toLowerCase();
+      // them by their own framework segment (net.ios -> net/ios).
+      //
+      // A framework typed in the query wins over the page's framework, so
+      // "barcode capture ios" from a web page returns iOS results; two typed
+      // frameworks return both. With nothing typed we keep the page framework.
+      // On a framework-less page (home, /hosted/, concept pages) we fall back to
+      // the most-used framework (web) rather than showing every framework's
+      // guide - which would spam the user - while keeping framework-agnostic
+      // pages (e.g. /hosted/, /id-documents/) that belong to no SDK.
+      const queriedFrameworks = frameworksInQuery(latestQueryRef.current);
+      const hasQueriedFramework = queriedFrameworks.length > 0;
+      const pageFwToken = currentFramework.replace(/^\/sdks\//, "");
+      const apiFwTargets = hasQueriedFramework
+        ? queriedFrameworks
+        : [(pageFwToken || API_FALLBACK_FRAMEWORK).toLowerCase()];
+      const guideSegments = hasQueriedFramework
+        ? queriedFrameworks.map((fw) => `/sdks/${fw}/`)
+        : null;
       const filteredItems = items.filter((elem) => {
         const url = elem.url || "";
         const apiMatch = url.match(/\/data-capture-sdk\/([^/]+)\//);
         if (apiMatch) {
-          return apiFrameworkToSdk(apiMatch[1]) === apiFwTarget;
+          return apiFwTargets.includes(apiFrameworkToSdk(apiMatch[1]));
         }
-        return url.includes(currentFramework);
+        if (guideSegments) {
+          return guideSegments.some((seg) => url.includes(seg));
+        }
+        if (currentFramework) {
+          return url.includes(currentFramework);
+        }
+        // Framework-less page: the most-used framework's guides only (not every
+        // framework's), plus pages tied to no framework so they stay findable.
+        if (url.includes("/sdks/")) {
+          return url.includes(`/sdks/${API_FALLBACK_FRAMEWORK}/`);
+        }
+        return true;
       });
       return props.transformItems
         ? // Custom transformItems
@@ -298,10 +378,26 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
       // every keystroke's request passes through here.
       const originalSearch = searchClient.search.bind(searchClient);
       searchClient.search = (requests) => {
-        const resultPromise = originalSearch(requests);
         const first = Array.isArray(requests) ? requests[0] : null;
         const query =
           first && ((first.params && first.params.query) || first.query);
+        // Record the query so transformItems can route by a typed framework.
+        latestQueryRef.current = query || "";
+        // A version typed in the query overrides the page's version: swap the
+        // contextual docusaurus_tag filter to the newest tag for that major.
+        const targetTag = versionTagInQuery(query);
+        const effectiveRequests =
+          targetTag && Array.isArray(requests)
+            ? requests.map((r) => {
+                const ff = r.params ? r.params.facetFilters : r.facetFilters;
+                if (!ff) return r;
+                const rewritten = rewriteVersionTag(ff, targetTag);
+                return r.params
+                  ? { ...r, params: { ...r.params, facetFilters: rewritten } }
+                  : { ...r, facetFilters: rewritten };
+              })
+            : requests;
+        const resultPromise = originalSearch(effectiveRequests);
         if (query) {
           resultPromise
             .then((response) => {


### PR DESCRIPTION
Search results are filtered to the framework/version of the page the user is on. When the user names one explicitly in the query, that should win - so "barcode capture ios" from a web page returns iOS results.

- Framework: a framework typed in the query (ios, android, flutter, web, react native, capacitor, cordova, titanium, .net ios/android) overrides the page framework; two named frameworks return both. Nothing typed keeps the page framework. On a framework-less page (home, /hosted/, concept pages) guides fall back to the most-used framework (web) rather than every framework's guide, while framework-agnostic pages (/hosted/, /id-documents/) stay findable.

- Version: a version named in the query (version 6, v6, 6.x, 6.28, sdk 6) rewrites the contextual docusaurus_tag filter to the newest tag on that major line - 6 to docs-default-6.28.11, 7 to docs-default-7.6.14, 8 to current.

The typed framework word is left in the query; removeWordsIfNoResults drops it when it does not match page text, so ranking is unaffected.