### PR TITLE
docs: rewrite frontmatter descriptions for SEO and LLM quality

### DIFF
--- a/docs/hosted/express/configuration/custom-data-transfer/input-configuration.md
+++ b/docs/hosted/express/configuration/custom-data-transfer/input-configuration.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn how to configure input data for the Custom Data Transfer feature in Scandit Express, enabling you to collect and manage data efficiently during scanning tasks."
+description: "Define the input fields Custom Data Transfer collects during scanning in Scandit Express, and set each field's type and format."
 framework: express
 sidebar_label: Input Configuration
 keywords:

--- a/docs/hosted/express/configuration/custom-data-transfer/output-configuration.md
+++ b/docs/hosted/express/configuration/custom-data-transfer/output-configuration.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn how to configure output data for the Custom Data Transfer feature in Scandit Express, enabling you to collect and manage data efficiently during scanning tasks."
+description: "Configure how Custom Data Transfer structures, transforms, and exports scanned data to external systems in Scandit Express."
 framework: express
 sidebar_label: Output Configuration
 keywords:

--- a/docs/hosted/express/configuration/custom-data-transfer/overview.md
+++ b/docs/hosted/express/configuration/custom-data-transfer/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "Custom Data Transfer in Scandit Express allows you to import and export data using configurable CSV files or Google Sheets, ensuring seamless integration with your system without the need for coding or reformatting."
+description: "Import and export data in Scandit Express using a configurable CSV file or Google Sheet, aligning formats with your system without coding."
 framework: express
 sidebar_label: Overview
 keywords:

--- a/docs/hosted/express/configuration/device-pairing/bluetooth-pairing.md
+++ b/docs/hosted/express/configuration/device-pairing/bluetooth-pairing.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to integrating and configuring Bluetooth device pairing using the Scandit Express."
+description: "Set up Bluetooth device pairing in Scandit Express to send scanned data from one device to another."
 framework: express
 keywords:
   - express

--- a/docs/hosted/express/configuration/device-pairing/device-pairing.md
+++ b/docs/hosted/express/configuration/device-pairing/device-pairing.md
@@ -1,5 +1,5 @@
 ---
-description: "Device Pairing in Scandit Express allows you to transfer scanned barcode data from one smart device (the sender) to another (the receiver) where your system application is running. This enables fast, flexible, and reliable data transfer between devices in real time—without needing to use additional hardware."
+description: "Use Device Pairing in Scandit Express to transfer scanned barcode data in real time from a sender device to the receiver running your app."
 framework: express
 sidebar_label: Overview
 keywords:

--- a/docs/hosted/express/configuration/device-pairing/online-connection.md
+++ b/docs/hosted/express/configuration/device-pairing/online-connection.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to integrating and configuring online device pairing using the Scandit Express app."
+description: "Set up online device pairing in Scandit Express to send scanned data to a web application."
 framework: express
 keywords:
   - express

--- a/docs/hosted/express/configuration/express-find.md
+++ b/docs/hosted/express/configuration/express-find.md
@@ -1,5 +1,5 @@
 ---
-description: "Powered by , a feature available in the Scandit Smart Data Capture SDK, this mode enables you to speed up finding and picking workflows by scanning multiple items at once and highlighting the correct item(s) in real-time using an AR overlay.                                                           "
+description: "Find Items in Scandit Express, powered by MatrixScan Find, speeds up picking by scanning many items and highlighting the right ones in AR."
 
 framework: express
 keywords:

--- a/docs/hosted/express/configuration/id-check.md
+++ b/docs/hosted/express/configuration/id-check.md
@@ -1,5 +1,5 @@
 ---
-description: 'Configuration options for the ID Check workflow in Scandit Express.'
+description: "Scan and verify identity documents in Scandit Express to check age or validity for retail, hospitality, and regulated sales."
 sidebar_label: 'ID Check'
 displayed_sidebar: expressSidebar
 keywords:

--- a/docs/hosted/express/configuration/index.md
+++ b/docs/hosted/express/configuration/index.md
@@ -1,5 +1,5 @@
 ---
-description: "There are many configuration options and functionalities available in Scandit Express. This section provides an overview of the different configuration options and how to set them up.                                                                         "
+description: "Overview of the configuration options available in Scandit Express and how to set them up."
 
 toc_max_heading_level: 4
 framework: express

--- a/docs/hosted/express/configuration/inventory-count.md
+++ b/docs/hosted/express/configuration/inventory-count.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn how to use the Inventory Count feature in Scandit Express."
+description: "Use the Inventory Count mode in Scandit Express for fast, accurate stock counting."
 framework: express
 keywords:
   - express

--- a/docs/hosted/express/configuration/scan-labels.md
+++ b/docs/hosted/express/configuration/scan-labels.md
@@ -1,5 +1,5 @@
 ---
-description: "Powered by Smart Label Capture, a feature available in the Scandit Smart Data Capture SDK, this mode enables the simultaneous scanning of multiple barcodes and printed text on labels, streamlining data entry and reducing errors."
+description: "Scan Labels in Scandit Express, powered by Smart Label Capture, reads multiple barcodes and printed text on a label in one scan."
 framework: express
 keywords:
   - express

--- a/docs/hosted/express/getting-started/installation.md
+++ b/docs/hosted/express/getting-started/installation.md
@@ -1,5 +1,5 @@
 ---
-description: "Follow the steps below to get started with Scandit Express."
+description: "Install Scandit Express on iOS or Android and activate it to add barcode scanning to any app."
 sidebar_label: 'Installation'
 displayed_sidebar: expressSidebar
 sidebar_position: 1

--- a/docs/hosted/express/getting-started/rollout.md
+++ b/docs/hosted/express/getting-started/rollout.md
@@ -1,5 +1,5 @@
 ---
-description: "For production use, Scandit Express is typically distributed via a mobile device management (MDM) or enterprise mobility management (EMM) system. This page will guide you rolling out Scandit Express using such a system for either Android or iOS.                                                              "
+description: "Roll out Scandit Express to production with a mobile device management (MDM or EMM) system on Android or iOS."
 
 sidebar_label: 'Rollout via MDM/EMM'
 displayed_sidebar: expressSidebar

--- a/docs/hosted/express/overview.md
+++ b/docs/hosted/express/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit Express is an application that enables you to instantly add barcode scanning to any existing app or software tool on a smart device.It requires no software changes or coding effort, and is compatible with any app or system, even those that cannot be modified. By adding a keyboard that has a scan button above the standard keys (a keyboard wedge), it allows users to scan barcodes directly into any input field.                            "
+description: "Scandit Express instantly adds barcode scanning to any existing app or tool on a smart device, with no code changes required."
 
 sidebar_position: 1
 sidebar_label: 'Overview'

--- a/docs/hosted/express/workflows/markdown.md
+++ b/docs/hosted/express/workflows/markdown.md
@@ -1,5 +1,5 @@
 ---
-description: 'Configuration options for the Markdown workflow in Scandit Express.'
+description: "Configure the Markdown workflow in Scandit Express to guide users through task-based work such as product recalls."
 sidebar_label: 'Markdown Configuration'
 displayed_sidebar: expressSidebar
 keywords:

--- a/docs/hosted/express/workflows/overview.md
+++ b/docs/hosted/express/workflows/overview.md
@@ -1,5 +1,5 @@
 ---
-description: 'An overview of Scandit Express’s built-in workflows.'
+description: "Scandit Express built-in workflows: configurable, ready-to-deploy modes that guide users with prompts and AR guidance."
 sidebar_label: 'Overview'
 displayed_sidebar: expressSidebar
 keywords:

--- a/docs/hosted/express/workflows/task-management.md
+++ b/docs/hosted/express/workflows/task-management.md
@@ -1,5 +1,5 @@
 ---
-description: 'Configuration options for the Task Management workflow in Scandit Express.'
+description: "Configure the Task Management workflow in Scandit Express to assign and track task-based scanning work."
 sidebar_label: 'Task Management Configuration'
 displayed_sidebar: expressSidebar
 keywords:

--- a/docs/hosted/id-bolt/advanced.md
+++ b/docs/hosted/id-bolt/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "This page covers advanced features and options for ID Bolt that help optimize performance and handle specific use cases.                                                                                 "
+description: "Advanced ID Bolt options for performance tuning and less-common integration scenarios."
 
 sidebar_label: "Advanced Options"
 title: "Advanced Options"

--- a/docs/hosted/id-bolt/api-overview.md
+++ b/docs/hosted/id-bolt/api-overview.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt is built around the concept of a **session** - a complete user journey from starting the ID scanning process to either successful completion or cancellation. The main class `IdBoltSession` represents this session and manages the entire workflow.                                                             "
+description: "Overview of the ID Bolt API, built around the IdBoltSession class that manages the full ID scanning journey from start to completion."
 
 sidebar_label: "API Overview"
 title: "API Overview"

--- a/docs/hosted/id-bolt/callbacks.md
+++ b/docs/hosted/id-bolt/callbacks.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt provides callbacks to handle session completion and cancellation, allowing your application to respond appropriately to user actions and scan results.                                                                              "
+description: "Handle ID Bolt session completion and cancellation with callbacks so your app can respond to user actions and scan results."
 
 sidebar_label: "Callbacks"
 title: "Callbacks"

--- a/docs/hosted/id-bolt/data-handling.md
+++ b/docs/hosted/id-bolt/data-handling.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt provides options to control what data is returned from scanned documents and how sensitive information is handled, allowing you to balance functionality with privacy requirements.                                                                         "
+description: "Control what data ID Bolt returns from scanned documents and how sensitive information is handled to balance functionality and privacy."
 
 sidebar_label: "Data Handling"
 title: "Data Handling"

--- a/docs/hosted/id-bolt/document-selection.md
+++ b/docs/hosted/id-bolt/document-selection.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt allows you to specify which types of documents are acceptable for scanning. Documents are selected using the `DocumentSelection` class.                                                                               "
+description: "Specify which document types ID Bolt accepts for scanning using the DocumentSelection class."
 
 sidebar_label: "Document Selection"
 title: "Document Selection"

--- a/docs/hosted/id-bolt/getting-started.md
+++ b/docs/hosted/id-bolt/getting-started.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt can be integrated into your existing application or website with minimal time and effort, often ready to test in your staging environment in just one hour.                                                                        "
+description: "Integrate ID Bolt into your existing app or website with minimal effort, often ready to test in your staging environment within an hour."
 
 sidebar_label: "Getting Started"
 title: "Getting Started"

--- a/docs/hosted/id-bolt/overview.md
+++ b/docs/hosted/id-bolt/overview.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt is a cloud-based identity scanning solution that enables you to provide customers a fast, foolproof ID scanning in just 1 second, leading to an improved customer experience as well as compliance. It works on-device, via desktop and mobile in a unified solution, ensuring no identity information is collected by third-party servers and reduces latency for quick scanning performance.                                        "
+description: "ID Bolt is a cloud-based identity scanning solution for fast, on-device ID scanning across desktop and mobile, improving experience and compliance."
 
 sidebar_position: 1
 sidebar_label: "Overview"

--- a/docs/hosted/id-bolt/release-notes.md
+++ b/docs/hosted/id-bolt/release-notes.md
@@ -1,5 +1,5 @@
 ---
-description: "Release notes and updates for ID Bolt."
+description: "Release notes for ID Bolt: new features, changes, and fixes by date."
 toc_max_heading_level: 3
 displayed_sidebar: boltSidebar
 framework: bolt

--- a/docs/hosted/id-bolt/session.md
+++ b/docs/hosted/id-bolt/session.md
@@ -1,1 +1,8 @@
- 
+---
+title: ID Bolt session
+sidebar_label: Session
+---
+
+import {Redirect} from '@docusaurus/router';
+
+<Redirect to="/hosted/id-bolt/api-overview/" />

--- a/docs/hosted/id-bolt/text-overrides.md
+++ b/docs/hosted/id-bolt/text-overrides.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt allows you to customize the text displayed in the user interface to better match your application's tone, branding, or to provide more specific instructions to users.                                                                        "
+description: "Customize the text ID Bolt displays in its user interface to match your branding or give users more specific instructions."
 
 sidebar_label: "Text Overrides"
 title: "Text Overrides"

--- a/docs/hosted/id-bolt/theming.md
+++ b/docs/hosted/id-bolt/theming.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt allows comprehensive customization of its visual appearance to match your brand identity. Use the `theme` option when creating an ID Bolt session to customize colors, dimensions, and other visual elements.                                                                    "
+description: "Customize the ID Bolt visual appearance with the theme option to match your brand, including colors, dimensions, and other elements."
 
 sidebar_label: "Theming"
 title: "Theming"

--- a/docs/hosted/id-bolt/validators.md
+++ b/docs/hosted/id-bolt/validators.md
@@ -1,5 +1,5 @@
 ---
-description: "Validators allow you to run checks on scanned ID documents to ensure they meet specific criteria. They are only run on documents that are on the list of accepted documents.                                                                      "
+description: "Use ID Bolt validators to check scanned documents against your criteria, applied only to documents on the accepted list."
 
 sidebar_label: "Validators"
 title: "Validators"

--- a/docs/hosted/id-bolt/workflow.md
+++ b/docs/hosted/id-bolt/workflow.md
@@ -1,5 +1,5 @@
 ---
-description: "ID Bolt allows you to customize both the user interface flow and the scanning behavior to meet your specific requirements.                                                                                "
+description: "Customize the ID Bolt user-interface flow and scanning behavior to meet your requirements."
 
 sidebar_label: "Workflow Options"
 title: "Workflow & Scanner Options"

--- a/docs/sdks/android/add-sdk.md
+++ b/docs/sdks/android/add-sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to integrating the Scandit Data Capture SDK into your project."
+description: "Add the Scandit Data Capture SDK to your Android project: dependencies, license key, and camera permissions."
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/android/agent-skills.mdx
+++ b/docs/sdks/android/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Android directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Android from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: android
 keywords:

--- a/docs/sdks/android/agents-android.md
+++ b/docs/sdks/android/agents-android.md
@@ -1,3 +1,8 @@
+---
+description: "Agent guide to install and integrate the Scandit Data Capture SDK on Android (Kotlin/Java): SparkScan, MatrixScan, Label Capture, ID Capture."
+framework: android
+---
+
 # AGENTS.md — Scandit Data Capture SDK (Android: Java/Kotlin)
 
 This file guides coding agents (and humans!) to install and integrate the **Scandit Smart Data Capture SDK** for Android using **Java/Kotlin**. It covers setup and how to add key Scandit products: **SparkScan**, **MatrixScan Find/Count**, **Smart Label Capture**, **Barcode Capture**, and **ID Capture**.

--- a/docs/sdks/android/barcode-capture/get-started.md
+++ b/docs/sdks/android/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes the step-by-step instructions that helps you to add Barcode Capture to your application.                                                                                    "
+description: "Add Barcode Capture to your Android app: configure the mode, set up the camera and view, and handle scanned barcodes."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/android/barcode-generator.md
+++ b/docs/sdks/android/barcode-generator.md
@@ -1,5 +1,5 @@
 ---
-description: "The Barcode Generator is a simple tool to generate barcodes directly from the Scandit SDK. In this guide, we will show you how to use the Barcode Generator to generate barcodes and QR codes.                                                                  "
+description: "Generate barcodes and QR codes in your Android app with the Scandit Data Capture SDK."
 
 sidebar_label: Get Started
 pagination_prev: null

--- a/docs/sdks/android/barcode-selection/get-started.md
+++ b/docs/sdks/android/barcode-selection/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes the steps to add Barcode Selection to your application.                                                                                        "
+description: "Add Barcode Selection to your Android app so users can tap or aim to select a single barcode among many."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/android/barcode-selection/intro.md
+++ b/docs/sdks/android/barcode-selection/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "Barcode Selection enables you to increase scanning accuracy and prevent users from scanning the wrong code in scenario where there are multiple barcodes present. This includes the following:                                                                        "
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your Android app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/barcode-symbologies.mdx
+++ b/docs/sdks/android/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/android/batch-scanning.md
+++ b/docs/sdks/android/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your Android app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 pagination_prev: null
 framework: android

--- a/docs/sdks/android/core-concepts.mdx
+++ b/docs/sdks/android/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/android/extension-codes.mdx
+++ b/docs/sdks/android/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Android app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/android/id-capture/advanced.md
+++ b/docs/sdks/android/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for Android: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/android/id-capture/get-started.md
+++ b/docs/sdks/android/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page will guide you through the process of adding ID Capture to your Android application. ID Capture is a mode of the Scandit Data Capture SDK that allows you to capture and extract information from personal identification documents, such as driver's licenses, passports, and ID cards.                                                     "
+description: "Add ID Capture to your Android app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/id-capture/intro.md
+++ b/docs/sdks/android/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your Android app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/android/id-capture/supported-documents.md
+++ b/docs/sdks/android/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on Android, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/android/label-capture/advanced.md
+++ b/docs/sdks/android/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit Android Label Capture SDK."
+description: "Customize Smart Label Capture overlays on Android by implementing a LabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: android

--- a/docs/sdks/android/label-capture/get-started.md
+++ b/docs/sdks/android/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application.                                                                                    "
+description: "Add Smart Label Capture to your Android app to scan labels that combine barcodes and text in a single step."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/label-capture/intro.md
+++ b/docs/sdks/android/label-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutLabelCapture from '../../../partials/intro/_about-smart-label-capture.mdx';                                                                                                "
+description: "Smart Label Capture reads labels that combine barcodes and text in a single scan in your Android app."
 
 sidebar_label: About Smart Label Capture
 title: About Smart Label Capture

--- a/docs/sdks/android/label-capture/label-definitions.md
+++ b/docs/sdks/android/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans.                                                                            "
+description: "Define label layouts for Smart Label Capture on Android: the barcodes and text fields to extract."
 
 framework: android
 keywords:

--- a/docs/sdks/android/matrixscan-ar/get-started.md
+++ b/docs/sdks/android/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your Android app: set up the view and the overlays that guide users to the right items."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/matrixscan-ar/intro.md
+++ b/docs/sdks/android/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Android app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/matrixscan-count/advanced.md
+++ b/docs/sdks/android/matrixscan-count/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Count is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Count to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Count settings for Android to further tune scanning efficiency, accuracy, and the user experience beyond the defaults."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/android/matrixscan-count/get-started.md
+++ b/docs/sdks/android/matrixscan-count/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes the steps to add MatrixScan Count to your application.                                                                                        "
+description: "Add MatrixScan Count to your Android app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/matrixscan-count/intro.md
+++ b/docs/sdks/android/matrixscan-count/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCount from '../../../partials/intro/_about-matrixscan-count.mdx'                                                                                                "
+description: "MatrixScan Count scans and counts many barcodes at once in your Android app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/matrixscan-find/advanced.md
+++ b/docs/sdks/android/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for Android: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/android/matrixscan-find/get-started.md
+++ b/docs/sdks/android/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your Android app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/matrixscan-find/intro.md
+++ b/docs/sdks/android/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your Android app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/matrixscan-pick/advanced.md
+++ b/docs/sdks/android/matrixscan-pick/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Pick to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Pick settings for Android: customize picking logic, overlays, and workflows."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/android/matrixscan-pick/get-started.md
+++ b/docs/sdks/android/matrixscan-pick/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Pick to your application. Implementing MatrixScan Pick involves two primary elements:                                                                              "
+description: "Add MatrixScan Pick to your Android app to guide users through order picking with AR cues."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/matrixscan-pick/intro.md
+++ b/docs/sdks/android/matrixscan-pick/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.                                           "
+description: "MatrixScan Pick guides order picking in your Android app with on-screen AR cues for the items to pick."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/matrixscan/advanced.md
+++ b/docs/sdks/android/matrixscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "In the previous section we covered how to vizualize the scan process using the `BarcodeBatchBasicOverlay`. This section describes the steps to add custom AR overlays to your MatrixScan application.                                                                       "
+description: "Advanced MatrixScan settings for Android: tune tracking, overlays, and scanning performance."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/android/matrixscan/get-started.md
+++ b/docs/sdks/android/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan to your application.                                                                                      "
+description: "Add MatrixScan to your Android app to detect, track, and highlight multiple barcodes in the same frame."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/matrixscan/intro.md
+++ b/docs/sdks/android/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'                                                                                                "
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Android app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/parser/get-started.md
+++ b/docs/sdks/android/parser/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "The parser parses data strings, e.g. as found in barcodes, into a set of key-value mappings. In this guide, you will know briefly how to use a parser and what types of parser are currently supported by Scandit. These data formats are supported: , and , , .                                                    "
+description: "Use the Scandit parser in your Android app to turn barcode data strings into key-value fields, including formats such as HIBC."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/android/scanning-composite-codes.mdx
+++ b/docs/sdks/android/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Android app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/android/single-scanning.md
+++ b/docs/sdks/android/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your Android app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/android/sparkscan/advanced.md
+++ b/docs/sdks/android/sparkscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are some cases where you might want to customize the behavior of SparkScan. This guide will show you how to add additional capabilities and further customize SparkScan to best fit your needs."
+description: "Advanced SparkScan settings for Android: customize the UI, scanning behavior, and feedback beyond the defaults."
 sidebar_position: 3
 pagination_next: null
 framework: android

--- a/docs/sdks/android/sparkscan/get-started.md
+++ b/docs/sdks/android/sparkscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes the step-by-step instructions that helps you to add SparkScan to your application:                                                                                     "
+description: "Add SparkScan to your Android app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 
 sidebar_position: 2
 framework: android

--- a/docs/sdks/android/sparkscan/intro.md
+++ b/docs/sdks/android/sparkscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows, such as inventory management in retail, or goods receiving in logistics.                                                       "
+description: "SparkScan is a prebuilt smartphone scanning UI for fast, ergonomic barcode scanning that drops on top of any Android app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/android/system-requirements.mdx
+++ b/docs/sdks/android/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on Android: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/capacitor/add-sdk.md
+++ b/docs/sdks/capacitor/add-sdk.md
@@ -1,4 +1,5 @@
 ---
+description: "Add the Scandit Data Capture SDK to your Capacitor project: dependencies, license key, and camera permissions."
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null

--- a/docs/sdks/capacitor/agent-skills.mdx
+++ b/docs/sdks/capacitor/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Capacitor directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Capacitor from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: capacitor
 keywords:

--- a/docs/sdks/capacitor/barcode-capture/get-started.md
+++ b/docs/sdks/capacitor/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Capture to your application.                                                                                     "
+description: "Add Barcode Capture to your Capacitor app: configure the mode, set up the camera and view, and handle scanned barcodes."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/capacitor/barcode-generator.md
+++ b/docs/sdks/capacitor/barcode-generator.md
@@ -1,5 +1,5 @@
 ---
-description: "The Barcode Generator is a simple tool to generate barcodes directly from the Scandit SDK. In this guide, we will show you how to use the Barcode Generator to generate barcodes and QR codes.                                                                  "
+description: "Generate barcodes and QR codes in your Capacitor app with the Scandit Data Capture SDK."
 
 displayed_sidebar: capacitorSidebar
 sidebar_label: Get Started

--- a/docs/sdks/capacitor/barcode-selection/get-started.md
+++ b/docs/sdks/capacitor/barcode-selection/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Selection to your application.                                                                                     "
+description: "Add Barcode Selection to your Capacitor app so users can tap or aim to select a single barcode among many."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/capacitor/barcode-selection/intro.md
+++ b/docs/sdks/capacitor/barcode-selection/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "Barcode Selection enables you to increase scanning accuracy and prevent users from scanning the wrong code in scenarios where there are multiple barcodes present, such as a crowded shelf, an order catalog with barcodes printed closely together, or a label with multiple barcodes.                                                         "
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your Capacitor app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/capacitor/barcode-symbologies.mdx
+++ b/docs/sdks/capacitor/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/capacitor/batch-scanning.md
+++ b/docs/sdks/capacitor/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your Capacitor app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 
 

--- a/docs/sdks/capacitor/core-concepts.mdx
+++ b/docs/sdks/capacitor/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/capacitor/extension-codes.mdx
+++ b/docs/sdks/capacitor/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Capacitor app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/capacitor/id-capture/advanced.md
+++ b/docs/sdks/capacitor/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for Capacitor: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/capacitor/id-capture/get-started.md
+++ b/docs/sdks/capacitor/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add ID Capture to your application.                                                                                     "
+description: "Add ID Capture to your Capacitor app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 framework: capacitor

--- a/docs/sdks/capacitor/id-capture/intro.md
+++ b/docs/sdks/capacitor/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your Capacitor app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/capacitor/id-capture/supported-documents.md
+++ b/docs/sdks/capacitor/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on Capacitor, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/capacitor/label-capture/advanced.md
+++ b/docs/sdks/capacitor/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit Web Label Capture SDK."
+description: "Customize Smart Label Capture overlays on Capacitor by implementing a LabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: capacitor

--- a/docs/sdks/capacitor/label-capture/get-started.md
+++ b/docs/sdks/capacitor/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application."
+description: "Add Smart Label Capture to your Capacitor app to scan labels that combine barcodes and text in a single step."
 sidebar_position: 2
 framework: capacitor
 keywords:

--- a/docs/sdks/capacitor/label-capture/label-definitions.md
+++ b/docs/sdks/capacitor/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans."
+description: "Define label layouts for Smart Label Capture on Capacitor: the barcodes and text fields to extract."
 framework: capacitor
 toc_max_heading_level: 4
 keywords:

--- a/docs/sdks/capacitor/matrixscan-ar/get-started.md
+++ b/docs/sdks/capacitor/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your Capacitor app: set up the view and the overlays that guide users to the right items."
 
 displayed_sidebar: capacitorSidebar
 sidebar_position: 2

--- a/docs/sdks/capacitor/matrixscan-ar/intro.md
+++ b/docs/sdks/capacitor/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Capacitor app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/capacitor/matrixscan-count/advanced.md
+++ b/docs/sdks/capacitor/matrixscan-count/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Count is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Count to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Count settings for Capacitor to tune counting accuracy, performance, and the user experience."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/capacitor/matrixscan-count/get-started.md
+++ b/docs/sdks/capacitor/matrixscan-count/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Count to your application.                                                                                     "
+description: "Add MatrixScan Count to your Capacitor app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
 framework: capacitor

--- a/docs/sdks/capacitor/matrixscan-count/intro.md
+++ b/docs/sdks/capacitor/matrixscan-count/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCount from '../../../partials/intro/_about-matrixscan-count.mdx'                                                                                                "
+description: "MatrixScan Count scans and counts many barcodes at once in your Capacitor app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/capacitor/matrixscan-find/advanced.md
+++ b/docs/sdks/capacitor/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for Capacitor: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/capacitor/matrixscan-find/get-started.md
+++ b/docs/sdks/capacitor/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your Capacitor app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 framework: capacitor

--- a/docs/sdks/capacitor/matrixscan-find/intro.md
+++ b/docs/sdks/capacitor/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your Capacitor app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/capacitor/matrixscan-pick/advanced.md
+++ b/docs/sdks/capacitor/matrixscan-pick/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Pick to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Pick settings for Capacitor: customize picking logic, overlays, and workflows."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/capacitor/matrixscan-pick/get-started.md
+++ b/docs/sdks/capacitor/matrixscan-pick/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Pick to your application. Implementing MatrixScan Pick involves two primary elements:                                                                              "
+description: "Add MatrixScan Pick to your Capacitor app to guide users through order picking with AR cues."
 
 sidebar_position: 2
 framework: capacitor

--- a/docs/sdks/capacitor/matrixscan-pick/intro.md
+++ b/docs/sdks/capacitor/matrixscan-pick/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.                                           "
+description: "MatrixScan Pick guides order picking in your Capacitor app with on-screen AR cues for the items to pick."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/capacitor/matrixscan/advanced.md
+++ b/docs/sdks/capacitor/matrixscan/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan settings for Capacitor: tune tracking, overlays, and scanning performance."
 sidebar_position: 3
 pagination_next: null
 framework: capacitor

--- a/docs/sdks/capacitor/matrixscan/get-started.md
+++ b/docs/sdks/capacitor/matrixscan/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan to your Capacitor app to detect, track, and highlight multiple barcodes in the same frame."
 sidebar_position: 2
 framework: capacitor
 keywords:

--- a/docs/sdks/capacitor/matrixscan/intro.md
+++ b/docs/sdks/capacitor/matrixscan/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Capacitor app."
 sidebar_position: 1
 pagination_prev: null
 framework: capacitor

--- a/docs/sdks/capacitor/parser/get-started.md
+++ b/docs/sdks/capacitor/parser/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Use the Scandit parser in your Capacitor app to turn barcode data strings into key-value fields, including formats such as HIBC."
 sidebar_position: 2
 pagination_next: null
 pagination_prev: null

--- a/docs/sdks/capacitor/release-notes.md
+++ b/docs/sdks/capacitor/release-notes.md
@@ -1,4 +1,5 @@
 ---
+description: "Release notes for the Scandit Data Capture SDK on Capacitor: new features, changes, and fixes by version."
 toc_max_heading_level: 3
 displayed_sidebar: capacitorSidebar
 hide_title: true

--- a/docs/sdks/capacitor/scanning-composite-codes.mdx
+++ b/docs/sdks/capacitor/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Capacitor app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/capacitor/single-scanning.md
+++ b/docs/sdks/capacitor/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your Capacitor app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/capacitor/sparkscan/advanced.md
+++ b/docs/sdks/capacitor/sparkscan/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced SparkScan settings for Capacitor: customize the UI, scanning behavior, and feedback beyond the defaults."
 sidebar_position: 3
 pagination_next: null
 framework: capacitor

--- a/docs/sdks/capacitor/sparkscan/get-started.md
+++ b/docs/sdks/capacitor/sparkscan/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add SparkScan to your Capacitor app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 sidebar_position: 2
 framework: capacitor
 keywords:

--- a/docs/sdks/capacitor/sparkscan/intro.md
+++ b/docs/sdks/capacitor/sparkscan/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "SparkScan is a prebuilt smartphone scanning UI for fast, ergonomic barcode scanning that drops on top of any Capacitor app."
 sidebar_position: 1
 pagination_prev: null
 framework: capacitor

--- a/docs/sdks/capacitor/system-requirements.mdx
+++ b/docs/sdks/capacitor/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on Capacitor: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/cordova/add-sdk.md
+++ b/docs/sdks/cordova/add-sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "This guide shows you how to add the Scandit Data Capture SDK to your existing project.                                                                                    "
+description: "Add the Scandit Data Capture SDK to your Cordova project: dependencies, license key, and camera permissions."
 
 sidebar_position: 1
 toc_max_heading_level: 4

--- a/docs/sdks/cordova/agent-skills.mdx
+++ b/docs/sdks/cordova/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Cordova directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Cordova from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: cordova
 keywords:

--- a/docs/sdks/cordova/barcode-capture/get-started.md
+++ b/docs/sdks/cordova/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step by step how to add barcode capture to your application. The general steps are:                                                                               "
+description: "Add Barcode Capture to your Cordova app: configure the mode, set up the camera and view, and handle scanned barcodes."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/cordova/barcode-generator.md
+++ b/docs/sdks/cordova/barcode-generator.md
@@ -1,5 +1,5 @@
 ---
-description: "The Barcode Generator is a simple tool to generate barcodes directly from the Scandit SDK. In this guide, we will show you how to use the Barcode Generator to generate barcodes and QR codes.                                                                  "
+description: "Generate barcodes and QR codes in your Cordova app with the Scandit Data Capture SDK."
 
 displayed_sidebar: cordovaSidebar
 sidebar_label: Get Started

--- a/docs/sdks/cordova/barcode-selection/get-started.md
+++ b/docs/sdks/cordova/barcode-selection/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step by step how to add barcode selection to your application. The general step are:                                                                               "
+description: "Add Barcode Selection to your Cordova app so users can tap or aim to select a single barcode among many."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/cordova/barcode-selection/intro.md
+++ b/docs/sdks/cordova/barcode-selection/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "Barcode Selection enables you to increase scanning accuracy and prevent users from scanning the wrong code in scenarios where there are multiple barcodes present, such as a crowded shelf, an order catalog with barcodes printed closely together, or a label with multiple barcodes.                                                         "
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your Cordova app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/barcode-symbologies.mdx
+++ b/docs/sdks/cordova/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/cordova/batch-scanning.md
+++ b/docs/sdks/cordova/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your Cordova app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 
 

--- a/docs/sdks/cordova/core-concepts.mdx
+++ b/docs/sdks/cordova/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/cordova/extension-codes.mdx
+++ b/docs/sdks/cordova/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Cordova app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/cordova/id-capture/advanced.md
+++ b/docs/sdks/cordova/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for Cordova: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/cordova/id-capture/get-started.md
+++ b/docs/sdks/cordova/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page will guide you through the process of adding ID Capture to your Cordova application. ID Capture is a mode of the Scandit Data Capture SDK that allows you to capture and extract information from personal identification documents, such as driver's licenses, passports, and ID cards.                                                     "
+description: "Add ID Capture to your Cordova app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/cordova/id-capture/intro.md
+++ b/docs/sdks/cordova/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your Cordova app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/cordova/id-capture/supported-documents.md
+++ b/docs/sdks/cordova/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on Cordova, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/cordova/label-capture/advanced.md
+++ b/docs/sdks/cordova/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit Web Label Capture SDK."
+description: "Customize Smart Label Capture overlays on Cordova by implementing a LabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: cordova

--- a/docs/sdks/cordova/label-capture/get-started.md
+++ b/docs/sdks/cordova/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application."
+description: "Add Smart Label Capture to your Cordova app to scan labels that combine barcodes and text in a single step."
 sidebar_position: 2
 framework: cordova
 keywords:

--- a/docs/sdks/cordova/label-capture/label-definitions.md
+++ b/docs/sdks/cordova/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans."
+description: "Define label layouts for Smart Label Capture on Cordova: the barcodes and text fields to extract."
 framework: cordova
 toc_max_heading_level: 4
 keywords:

--- a/docs/sdks/cordova/matrixscan-ar/get-started.md
+++ b/docs/sdks/cordova/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your Cordova app: set up the view and the overlays that guide users to the right items."
 
 displayed_sidebar: cordovaSidebar
 sidebar_position: 2

--- a/docs/sdks/cordova/matrixscan-ar/intro.md
+++ b/docs/sdks/cordova/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Cordova app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/matrixscan-count/advanced.md
+++ b/docs/sdks/cordova/matrixscan-count/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Count is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Count to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Count settings for Cordova to tune counting accuracy, performance, and the user experience."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/cordova/matrixscan-count/get-started.md
+++ b/docs/sdks/cordova/matrixscan-count/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Count to your application.                                                                                     "
+description: "Add MatrixScan Count to your Cordova app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
 framework: cordova

--- a/docs/sdks/cordova/matrixscan-count/intro.md
+++ b/docs/sdks/cordova/matrixscan-count/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCount from '../../../partials/intro/_about-matrixscan-count.mdx'                                                                                                "
+description: "MatrixScan Count scans and counts many barcodes at once in your Cordova app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/matrixscan-find/advanced.md
+++ b/docs/sdks/cordova/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for Cordova: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/cordova/matrixscan-find/get-started.md
+++ b/docs/sdks/cordova/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your Cordova app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 framework: cordova

--- a/docs/sdks/cordova/matrixscan-find/intro.md
+++ b/docs/sdks/cordova/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your Cordova app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/matrixscan-pick/advanced.md
+++ b/docs/sdks/cordova/matrixscan-pick/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Pick to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Pick settings for Cordova: customize picking logic, overlays, and workflows."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/cordova/matrixscan-pick/get-started.md
+++ b/docs/sdks/cordova/matrixscan-pick/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Pick to your application. Implementing MatrixScan Pick involves two primary elements:                                                                              "
+description: "Add MatrixScan Pick to your Cordova app to guide users through order picking with AR cues."
 
 sidebar_position: 2
 framework: cordova

--- a/docs/sdks/cordova/matrixscan-pick/intro.md
+++ b/docs/sdks/cordova/matrixscan-pick/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.                                           "
+description: "MatrixScan Pick guides order picking in your Cordova app with on-screen AR cues for the items to pick."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/matrixscan/advanced.md
+++ b/docs/sdks/cordova/matrixscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to integrating and configuring advanced AR overlays using the Scandit Cordova SDK."
+description: "Add and configure AR overlays for MatrixScan on Cordova, building on an existing MatrixScan setup."
 sidebar_position: 3
 pagination_next: null
 framework: cordova

--- a/docs/sdks/cordova/matrixscan/get-started.md
+++ b/docs/sdks/cordova/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan to your application.                                                                                      "
+description: "Add MatrixScan to your Cordova app to detect, track, and highlight multiple barcodes in the same frame."
 
 sidebar_position: 2
 framework: cordova

--- a/docs/sdks/cordova/matrixscan/intro.md
+++ b/docs/sdks/cordova/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'                                                                                                "
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Cordova app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/parser/get-started.md
+++ b/docs/sdks/cordova/parser/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "The parser parses data strings, e.g. as found in barcodes, into a set of key-value mappings. In this guide, you will know briefly how to use a parser and what types of parser are currently supported by Scandit. These data formats are supported: , and , , .                                                    "
+description: "Use the Scandit parser in your Cordova app to turn barcode data strings into key-value fields, including formats such as HIBC."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/cordova/scanning-composite-codes.mdx
+++ b/docs/sdks/cordova/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Cordova app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/cordova/single-scanning.md
+++ b/docs/sdks/cordova/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your Cordova app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/cordova/sparkscan/advanced.md
+++ b/docs/sdks/cordova/sparkscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are some cases where you might want to customize the behavior of SparkScan. This guide will show you how to add additional capabilities and further customize SparkScan to best fit your needs.                                                     "
+description: "Advanced SparkScan settings for Cordova: customize the UI, scanning behavior, and feedback beyond the defaults."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/cordova/sparkscan/get-started.md
+++ b/docs/sdks/cordova/sparkscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add SparkScan to your application. The general steps are:                                                                                  "
+description: "Add SparkScan to your Cordova app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 
 sidebar_position: 2
 framework: cordova

--- a/docs/sdks/cordova/sparkscan/intro.md
+++ b/docs/sdks/cordova/sparkscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.                                                       "
+description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any Cordova app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/cordova/system-requirements.mdx
+++ b/docs/sdks/cordova/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on Cordova: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/flutter/add-sdk.md
+++ b/docs/sdks/flutter/add-sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to integrating the Scandit Data Capture SDK into your project."
+description: "Add the Scandit Data Capture SDK to your Flutter project: dependencies, license key, and camera permissions."
 
 sidebar_position: 1
 toc_max_heading_level: 4

--- a/docs/sdks/flutter/agent-skills.mdx
+++ b/docs/sdks/flutter/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Flutter directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Flutter from your coding agent (Claude Code, Codex, Cursor)."
 toc_max_heading_level: 3
 framework: flutter
 keywords:

--- a/docs/sdks/flutter/barcode-capture/get-started.md
+++ b/docs/sdks/flutter/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Capture to your application.                                                                                     "
+description: "Add Barcode Capture to your Flutter app: configure the mode, set up the camera and view, and handle scanned barcodes."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/flutter/barcode-generator.md
+++ b/docs/sdks/flutter/barcode-generator.md
@@ -1,5 +1,5 @@
 ---
-description: "The Barcode Generator is a simple tool to generate barcodes directly from the Scandit SDK. In this guide, we will show you how to use the Barcode Generator to generate barcodes and QR codes.                                                                  "
+description: "Generate barcodes and QR codes in your Flutter app with the Scandit Data Capture SDK."
 
 displayed_sidebar: flutterSidebar
 pagination_prev: null

--- a/docs/sdks/flutter/barcode-selection/get-started.md
+++ b/docs/sdks/flutter/barcode-selection/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Selection to your application.                                                                                     "
+description: "Add Barcode Selection to your Flutter app so users can tap or aim to select a single barcode among many."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/flutter/barcode-selection/intro.md
+++ b/docs/sdks/flutter/barcode-selection/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "Barcode Selection enables you to increase scanning accuracy and prevent users from scanning the wrong code in scenarios where there are multiple barcodes present, such as a crowded shelf, an order catalog with barcodes printed closely together, or a label with multiple barcodes.                                                         "
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your Flutter app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/barcode-symbologies.mdx
+++ b/docs/sdks/flutter/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/flutter/batch-scanning.md
+++ b/docs/sdks/flutter/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your Flutter app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 
 

--- a/docs/sdks/flutter/core-concepts.mdx
+++ b/docs/sdks/flutter/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/flutter/extension-codes.mdx
+++ b/docs/sdks/flutter/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Flutter app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/flutter/id-capture/advanced.md
+++ b/docs/sdks/flutter/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for Flutter: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/flutter/id-capture/get-started.md
+++ b/docs/sdks/flutter/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page will guide you through the process of adding ID Capture to your Flutter application. ID Capture is a mode of the Scandit Data Capture SDK that allows you to capture and extract information from personal identification documents, such as driver's licenses, passports, and ID cards.                                                     "
+description: "Add ID Capture to your Flutter app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/id-capture/intro.md
+++ b/docs/sdks/flutter/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your Flutter app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/flutter/id-capture/supported-documents.md
+++ b/docs/sdks/flutter/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on Flutter, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/flutter/label-capture/advanced.md
+++ b/docs/sdks/flutter/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit Flutter Label Capture SDK."
+description: "Customize Smart Label Capture overlays on Flutter by implementing a LabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: flutter

--- a/docs/sdks/flutter/label-capture/get-started.md
+++ b/docs/sdks/flutter/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application.                                                                                    "
+description: "Add Smart Label Capture to your Flutter app to scan labels that combine barcodes and text in a single step."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/label-capture/intro.md
+++ b/docs/sdks/flutter/label-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutLabelCapture from '../../../partials/intro/_about-smart-label-capture.mdx';                                                                                                "
+description: "Smart Label Capture reads labels that combine barcodes and text in a single scan in your Flutter app."
 
 sidebar_label: About Smart Label Capture
 title: About Smart Label Capture

--- a/docs/sdks/flutter/label-capture/label-definitions.md
+++ b/docs/sdks/flutter/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans.                                                                            "
+description: "Define label layouts for Smart Label Capture on Flutter: the barcodes and text fields to extract."
 
 framework: flutter
 keywords:

--- a/docs/sdks/flutter/matrixscan-ar/get-started.md
+++ b/docs/sdks/flutter/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your Flutter app: set up the view and the overlays that guide users to the right items."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/matrixscan-ar/intro.md
+++ b/docs/sdks/flutter/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Flutter app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/matrixscan-count/advanced.md
+++ b/docs/sdks/flutter/matrixscan-count/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Count is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Count to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Count settings for Flutter to tune counting accuracy, performance, and the user experience."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/flutter/matrixscan-count/get-started.md
+++ b/docs/sdks/flutter/matrixscan-count/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Count to your application.                                                                                     "
+description: "Add MatrixScan Count to your Flutter app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/matrixscan-count/intro.md
+++ b/docs/sdks/flutter/matrixscan-count/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCount from '../../../partials/intro/_about-matrixscan-count.mdx'                                                                                                "
+description: "MatrixScan Count scans and counts many barcodes at once in your Flutter app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/matrixscan-find/advanced.md
+++ b/docs/sdks/flutter/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for Flutter: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/flutter/matrixscan-find/get-started.md
+++ b/docs/sdks/flutter/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your Flutter app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/matrixscan-find/intro.md
+++ b/docs/sdks/flutter/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your Flutter app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/matrixscan-pick/advanced.md
+++ b/docs/sdks/flutter/matrixscan-pick/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Pick to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Pick settings for Flutter: customize picking logic, overlays, and workflows."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/flutter/matrixscan-pick/get-started.md
+++ b/docs/sdks/flutter/matrixscan-pick/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Pick to your application. Implementing MatrixScan Pick involves two primary elements:                                                                              "
+description: "Add MatrixScan Pick to your Flutter app to guide users through order picking with AR cues."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/matrixscan-pick/intro.md
+++ b/docs/sdks/flutter/matrixscan-pick/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.                                           "
+description: "MatrixScan Pick guides order picking in your Flutter app with on-screen AR cues for the items to pick."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/matrixscan/advanced.md
+++ b/docs/sdks/flutter/matrixscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are two ways to add advanced AR overlays to a Data Capture View:                                                                                      "
+description: "Advanced MatrixScan settings for Flutter: tune tracking, overlays, and scanning performance."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/flutter/matrixscan/get-started.md
+++ b/docs/sdks/flutter/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan to your application.                                                                                      "
+description: "Add MatrixScan to your Flutter app to detect, track, and highlight multiple barcodes in the same frame."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/matrixscan/intro.md
+++ b/docs/sdks/flutter/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'                                                                                                "
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Flutter app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/parser/get-started.md
+++ b/docs/sdks/flutter/parser/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "The parser parses data strings, e.g. as found in barcodes, into a set of key-value mappings. In this guide, you will know briefly how to use a parser and what types of parser are currently supported by Scandit. These data formats are supported: , and , , .                                                    "
+description: "Use the Scandit parser in your Flutter app to turn barcode data strings into key-value fields, including formats such as HIBC."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/flutter/scanning-composite-codes.mdx
+++ b/docs/sdks/flutter/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Flutter app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/flutter/single-scanning.md
+++ b/docs/sdks/flutter/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your Flutter app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/flutter/sparkscan/advanced.md
+++ b/docs/sdks/flutter/sparkscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are some cases where you might want to customize the behavior of SparkScan. This guide will show you how to add additional capabilities and further customize SparkScan to best fit your needs.                                                     "
+description: "Advanced SparkScan settings for Flutter: customize the UI, scanning behavior, and feedback beyond the defaults."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/flutter/sparkscan/get-started.md
+++ b/docs/sdks/flutter/sparkscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes the step-by-step instructions that helps you to add SparkScan to your application:                                                                                     "
+description: "Add SparkScan to your Flutter app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 
 sidebar_position: 2
 framework: flutter

--- a/docs/sdks/flutter/sparkscan/intro.md
+++ b/docs/sdks/flutter/sparkscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows, such as inventory management in retail, or goods receiving in logistics.                                                       "
+description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any Flutter app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/flutter/system-requirements.mdx
+++ b/docs/sdks/flutter/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on Flutter, including supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/ios/add-sdk.md
+++ b/docs/sdks/ios/add-sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes how to integrate the Scandit Data Capture SDK into your iOS project. The SDK can be added via:                                                                               "
+description: "Add the Scandit Data Capture SDK to your iOS project: dependencies, license key, and camera permissions."
 
 sidebar_position: 1
 toc_max_heading_level: 4

--- a/docs/sdks/ios/agent-skills.mdx
+++ b/docs/sdks/ios/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for iOS directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for iOS from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: ios
 keywords:

--- a/docs/sdks/ios/barcode-capture/get-started.md
+++ b/docs/sdks/ios/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Capture to your application.                                                                                     "
+description: "Add Barcode Capture to your iOS app: configure the mode, set up the camera and view, and handle scanned barcodes."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/ios/barcode-generator.md
+++ b/docs/sdks/ios/barcode-generator.md
@@ -1,5 +1,5 @@
 ---
-description: "The Barcode Generator is a simple tool to generate barcodes directly from the Scandit SDK. In this guide, we will show you how to use the Barcode Generator to generate barcodes and QR codes.                                                                  "
+description: "Generate barcodes and QR codes in your iOS app with the Scandit Data Capture SDK."
 
 sidebar_label: Get Started
 pagination_prev: null

--- a/docs/sdks/ios/barcode-selection/get-started.md
+++ b/docs/sdks/ios/barcode-selection/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Selection to your application.                                                                                     "
+description: "Add Barcode Selection to your iOS app so users can tap or aim to select a single barcode among many."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/ios/barcode-selection/intro.md
+++ b/docs/sdks/ios/barcode-selection/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "Barcode Selection enables you to increase scanning accuracy and prevent users from scanning the wrong code in scenario where there are multiple barcodes present. This includes the following:                                                                        "
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your iOS app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/ios/barcode-symbologies.mdx
+++ b/docs/sdks/ios/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/ios/batch-scanning.md
+++ b/docs/sdks/ios/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your iOS app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 
 

--- a/docs/sdks/ios/core-concepts.mdx
+++ b/docs/sdks/ios/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/ios/extension-codes.mdx
+++ b/docs/sdks/ios/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your iOS app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/ios/id-capture/advanced.md
+++ b/docs/sdks/ios/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for iOS: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/ios/id-capture/get-started.md
+++ b/docs/sdks/ios/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page will guide you through the process of adding ID Capture to your iOS application. ID Capture is a mode of the Scandit Data Capture SDK that allows you to capture and extract information from personal identification documents, such as driver's licenses, passports, and ID cards.                                                     "
+description: "Add ID Capture to your iOS app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/id-capture/intro.md
+++ b/docs/sdks/ios/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your iOS app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/ios/id-capture/supported-documents.md
+++ b/docs/sdks/ios/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on iOS, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/ios/label-capture/advanced.md
+++ b/docs/sdks/ios/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit iOS Label Capture SDK."
+description: "Customize Smart Label Capture overlays on iOS by implementing a LabelCaptureBasicOverlayDelegate."
 sidebar_position: 3
 pagination_next: null
 framework: ios

--- a/docs/sdks/ios/label-capture/get-started.md
+++ b/docs/sdks/ios/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application.                                                                                    "
+description: "Add Smart Label Capture to your iOS app to scan labels that combine barcodes and text in a single step."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/label-capture/intro.md
+++ b/docs/sdks/ios/label-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutLabelCapture from '../../../partials/intro/_about-smart-label-capture.mdx';                                                                                                "
+description: "Smart Label Capture reads labels that combine barcodes and text in a single scan in your iOS app."
 
 sidebar_label: About Smart Label Capture
 title: About Smart Label Capture

--- a/docs/sdks/ios/label-capture/label-definitions.md
+++ b/docs/sdks/ios/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "Smart Label Capture provides a API, enabling you to configure and extract structured data from predefined and custom labels. This feature provides a flexible way to recognize and decode fields within a specific label layout such as price tags, VIN labels, or packaging stickers without needing to write custom code for each label type.                                              "
+description: "Define label layouts for Smart Label Capture on iOS: the barcodes and text fields to extract."
 
 framework: ios
 toc_max_heading_level: 4

--- a/docs/sdks/ios/matrixscan-ar/get-started.md
+++ b/docs/sdks/ios/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your iOS app: set up the view and the overlays that guide users to the right items."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/matrixscan-ar/intro.md
+++ b/docs/sdks/ios/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your iOS app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/ios/matrixscan-count/advanced.md
+++ b/docs/sdks/ios/matrixscan-count/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Count is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Count to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Count settings for iOS to tune counting accuracy, performance, and the user experience."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/ios/matrixscan-count/get-started.md
+++ b/docs/sdks/ios/matrixscan-count/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Count to your application.                                                                                     "
+description: "Add MatrixScan Count to your iOS app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/matrixscan-count/intro.md
+++ b/docs/sdks/ios/matrixscan-count/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCount from '../../../partials/intro/_about-matrixscan-count.mdx'                                                                                                "
+description: "MatrixScan Count scans and counts many barcodes at once in your iOS app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/ios/matrixscan-find/advanced.md
+++ b/docs/sdks/ios/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for iOS: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/ios/matrixscan-find/get-started.md
+++ b/docs/sdks/ios/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your iOS app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/matrixscan-find/intro.md
+++ b/docs/sdks/ios/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your iOS app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/ios/matrixscan-pick/advanced.md
+++ b/docs/sdks/ios/matrixscan-pick/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Pick to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Pick settings for iOS: customize picking logic, overlays, and workflows."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/ios/matrixscan-pick/get-started.md
+++ b/docs/sdks/ios/matrixscan-pick/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Pick to your application. Implementing MatrixScan Pick involves two primary elements:                                                                              "
+description: "Add MatrixScan Pick to your iOS app to guide users through order picking with AR cues."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/matrixscan-pick/intro.md
+++ b/docs/sdks/ios/matrixscan-pick/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.                                           "
+description: "MatrixScan Pick guides order picking in your iOS app with on-screen AR cues for the items to pick."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/ios/matrixscan/advanced.md
+++ b/docs/sdks/ios/matrixscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "In the previous section we covered how to vizualize the scan process using the . In this section we will cover how to add custom AR overlays to your MatrixScan application.                                                                     "
+description: "Advanced MatrixScan settings for iOS: tune tracking, overlays, and scanning performance."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/ios/matrixscan/get-started.md
+++ b/docs/sdks/ios/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan to your application.                                                                                      "
+description: "Add MatrixScan to your iOS app to detect, track, and highlight multiple barcodes in the same frame."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/matrixscan/intro.md
+++ b/docs/sdks/ios/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'                                                                                                "
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your iOS app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/ios/parser/get-started.md
+++ b/docs/sdks/ios/parser/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "The parser parses data strings, e.g. as found in barcodes, into a set of key-value mappings. In this guide, you will know briefly how to use a parser and what types of parser are currently supported by Scandit. These data formats are supported: , and , , .                                                    "
+description: "Use the Scandit parser in your iOS app to turn barcode data strings into key-value fields, including formats such as HIBC."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/ios/scanning-composite-codes.mdx
+++ b/docs/sdks/ios/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your iOS app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/ios/single-scanning.md
+++ b/docs/sdks/ios/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your iOS app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/ios/sparkscan/advanced.md
+++ b/docs/sdks/ios/sparkscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are some cases where you might want to customize the behavior of SparkScan. This guide will show you how to add additional capabilities and further customize SparkScan to best fit your needs.                                                     "
+description: "Advanced SparkScan settings for iOS: customize the UI, scanning behavior, and feedback beyond the defaults."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/ios/sparkscan/get-started.md
+++ b/docs/sdks/ios/sparkscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add SparkScan to your application by:                                                                                     "
+description: "Add SparkScan to your iOS app: create a data capture context, configure the mode, add the SparkScan view, and handle scanned barcodes."
 
 sidebar_position: 2
 framework: ios

--- a/docs/sdks/ios/sparkscan/intro.md
+++ b/docs/sdks/ios/sparkscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.                                                       "
+description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any iOS app."
 
 sidebar_position: 1
 displayed_sidebar: iosSidebar

--- a/docs/sdks/ios/system-requirements.mdx
+++ b/docs/sdks/ios/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on iOS: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/linux/add-sdk.md
+++ b/docs/sdks/linux/add-sdk.md
@@ -1,4 +1,5 @@
 ---
+description: "Add the Scandit Data Capture SDK to your Linux project: dependencies, license key, and camera permissions."
 toc_max_heading_level: 4
 pagination_next: null
 framework: linux

--- a/docs/sdks/linux/barcode-capture/add-on-codes.md
+++ b/docs/sdks/linux/barcode-capture/add-on-codes.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan add-on (extension) codes for EAN-8, EAN-13, UPC-A, and UPC-E in your Linux app with the Scandit Data Capture SDK."
 sidebar_position: 1
 pagination_next: null
 framework: linux

--- a/docs/sdks/linux/barcode-capture/composite-codes.md
+++ b/docs/sdks/linux/barcode-capture/composite-codes.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan composite codes that combine a linear (1D) barcode with a 2D code in your Linux app with the Scandit Data Capture SDK."
 sidebar_position: 5
 pagination_next: null
 framework: linux

--- a/docs/sdks/linux/barcode-capture/configure-barcode-symbologies.md
+++ b/docs/sdks/linux/barcode-capture/configure-barcode-symbologies.md
@@ -1,4 +1,5 @@
 ---
+description: "Enable and configure barcode symbologies for Barcode Capture on Linux."
 sidebar_position: 3
 pagination_next: null
 framework: linux

--- a/docs/sdks/linux/barcode-capture/configure-with-json.md
+++ b/docs/sdks/linux/barcode-capture/configure-with-json.md
@@ -1,4 +1,5 @@
 ---
+description: "Configure Scandit barcode scanner settings on Linux with JSON using the sc_barcode_scanner_settings_new_from_json() function."
 sidebar_position: 2
 pagination_prev: null
 framework: linux

--- a/docs/sdks/linux/barcode-capture/structured-append-codes.md
+++ b/docs/sdks/linux/barcode-capture/structured-append-codes.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan structured append codes, which split message data across a sequence of barcodes, in your Linux app with the Scandit SDK."
 sidebar_position: 1
 pagination_next: null
 framework: linux

--- a/docs/sdks/linux/barcode-generator.md
+++ b/docs/sdks/linux/barcode-generator.md
@@ -1,4 +1,5 @@
 ---
+description: "Generate barcodes and QR codes in your Linux app with the Scandit Data Capture SDK."
 displayed_sidebar: linuxSidebar
 sidebar_label: Configure barcode encoding
 ---

--- a/docs/sdks/linux/barcode-symbologies.mdx
+++ b/docs/sdks/linux/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/linux/extension-codes.mdx
+++ b/docs/sdks/linux/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Linux app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/linux/matrixscan-ar/intro.md
+++ b/docs/sdks/linux/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan AR is not available on the Linux SDK."
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Linux app."
 displayed_sidebar: linuxSidebar
 ---
 

--- a/docs/sdks/linux/matrixscan-ar/intro.md
+++ b/docs/sdks/linux/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Linux app."
+description: "MatrixScan AR is not available on the Linux SDK."
 displayed_sidebar: linuxSidebar
 ---
 

--- a/docs/sdks/linux/matrixscan/get-started.md
+++ b/docs/sdks/linux/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan is not available on the Linux SDK."
+description: "Add MatrixScan to your Linux app to detect, track, and highlight multiple barcodes in the same frame."
 displayed_sidebar: linuxSidebar
 ---
 

--- a/docs/sdks/linux/matrixscan/get-started.md
+++ b/docs/sdks/linux/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "Add MatrixScan to your Linux app to detect, track, and highlight multiple barcodes in the same frame."
+description: "MatrixScan is not available on the Linux SDK."
 displayed_sidebar: linuxSidebar
 ---
 

--- a/docs/sdks/linux/matrixscan/intro.md
+++ b/docs/sdks/linux/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan is not available on the Linux SDK."
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Linux app."
 displayed_sidebar: linuxSidebar
 ---
 

--- a/docs/sdks/linux/matrixscan/intro.md
+++ b/docs/sdks/linux/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Linux app."
+description: "MatrixScan is not available on the Linux SDK."
 displayed_sidebar: linuxSidebar
 ---
 

--- a/docs/sdks/linux/overview.md
+++ b/docs/sdks/linux/overview.md
@@ -1,4 +1,5 @@
 ---
+description: "Overview of the Scandit Data Capture SDK C API on Linux, a low-level interface also available on Android and iOS."
 toc_max_heading_level: 4
 pagination_next: null
 framework: linux

--- a/docs/sdks/linux/release-notes.md
+++ b/docs/sdks/linux/release-notes.md
@@ -1,4 +1,5 @@
 ---
+description: "Release notes for the Scandit Data Capture SDK on Linux: new features, changes, and fixes by version."
 toc_max_heading_level: 3
 displayed_sidebar: linuxSidebar
 hide_title: true

--- a/docs/sdks/linux/samples.md
+++ b/docs/sdks/linux/samples.md
@@ -1,4 +1,5 @@
 ---
+description: "Sample programs that show how to use the Scandit Data Capture SDK for C on Linux."
 sidebar_position: 2
 toc_max_heading_level: 5
 sidebar_label: 'Samples'

--- a/docs/sdks/linux/scanning-composite-codes.mdx
+++ b/docs/sdks/linux/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Linux app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/linux/single-scanning.md
+++ b/docs/sdks/linux/single-scanning.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan a single barcode at a time in your Linux app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 pagination_prev: null
 displayed_sidebar: linuxSidebar

--- a/docs/sdks/net/android/add-sdk.md
+++ b/docs/sdks/net/android/add-sdk.md
@@ -1,4 +1,5 @@
 ---
+description: "Add the Scandit Data Capture SDK to your .NET Android project: dependencies, license key, and camera permissions."
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null

--- a/docs/sdks/net/android/agent-skills.mdx
+++ b/docs/sdks/net/android/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for .NET Android directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for .NET Android from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: net-android
 keywords:

--- a/docs/sdks/net/android/barcode-capture/configure-barcode-symbologies.md
+++ b/docs/sdks/net/android/barcode-capture/configure-barcode-symbologies.md
@@ -1,4 +1,5 @@
 ---
+description: "Enable and configure barcode symbologies for Barcode Capture on .NET Android."
 sidebar_position: 3
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/barcode-capture/get-started.md
+++ b/docs/sdks/net/android/barcode-capture/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add Barcode Capture to your .NET Android app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/barcode-selection/get-started.md
+++ b/docs/sdks/net/android/barcode-selection/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add Barcode Selection to your .NET Android app so users can tap or aim to select a single barcode among many."
 sidebar_position: 2
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/barcode-selection/intro.md
+++ b/docs/sdks/net/android/barcode-selection/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your .NET Android app."
 sidebar_position: 1
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/barcode-symbologies.mdx
+++ b/docs/sdks/net/android/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/net/android/batch-scanning.md
+++ b/docs/sdks/net/android/batch-scanning.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan and process many barcodes in one session in your .NET Android app with the Scandit Data Capture SDK."
 pagination_prev: null
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/core-concepts.mdx
+++ b/docs/sdks/net/android/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/net/android/extension-codes.mdx
+++ b/docs/sdks/net/android/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your .NET Android app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/net/android/id-capture/advanced.md
+++ b/docs/sdks/net/android/id-capture/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced ID Capture settings for .NET Android: configure document types, extracted fields, and verification."
 sidebar_position: 4
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/id-capture/get-started.md
+++ b/docs/sdks/net/android/id-capture/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add ID Capture to your .NET Android app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/id-capture/intro.md
+++ b/docs/sdks/net/android/id-capture/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your .NET Android app."
 sidebar_label: About ID Capture
 title: About ID Capture
 sidebar_position: 1

--- a/docs/sdks/net/android/id-capture/supported-documents.md
+++ b/docs/sdks/net/android/id-capture/supported-documents.md
@@ -1,4 +1,5 @@
 ---
+description: "Identity documents and regions supported by Scandit ID Capture on .NET Android, and the data each returns."
 sidebar_label: Supported Documents
 title: Supported Documents
 hide_title: true

--- a/docs/sdks/net/android/label-capture/advanced.md
+++ b/docs/sdks/net/android/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit .NET Android Label Capture SDK."
+description: "Customize Smart Label Capture overlays on .NET Android by implementing an ILabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: net-android

--- a/docs/sdks/net/android/label-capture/get-started.md
+++ b/docs/sdks/net/android/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application.                                                                                    "
+description: "Add Smart Label Capture to your .NET Android app to scan labels that combine barcodes and text in a single step."
 
 sidebar_position: 2
 framework: net-android

--- a/docs/sdks/net/android/label-capture/intro.md
+++ b/docs/sdks/net/android/label-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutLabelCapture from '../../../../partials/intro/_about-smart-label-capture.mdx';                                                                                                "
+description: "Smart Label Capture reads labels that combine barcodes and text in a single scan in your .NET Android app."
 
 sidebar_label: About Smart Label Capture
 title: About Smart Label Capture

--- a/docs/sdks/net/android/label-capture/label-definitions.md
+++ b/docs/sdks/net/android/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans.                                                                            "
+description: "Define label layouts for Smart Label Capture on .NET Android: the barcodes and text fields to extract."
 
 framework: net-android
 keywords:

--- a/docs/sdks/net/android/matrixscan-ar/get-started.md
+++ b/docs/sdks/net/android/matrixscan-ar/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan AR to your .NET Android app: set up the view and the overlays that guide users to the right items."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/matrixscan-ar/intro.md
+++ b/docs/sdks/net/android/matrixscan-ar/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your .NET Android app."
 displayed_sidebar: netIosSidebar
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan-count/advanced.md
+++ b/docs/sdks/net/android/matrixscan-count/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan Count settings for .NET Android to tune counting accuracy, performance, and the user experience."
 sidebar_position: 3
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan-count/get-started.md
+++ b/docs/sdks/net/android/matrixscan-count/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan Count to your .NET Android app: set up the mode, scan and count multiple barcodes, and handle the results."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/matrixscan-count/intro.md
+++ b/docs/sdks/net/android/matrixscan-count/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan Count scans and counts many barcodes at once in your .NET Android app."
 sidebar_position: 1
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan-find/advanced.md
+++ b/docs/sdks/net/android/matrixscan-find/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan Find settings for .NET Android: customize matching, overlays, and search behavior."
 sidebar_position: 3
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan-find/get-started.md
+++ b/docs/sdks/net/android/matrixscan-find/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan Find to your .NET Android app to search for and highlight specific items with the camera."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/matrixscan-find/intro.md
+++ b/docs/sdks/net/android/matrixscan-find/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan Find helps users locate specific items in your .NET Android app by highlighting matches in the camera feed."
 sidebar_position: 1
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan-pick/advanced.md
+++ b/docs/sdks/net/android/matrixscan-pick/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan Pick settings for .NET Android: customize picking logic, overlays, and workflows."
 sidebar_position: 3
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan-pick/get-started.md
+++ b/docs/sdks/net/android/matrixscan-pick/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan Pick to your .NET Android app to guide users through order picking with AR cues."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/matrixscan-pick/intro.md
+++ b/docs/sdks/net/android/matrixscan-pick/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan Pick guides order picking in your .NET Android app with on-screen AR cues for the items to pick."
 sidebar_position: 1
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan/advanced.md
+++ b/docs/sdks/net/android/matrixscan/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan settings for .NET Android: tune tracking, overlays, and scanning performance."
 sidebar_position: 3
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/matrixscan/get-started.md
+++ b/docs/sdks/net/android/matrixscan/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan to your .NET Android app to detect, track, and highlight multiple barcodes in the same frame."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/matrixscan/intro.md
+++ b/docs/sdks/net/android/matrixscan/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your .NET Android app."
 sidebar_position: 1
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/parser/get-started.md
+++ b/docs/sdks/net/android/parser/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Use the Scandit parser in your .NET Android app to turn barcode data strings into key-value fields, including formats such as HIBC."
 sidebar_position: 2
 pagination_prev: null
 pagination_next: null

--- a/docs/sdks/net/android/release-notes.md
+++ b/docs/sdks/net/android/release-notes.md
@@ -1,4 +1,5 @@
 ---
+description: "Release notes for the Scandit Data Capture SDK on .NET Android: new features, changes, and fixes by version."
 toc_max_heading_level: 3
 displayed_sidebar: netAndroidSidebar
 hide_title: true

--- a/docs/sdks/net/android/scanning-composite-codes.mdx
+++ b/docs/sdks/net/android/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your .NET Android app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/net/android/single-scanning.md
+++ b/docs/sdks/net/android/single-scanning.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan a single barcode at a time in your .NET Android app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/sparkscan/advanced.md
+++ b/docs/sdks/net/android/sparkscan/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced SparkScan settings for .NET Android: customize the UI, scanning behavior, and feedback beyond the defaults."
 sidebar_position: 3
 pagination_next: null
 framework: netAndroid

--- a/docs/sdks/net/android/sparkscan/get-started.md
+++ b/docs/sdks/net/android/sparkscan/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add SparkScan to your .NET Android app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 sidebar_position: 2
 framework: netAndroid
 keywords:

--- a/docs/sdks/net/android/sparkscan/intro.md
+++ b/docs/sdks/net/android/sparkscan/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "SparkScan is a prebuilt smartphone scanning UI for fast, ergonomic barcode scanning that drops on top of any .NET Android app."
 sidebar_position: 1
 pagination_prev: null
 framework: netAndroid

--- a/docs/sdks/net/android/system-requirements.mdx
+++ b/docs/sdks/net/android/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on .NET Android: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/net/ios/add-sdk.md
+++ b/docs/sdks/net/ios/add-sdk.md
@@ -1,4 +1,5 @@
 ---
+description: "Add the Scandit Data Capture SDK to your .NET iOS project: dependencies, license key, and camera permissions."
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null

--- a/docs/sdks/net/ios/agent-skills.mdx
+++ b/docs/sdks/net/ios/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for .NET iOS directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for .NET iOS from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: net-ios
 keywords:

--- a/docs/sdks/net/ios/barcode-capture/configure-barcode-symbologies.md
+++ b/docs/sdks/net/ios/barcode-capture/configure-barcode-symbologies.md
@@ -1,4 +1,5 @@
 ---
+description: "Enable and configure barcode symbologies for Barcode Capture on .NET iOS."
 sidebar_position: 3
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/barcode-capture/get-started.md
+++ b/docs/sdks/net/ios/barcode-capture/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add Barcode Capture to your .NET iOS app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/barcode-selection/get-started.md
+++ b/docs/sdks/net/ios/barcode-selection/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add Barcode Selection to your .NET iOS app so users can tap or aim to select a single barcode among many."
 sidebar_position: 2
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/barcode-selection/intro.md
+++ b/docs/sdks/net/ios/barcode-selection/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/barcode-symbologies.mdx
+++ b/docs/sdks/net/ios/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/net/ios/batch-scanning.md
+++ b/docs/sdks/net/ios/batch-scanning.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan and process many barcodes in one session in your .NET iOS app with the Scandit Data Capture SDK."
 pagination_prev: null
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/core-concepts.mdx
+++ b/docs/sdks/net/ios/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/net/ios/extension-codes.mdx
+++ b/docs/sdks/net/ios/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your .NET iOS app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/net/ios/id-capture/advanced.md
+++ b/docs/sdks/net/ios/id-capture/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced ID Capture settings for .NET iOS: configure document types, extracted fields, and verification."
 sidebar_position: 4
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/id-capture/get-started.md
+++ b/docs/sdks/net/ios/id-capture/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add ID Capture to your .NET iOS app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/id-capture/intro.md
+++ b/docs/sdks/net/ios/id-capture/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your .NET iOS app."
 sidebar_label: About ID Capture
 title: About ID Capture
 sidebar_position: 1

--- a/docs/sdks/net/ios/id-capture/supported-documents.md
+++ b/docs/sdks/net/ios/id-capture/supported-documents.md
@@ -1,4 +1,5 @@
 ---
+description: "Identity documents and regions supported by Scandit ID Capture on .NET iOS, and the data each returns."
 sidebar_label: Supported Documents
 title: Supported Documents
 hide_title: true

--- a/docs/sdks/net/ios/label-capture/advanced.md
+++ b/docs/sdks/net/ios/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit .NET iOS Label Capture SDK."
+description: "Customize Smart Label Capture overlays on .NET iOS by implementing an ILabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: net-ios

--- a/docs/sdks/net/ios/label-capture/get-started.md
+++ b/docs/sdks/net/ios/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application.                                                                                    "
+description: "Add Smart Label Capture to your .NET iOS app to scan labels that combine barcodes and text in a single step."
 
 sidebar_position: 2
 framework: net-ios

--- a/docs/sdks/net/ios/label-capture/intro.md
+++ b/docs/sdks/net/ios/label-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutLabelCapture from '../../../../partials/intro/_about-smart-label-capture.mdx';                                                                                                "
+description: "Smart Label Capture reads labels that combine barcodes and text in a single scan in your .NET iOS app."
 
 sidebar_label: About Smart Label Capture
 title: About Smart Label Capture

--- a/docs/sdks/net/ios/label-capture/label-definitions.md
+++ b/docs/sdks/net/ios/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans.                                                                            "
+description: "Define label layouts for Smart Label Capture on .NET iOS: the barcodes and text fields to extract."
 
 framework: net-ios
 keywords:

--- a/docs/sdks/net/ios/matrixscan-ar/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-ar/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan AR to your .NET iOS app: set up the view and the overlays that guide users to the right items while scanning."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/matrixscan-ar/intro.md
+++ b/docs/sdks/net/ios/matrixscan-ar/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your .NET iOS app."
 displayed_sidebar: netIosSidebar
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan-count/advanced.md
+++ b/docs/sdks/net/ios/matrixscan-count/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan Count settings for .NET iOS to tune counting accuracy, performance, and the user experience."
 sidebar_position: 3
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan-count/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-count/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan Count to your .NET iOS app: set up the mode, scan and count multiple barcodes, and handle the results."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/matrixscan-count/intro.md
+++ b/docs/sdks/net/ios/matrixscan-count/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan Count scans and counts many barcodes at once in your .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan-find/advanced.md
+++ b/docs/sdks/net/ios/matrixscan-find/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan Find settings for .NET iOS: customize matching, overlays, and search behavior."
 sidebar_position: 3
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan-find/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-find/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan Find to your .NET iOS app to search for and highlight specific items with the camera."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/matrixscan-find/intro.md
+++ b/docs/sdks/net/ios/matrixscan-find/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan Find helps users locate specific items in your .NET iOS app by highlighting matches in the camera feed."
 sidebar_position: 1
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan-pick/advanced.md
+++ b/docs/sdks/net/ios/matrixscan-pick/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan Pick settings for .NET iOS: customize picking logic, overlays, and workflows."
 sidebar_position: 3
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan-pick/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-pick/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan Pick to your .NET iOS app to guide users through order picking with AR cues."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/matrixscan-pick/intro.md
+++ b/docs/sdks/net/ios/matrixscan-pick/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan Pick guides order picking in your .NET iOS app with on-screen AR cues for the items to pick."
 sidebar_position: 1
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan/advanced.md
+++ b/docs/sdks/net/ios/matrixscan/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced MatrixScan settings for .NET iOS: tune tracking, overlays, and scanning performance."
 sidebar_position: 3
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/matrixscan/get-started.md
+++ b/docs/sdks/net/ios/matrixscan/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add MatrixScan to your .NET iOS app to detect, track, and highlight multiple barcodes in the same frame."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/matrixscan/intro.md
+++ b/docs/sdks/net/ios/matrixscan/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/parser/get-started.md
+++ b/docs/sdks/net/ios/parser/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Use the Scandit parser in your .NET iOS app to turn barcode data strings into key-value fields, including formats such as HIBC."
 sidebar_position: 2
 pagination_prev: null
 pagination_next: null

--- a/docs/sdks/net/ios/release-notes.md
+++ b/docs/sdks/net/ios/release-notes.md
@@ -1,4 +1,5 @@
 ---
+description: "Release notes for the Scandit Data Capture SDK on .NET iOS: new features, changes, and fixes by version."
 toc_max_heading_level: 3
 displayed_sidebar: netIosSidebar
 hide_title: true

--- a/docs/sdks/net/ios/scanning-composite-codes.mdx
+++ b/docs/sdks/net/ios/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your .NET iOS app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/net/ios/single-scanning.md
+++ b/docs/sdks/net/ios/single-scanning.md
@@ -1,4 +1,5 @@
 ---
+description: "Scan a single barcode at a time in your .NET iOS app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/sparkscan/advanced.md
+++ b/docs/sdks/net/ios/sparkscan/advanced.md
@@ -1,4 +1,5 @@
 ---
+description: "Advanced SparkScan settings for .NET iOS: customize the UI, scanning behavior, and feedback beyond the defaults."
 sidebar_position: 3
 pagination_next: null
 framework: netIos

--- a/docs/sdks/net/ios/sparkscan/get-started.md
+++ b/docs/sdks/net/ios/sparkscan/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add SparkScan to your .NET iOS app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 sidebar_position: 2
 framework: netIos
 keywords:

--- a/docs/sdks/net/ios/sparkscan/intro.md
+++ b/docs/sdks/net/ios/sparkscan/intro.md
@@ -1,4 +1,5 @@
 ---
+description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
 framework: netIos

--- a/docs/sdks/net/ios/system-requirements.mdx
+++ b/docs/sdks/net/ios/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on .NET iOS: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/react-native/add-sdk.md
+++ b/docs/sdks/react-native/add-sdk.md
@@ -1,4 +1,5 @@
 ---
+description: "Add the Scandit Data Capture SDK to your React Native project: dependencies, license key, and camera permissions."
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null

--- a/docs/sdks/react-native/agent-skills.mdx
+++ b/docs/sdks/react-native/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for React Native directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for React Native from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: react-native
 keywords:

--- a/docs/sdks/react-native/barcode-capture/get-started.md
+++ b/docs/sdks/react-native/barcode-capture/get-started.md
@@ -1,4 +1,5 @@
 ---
+description: "Add Barcode Capture to your React Native app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
 framework: react

--- a/docs/sdks/react-native/barcode-generator.md
+++ b/docs/sdks/react-native/barcode-generator.md
@@ -1,5 +1,5 @@
 ---
-description: "The Barcode Generator is a simple tool to generate barcodes directly from the Scandit SDK. In this guide, we will show you how to use the Barcode Generator to generate barcodes and QR codes.                                                                  "
+description: "Generate barcodes and QR codes in your React Native app with the Scandit Data Capture SDK."
 
 displayed_sidebar: reactnativeSidebar
 sidebar_label: Get Started

--- a/docs/sdks/react-native/barcode-selection/get-started.md
+++ b/docs/sdks/react-native/barcode-selection/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Selection to your application.                                                                                     "
+description: "Add Barcode Selection to your React Native app so users can tap or aim to select a single barcode among many."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/react-native/barcode-selection/intro.md
+++ b/docs/sdks/react-native/barcode-selection/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "Barcode Selection enables you to increase scanning accuracy and prevent users from scanning the wrong code in scenarios where there are multiple barcodes present, such as a crowded shelf, an order catalog with barcodes printed closely together, or a label with multiple barcodes.                                                         "
+description: "Barcode Selection lets users tap or aim to pick one barcode among many in your React Native app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/barcode-symbologies.mdx
+++ b/docs/sdks/react-native/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/react-native/batch-scanning.md
+++ b/docs/sdks/react-native/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your React Native app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 
 

--- a/docs/sdks/react-native/core-concepts.mdx
+++ b/docs/sdks/react-native/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/react-native/extension-codes.mdx
+++ b/docs/sdks/react-native/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your React Native app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/react-native/id-capture/advanced.md
+++ b/docs/sdks/react-native/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for React Native: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/react-native/id-capture/get-started.md
+++ b/docs/sdks/react-native/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page will guide you through the process of adding ID Capture to your React Native application. ID Capture is a mode of the Scandit Data Capture SDK that allows you to capture and extract information from personal identification documents, such as driver's licenses, passports, and ID cards.                                                    "
+description: "Add ID Capture to your React Native app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 framework: react

--- a/docs/sdks/react-native/id-capture/intro.md
+++ b/docs/sdks/react-native/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your React Native app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/react-native/id-capture/supported-documents.md
+++ b/docs/sdks/react-native/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on React Native, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/react-native/label-capture/advanced.md
+++ b/docs/sdks/react-native/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit React Native Label Capture SDK."
+description: "Customize Smart Label Capture overlays on React Native by implementing a LabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: react-native

--- a/docs/sdks/react-native/label-capture/get-started.md
+++ b/docs/sdks/react-native/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application.                                                                                    "
+description: "Add Smart Label Capture to your React Native app to scan labels that combine barcodes and text in a single step."
 
 sidebar_position: 2
 framework: react-native

--- a/docs/sdks/react-native/label-capture/intro.md
+++ b/docs/sdks/react-native/label-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutLabelCapture from '../../../partials/intro/_about-smart-label-capture.mdx';                                                                                                "
+description: "Smart Label Capture reads labels that combine barcodes and text in a single scan in your React Native app."
 
 sidebar_label: About Smart Label Capture
 title: About Smart Label Capture

--- a/docs/sdks/react-native/label-capture/label-definitions.md
+++ b/docs/sdks/react-native/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans.                                                                            "
+description: "Define label layouts for Smart Label Capture on React Native: the barcodes and text fields to extract."
 
 framework: react
 toc_max_heading_level: 4

--- a/docs/sdks/react-native/matrixscan-ar/get-started.md
+++ b/docs/sdks/react-native/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your React Native app: set up the view and the overlays that guide users to the right items."
 
 sidebar_position: 2
 framework: react

--- a/docs/sdks/react-native/matrixscan-ar/intro.md
+++ b/docs/sdks/react-native/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your React Native app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/matrixscan-count/advanced.md
+++ b/docs/sdks/react-native/matrixscan-count/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Count is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Count to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Count settings for React Native to tune counting accuracy, performance, and the user experience."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/react-native/matrixscan-count/get-started.md
+++ b/docs/sdks/react-native/matrixscan-count/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Count to your application.                                                                                     "
+description: "Add MatrixScan Count to your React Native app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
 framework: react

--- a/docs/sdks/react-native/matrixscan-count/intro.md
+++ b/docs/sdks/react-native/matrixscan-count/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCount from '../../../partials/intro/_about-matrixscan-count.mdx'                                                                                                "
+description: "MatrixScan Count scans and counts many barcodes at once in your React Native app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/matrixscan-find/advanced.md
+++ b/docs/sdks/react-native/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for React Native: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/react-native/matrixscan-find/get-started.md
+++ b/docs/sdks/react-native/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your React Native app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 framework: react

--- a/docs/sdks/react-native/matrixscan-find/intro.md
+++ b/docs/sdks/react-native/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your React Native app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/matrixscan-pick/advanced.md
+++ b/docs/sdks/react-native/matrixscan-pick/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Pick to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Pick settings for React Native: customize picking logic, overlays, and workflows."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/react-native/matrixscan-pick/get-started.md
+++ b/docs/sdks/react-native/matrixscan-pick/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Pick to your application. Implementing MatrixScan Pick involves two primary elements:                                                                              "
+description: "Add MatrixScan Pick to your React Native app to guide users through order picking with AR cues."
 
 sidebar_position: 2
 framework: react

--- a/docs/sdks/react-native/matrixscan-pick/intro.md
+++ b/docs/sdks/react-native/matrixscan-pick/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.                                           "
+description: "MatrixScan Pick guides order picking in your React Native app with on-screen AR cues for the items to pick."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/matrixscan/advanced.md
+++ b/docs/sdks/react-native/matrixscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "In the previous section we covered how to vizualize the scan process using the `BarcodeBatchBasicOverlay`. In this section we will cover how to add custom AR overlays to your MatrixScan application.                                                                     "
+description: "Advanced MatrixScan settings for React Native: tune tracking, overlays, and scanning performance."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/react-native/matrixscan/get-started.md
+++ b/docs/sdks/react-native/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan to your application.                                                                                      "
+description: "Add MatrixScan to your React Native app to detect, track, and highlight multiple barcodes in the same frame."
 
 framework: react
 keywords:

--- a/docs/sdks/react-native/matrixscan/intro.md
+++ b/docs/sdks/react-native/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'                                                                                                "
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your React Native app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/parser/get-started.md
+++ b/docs/sdks/react-native/parser/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "The parser parses data strings, e.g. as found in barcodes, into a set of key-value mappings. In this guide, you will know briefly how to use a parser and what types of parser are currently supported by Scandit. These data formats are supported: , and , , .                                                    "
+description: "Use the Scandit parser in React Native to turn barcode data strings into key-value fields, including formats such as HIBC."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/react-native/scanning-composite-codes.mdx
+++ b/docs/sdks/react-native/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your React Native app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/react-native/single-scanning.md
+++ b/docs/sdks/react-native/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your React Native app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/react-native/sparkscan/advanced.md
+++ b/docs/sdks/react-native/sparkscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are some cases where you might want to customize the behavior of SparkScan. This guide will show you how to add additional capabilities and further customize SparkScan to best fit your needs.                                                     "
+description: "Advanced SparkScan settings for React Native: customize the UI, scanning behavior, and feedback beyond the defaults."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/react-native/sparkscan/get-started.md
+++ b/docs/sdks/react-native/sparkscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add SparkScan to your application. The general steps are:                                                                                  "
+description: "Add SparkScan to your React Native app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 
 sidebar_position: 2
 framework: react

--- a/docs/sdks/react-native/sparkscan/intro.md
+++ b/docs/sdks/react-native/sparkscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.                                                       "
+description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any React Native app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/react-native/system-requirements.mdx
+++ b/docs/sdks/react-native/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on React Native: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/titanium/add-sdk.md
+++ b/docs/sdks/titanium/add-sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to integrating the Scandit Data Capture SDK into your project."
+description: "Add the Scandit Data Capture SDK to your Titanium project: dependencies, license key, and camera permissions."
 
 sidebar_position: 1
 toc_max_heading_level: 4

--- a/docs/sdks/titanium/barcode-capture/get-started.md
+++ b/docs/sdks/titanium/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Capture to your application.                                                                                     "
+description: "Add Barcode Capture to your Titanium app: configure the mode, set up the camera and view, and handle scanned barcodes."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/titanium/barcode-symbologies.mdx
+++ b/docs/sdks/titanium/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/titanium/core-concepts.mdx
+++ b/docs/sdks/titanium/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/titanium/extension-codes.mdx
+++ b/docs/sdks/titanium/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Titanium app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/titanium/matrixscan-ar/intro.md
+++ b/docs/sdks/titanium/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan AR is not available on the Titanium SDK."
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Titanium app."
 displayed_sidebar: titaniumSidebar
 ---
 

--- a/docs/sdks/titanium/matrixscan-ar/intro.md
+++ b/docs/sdks/titanium/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Titanium app."
+description: "MatrixScan AR is not available on the Titanium SDK."
 displayed_sidebar: titaniumSidebar
 ---
 

--- a/docs/sdks/titanium/matrixscan/get-started.md
+++ b/docs/sdks/titanium/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan is not available on the Titanium SDK."
+description: "Add MatrixScan to your Titanium app to detect, track, and highlight multiple barcodes in the same frame."
 displayed_sidebar: titaniumSidebar
 ---
 

--- a/docs/sdks/titanium/matrixscan/get-started.md
+++ b/docs/sdks/titanium/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "Add MatrixScan to your Titanium app to detect, track, and highlight multiple barcodes in the same frame."
+description: "MatrixScan is not available on the Titanium SDK."
 displayed_sidebar: titaniumSidebar
 ---
 

--- a/docs/sdks/titanium/matrixscan/intro.md
+++ b/docs/sdks/titanium/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan is not available on the Titanium SDK."
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Titanium app."
 displayed_sidebar: titaniumSidebar
 ---
 

--- a/docs/sdks/titanium/matrixscan/intro.md
+++ b/docs/sdks/titanium/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Titanium app."
+description: "MatrixScan is not available on the Titanium SDK."
 displayed_sidebar: titaniumSidebar
 ---
 

--- a/docs/sdks/titanium/scanning-composite-codes.mdx
+++ b/docs/sdks/titanium/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Titanium app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/titanium/single-scanning.md
+++ b/docs/sdks/titanium/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your Titanium app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/titanium/system-requirements.mdx
+++ b/docs/sdks/titanium/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on Titanium: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/web/add-sdk.md
+++ b/docs/sdks/web/add-sdk.md
@@ -1,5 +1,5 @@
 ---
-description: "This page describes how to integrate the Scandit Data Capture SDK into your web project. You can consume the Scandit Data Capture SDK Web packages in two ways:                                                                        "
+description: "Add the Scandit Data Capture SDK to your Web project: dependencies, license key, and camera permissions."
 
 sidebar_position: 1
 toc_max_heading_level: 3

--- a/docs/sdks/web/agent-skills.mdx
+++ b/docs/sdks/web/agent-skills.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent Skills
-description: Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Web directly from your coding agent (Claude Code, Codex, Cursor, and more).
+description: "Install Scandit Agent Skills to integrate, debug, and customize the Data Capture SDK for Web from your coding agent (Claude Code, Codex)."
 toc_max_heading_level: 3
 framework: web
 keywords:

--- a/docs/sdks/web/barcode-capture/get-started.md
+++ b/docs/sdks/web/barcode-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Barcode Capture to your application."
+description: "Add Barcode Capture to your Web app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
 framework: web

--- a/docs/sdks/web/barcode-symbologies.mdx
+++ b/docs/sdks/web/barcode-symbologies.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page details the different barcode symbologies and their use cases."
+description: "Reference of the barcode symbologies the Scandit Data Capture SDK supports, with guidance on when to use each."
 sidebar_label: 'Barcode Symbologies'
 title: 'Barcode Symbologies'
 ---

--- a/docs/sdks/web/batch-scanning.md
+++ b/docs/sdks/web/batch-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "Batch scanning enables you to capture and interact with multiple barcodes simultaneously, making it ideal for inventory management, retail, and logistics applications."
+description: "Scan and process many barcodes in one session in your Web app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 
 

--- a/docs/sdks/web/core-concepts.mdx
+++ b/docs/sdks/web/core-concepts.mdx
@@ -1,5 +1,5 @@
 ---
-description: "This page gives an overview of the core concepts and terms used in the Scandit Data Capture SDK."
+description: "Core concepts of the Scandit Data Capture SDK: the data capture context, capture modes, views, and the scanning flow."
 sidebar_label: 'Core Concepts'
 title: 'Core Concepts'
 ---

--- a/docs/sdks/web/extension-codes.mdx
+++ b/docs/sdks/web/extension-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Add-on Codes"
+description: "Read barcode extension (add-on) codes in your Web app with the Scandit Data Capture SDK."
 sidebar_label: 'Add-on Codes'
 title: 'Add-on Codes'
 ---

--- a/docs/sdks/web/id-capture/advanced.md
+++ b/docs/sdks/web/id-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "There are several advanced configurations that can be used to customize the behavior of the ID Capture SDK and enable additional features.                                                                              "
+description: "Advanced ID Capture settings for Web: configure document types, extracted fields, and verification."
 
 sidebar_position: 4
 pagination_next: null

--- a/docs/sdks/web/id-capture/get-started.md
+++ b/docs/sdks/web/id-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "This page will guide you through the process of adding ID Capture to your Web application. ID Capture is a mode of the Scandit Data Capture SDK that allows you to capture and extract information from personal identification documents, such as driver's licenses, passports, and ID cards.                                                     "
+description: "Add ID Capture to your web app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
 framework: web

--- a/docs/sdks/web/id-capture/intro.md
+++ b/docs/sdks/web/id-capture/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutIdCapture from '../../../partials/intro/_about-id-capture.mdx';                                                                                                "
+description: "ID Capture scans and extracts data from identity documents such as passports and driver's licenses in your Web app."
 
 sidebar_label: About ID Capture
 title: About ID Capture

--- a/docs/sdks/web/id-capture/supported-documents.md
+++ b/docs/sdks/web/id-capture/supported-documents.md
@@ -1,5 +1,5 @@
 ---
-description: "Scandit ID Capture provides various types, each designed for specific scanning workflows. These workflows can involve scanning either specific parts of a document or the entire document, including both the front and back sides. This section details the types of documents supported by each scanner type.                                                      "
+description: "Identity documents and regions supported by Scandit ID Capture on Web, and the data each returns."
 
 sidebar_label: Supported Documents
 title: Supported Documents

--- a/docs/sdks/web/label-capture/advanced.md
+++ b/docs/sdks/web/label-capture/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "Guide to customizing overlays in the Scandit Web Label Capture SDK."
+description: "Customize Smart Label Capture overlays on Web by implementing a LabelCaptureBasicOverlayListener."
 sidebar_position: 3
 pagination_next: null
 framework: web

--- a/docs/sdks/web/label-capture/get-started.md
+++ b/docs/sdks/web/label-capture/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add Smart Label Capture to your application."
+description: "Add Smart Label Capture to your Web app to scan labels that combine barcodes and text in a single step."
 sidebar_position: 2
 framework: web
 keywords:

--- a/docs/sdks/web/label-capture/label-definitions.md
+++ b/docs/sdks/web/label-capture/label-definitions.md
@@ -1,5 +1,5 @@
 ---
-description: "A **Label Definition** is a configuration that defines the label, and its relevant fields, that Smart Label Capture should recognize and extract during scans."
+description: "Define label layouts for Smart Label Capture on Web: the barcodes and text fields to extract."
 framework: web
 toc_max_heading_level: 4
 keywords:

--- a/docs/sdks/web/matrixscan-ar/get-started.md
+++ b/docs/sdks/web/matrixscan-ar/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan AR to your application. Implementing MatrixScan AR involves two primary elements:                                                                              "
+description: "Add MatrixScan AR to your Web app: set up the view and the overlays that guide users to the right items."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/web/matrixscan-ar/intro.md
+++ b/docs/sdks/web/matrixscan-ar/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScanCheck from '../../../partials/intro/_about-matrixscan-ar.mdx'                                                                                                "
+description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your Web app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/web/matrixscan-find/advanced.md
+++ b/docs/sdks/web/matrixscan-find/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "MatrixScan Find is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are multiple advanced settings available to further customize MatrixScan Find to best fit your needs.                                                                     "
+description: "Advanced MatrixScan Find settings for Web: customize matching, overlays, and search behavior."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/web/matrixscan-find/get-started.md
+++ b/docs/sdks/web/matrixscan-find/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan Find to your application. Implementing MatrixScan Find involves two primary elements:                                                                              "
+description: "Add MatrixScan Find to your Web app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/web/matrixscan-find/intro.md
+++ b/docs/sdks/web/matrixscan-find/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutFind from '../../../partials/intro/_about-matrixscan-find.mdx'                                                                                                "
+description: "MatrixScan Find helps users locate specific items in your Web app by highlighting matches in the camera feed."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/web/matrixscan/advanced.md
+++ b/docs/sdks/web/matrixscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "In the previous section we covered how to vizualize the scan process using the `BarcodeBatchBasicOverlay`. In this section we will cover how to add custom AR overlays to your MatrixScan application.                                                                     "
+description: "Advanced MatrixScan settings for Web: tune tracking, overlays, and scanning performance."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/web/matrixscan/get-started.md
+++ b/docs/sdks/web/matrixscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add MatrixScan to your application.                                                                                      "
+description: "Add MatrixScan to your Web app to detect, track, and highlight multiple barcodes in the same frame."
 
 sidebar_position: 2
 pagination_next: null

--- a/docs/sdks/web/matrixscan/intro.md
+++ b/docs/sdks/web/matrixscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "import AboutMatrixScan from '../../../partials/intro/_about-matrixscan.mdx'                                                                                                "
+description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your Web app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/web/parser/get-started.md
+++ b/docs/sdks/web/parser/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "The Parser parses data strings (as found in barcodes) into a set of key-value mappings. These data formats are supported:                                                                                "
+description: "Use the Scandit parser in your Web app to turn barcode data strings into key-value fields, including formats such as HIBC."
 
 sidebar_position: 2
 pagination_prev: null

--- a/docs/sdks/web/scanning-composite-codes.mdx
+++ b/docs/sdks/web/scanning-composite-codes.mdx
@@ -1,5 +1,5 @@
 ---
-description: "Composite Codes"
+description: "Scan composite codes that combine linear and 2D components in your Web app with the Scandit Data Capture SDK."
 sidebar_label: 'Composite Codes'
 title: 'Composite Codes'
 ---

--- a/docs/sdks/web/single-scanning.md
+++ b/docs/sdks/web/single-scanning.md
@@ -1,5 +1,5 @@
 ---
-description: "import SingleScanning from '../../partials/_single-scanning.mdx';                                                                                                "
+description: "Scan a single barcode at a time in your Web app with the Scandit Data Capture SDK."
 
 toc_max_heading_level: 4
 pagination_prev: null

--- a/docs/sdks/web/sparkscan/advanced.md
+++ b/docs/sdks/web/sparkscan/advanced.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is optimized by default for efficiency, accuracy, and a seamless user experience. However, there are some cases where you might want to customize the behavior of SparkScan. This guide will show you how to add additional capabilities and further customize SparkScan to best fit your needs.                                                     "
+description: "Advanced SparkScan settings for Web: customize the UI, scanning behavior, and feedback beyond the defaults."
 
 sidebar_position: 3
 pagination_next: null

--- a/docs/sdks/web/sparkscan/get-started.md
+++ b/docs/sdks/web/sparkscan/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "In this guide you will learn step-by-step how to add SparkScan to your application. The general steps are:                                                                                  "
+description: "Add SparkScan to your Web app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 
 sidebar_position: 2
 framework: web

--- a/docs/sdks/web/sparkscan/intro.md
+++ b/docs/sdks/web/sparkscan/intro.md
@@ -1,5 +1,5 @@
 ---
-description: "SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.                                                       "
+description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any Web app."
 
 sidebar_position: 1
 pagination_prev: null

--- a/docs/sdks/web/system-requirements.mdx
+++ b/docs/sdks/web/system-requirements.mdx
@@ -1,5 +1,5 @@
 ---
-description: "System Requirements"
+description: "System requirements for the Scandit Data Capture SDK on Web: supported OS versions, devices, and build tooling."
 sidebar_label: 'System Requirements'
 title: 'System Requirements'
 ---

--- a/docs/sdks/web/webview.md
+++ b/docs/sdks/web/webview.md
@@ -1,5 +1,5 @@
 ---
-description: "Learn how to use the Scandit Web SDK inside a native WebView on Android and iOS, including how to correctly handle camera permissions."
+description: "Run the Scandit Web SDK inside a native WebView on Android and iOS, with the host app delegating camera permissions."
 sidebar_position: 2
 framework: web
 keywords:


### PR DESCRIPTION
Replace missing, over-long (>150), truncated, and broken descriptions across current-version pages with concrete, faithful, <=150-char descriptions in Google style (no fabricated metrics). These descriptions feed SEO snippets and the llms.txt export, which previously carried broken fragments, leaked import statements, and truncated text.

- ~400 pages updated
- Fix leaked MDX imports and copy-paste errors (base MatrixScan wrongly labeled as AR; wrong SDK/class names on label-capture advanced pages)
- Redirect empty orphan docs/hosted/id-bolt/session.md to id-bolt/api-overview
- Add frontmatter to docs/sdks/android/agents-android.md

Verified: frontmatter validation passes, npm run build succeeds, 0 llms.txt truncation.