### PR TITLE
Web SDK 8.4.1 release notes: remove outdated SIMD detection snippet

### DIFF
--- a/docs/sdks/web/release-notes.md
+++ b/docs/sdks/web/release-notes.md
@@ -119,16 +119,6 @@ SDK 8.5.0 has a known issue that causes ID Capture to silently fail to scan any 
 
 * Fixed WebKit 26.x bugs causing pthreads WASM crashes (WebKit bug #303387) and SIMD corruption on affected versions (Apple Radar 176035764) by pinning memory and disabling SIMD engine-wide. This slows compute-heavy scanning on those versions, most noticeably Label Capture OCR.
 
-To detect affected devices and warn your users, you can check `BrowserHelper.isSIMDBroken()`:
-
-```ts
-import { BrowserHelper } from "@scandit/web-datacapture-core";
-
-if (BrowserHelper.isSIMDBroken()) {
-  // warn the user about slower scanning, or prompt them to update to iOS 27
-}
-```
-
 ## 8.4.0
 
 **Released**: May 18, 2026


### PR DESCRIPTION
**What:** removes the outdated `BrowserHelper.isSIMDBroken()` detection snippet from the 8.4.1 release note.

**Why:** SIMD is being restored (SDC-32854), which removes that API and resolves the slowdown the snippet worked around — so the snippet would point at a function that no longer exists. The 8.4.1 note itself stays accurate.

Split 1/3 of the SDC-32854 release-notes update. Ready to merge.
