### PR TITLE
Route trailing "web" in a query to the Web framework

### DIFF
--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -69,10 +69,12 @@ const QUERY_FRAMEWORK_TOKENS = [
   { re: /\bcapacitor\b/, fw: "capacitor" },
   { re: /\bcordova\b/, fw: "cordova" },
   { re: /\btitanium\b/, fw: "titanium" },
-  // "web" needs stronger context ("web sdk", "on/for/in/using web"). Bare "web"
-  // is a common English word ("web view", "web socket") and would hijack
-  // routing on ordinary queries, so an accompanying cue is required.
-  { re: /\bweb\s+sdk\b|\b(?:on|for|in|using)\s+web\b/, fw: "web" },
+  // "web" needs context: "web sdk", "on/for/in/using web", or "web" as the
+  // last word ("barcode capture web", "symbologies web"). Mid-query "web view"
+  // / "web socket" is a common English phrase and must NOT hijack routing, so
+  // bare "web" only counts with a cue or at the end of the query. (The query is
+  // space-padded in frameworksInQuery, so \s*$ matches a trailing "web".)
+  { re: /\bweb\s+sdk\b|\b(?:on|for|in|using)\s+web\b|\bweb\s*$/, fw: "web" },
 ];
 function frameworksInQuery(query) {
   let q = ` ${(query || "").toLowerCase()} `;


### PR DESCRIPTION
Follow-up to the framework/version routing: bare "web" was only treated as a framework signal with an explicit cue ("web sdk", "on/for/in/using web") to avoid "web view"/"web socket" hijacking. That left common queries like "barcode capture web" / "symbologies web" / "matrixscan web" unrouted.

Also treat "web" as a framework signal when it's the last word of the query (\bweb\s*$ against the space-padded query). "barcode capture web" now routes to Web, while mid-query "web view" / "web socket" / "webhook" still do not.