### PR TITLE
Web SDK 8.4.2 release notes: SIMD restored (hold for release)

### DIFF
--- a/docs/sdks/web/release-notes.md
+++ b/docs/sdks/web/release-notes.md
@@ -99,6 +99,16 @@ SDK 8.5.0 has a known issue that causes ID Capture to silently fail to scan any 
 
 * The SparkScan target-mode APIs and `ScanIntention.smartSelection` are deprecated in favour of selectionMode.
 
+## 8.4.2
+
+**Released**:
+
+### Performance Improvements
+
+#### Core
+
+* Re-enabled SIMD for iOS 26.
+
 ## 8.4.1
 
 **Released**: June 23, 2026


### PR DESCRIPTION
**What:** adds the SIMD-restored note under 8.4.2.

**Why:** documents that SIMD is re-enabled on iOS 26 (SDC-32854).

**Draft — hold:** no 8.4.2 release date scheduled yet; when it ships, fill in the date and mark ready to merge.

Split 3/3 of the SDC-32854 release-notes update.
