### PR TITLE
Web SDK 8.5.1 release notes: SIMD restored (hold for release)

### DIFF
--- a/docs/sdks/web/release-notes.md
+++ b/docs/sdks/web/release-notes.md
@@ -10,6 +10,16 @@ keywords:
   - web
 ---
 
+## 8.5.1
+
+**Released**:
+
+### Performance Improvements
+
+#### Core
+
+* Re-enabled SIMD for iOS 26.
+
 ## 8.5.0
 
 **Released**: July 9, 2026


### PR DESCRIPTION
**What:** adds the SIMD-restored note under 8.5.1.

**Why:** documents that SIMD is re-enabled on iOS 26 (SDC-32854), recovering Label Capture scanning speed that 8.4.1 traded away.

**Draft — hold:** waiting for the 8.5.1 release. When it ships, fill in the release date and mark ready to merge.

Split 2/3 of the SDC-32854 release-notes update.
