### PR TITLE
Document color inversion default for QR and Micro QR

### DIFF
--- a/docs/partials/_symbology-properties.mdx
+++ b/docs/partials/_symbology-properties.mdx
@@ -36,6 +36,8 @@ Symbologies often have different properties, such as symbol count (length of the
 
 ## 2D Symbology Properties
 
+* Color-inversion (bright modules on a dark background) decoding is **enabled by default only for QR Code and Micro QR Code**. For all other 2D symbologies that support it, it is disabled by default and must be explicitly enabled.
+
 | Symbology      | Supports Color-Inversion | Extensions   |
 |----------------|--------------------------|------------------------|
 | Aztec Code     | yes    |     |


### PR DESCRIPTION
The Symbology Properties page didn't state which symbologies have color inversion on by default. Add a note to the 2D section that inverted-color decoding is enabled by default only for QR Code and Micro QR Code; for all other 2D symbologies that support it, it stays disabled by default and must be explicitly enabled. Surfaced during FAQ review (Zendesk "How to Improve Barcode Detection Rates by Inverting Color").

Edited in the shared partial so it applies to every framework's page.