### PR TITLE
Make homepage header Agent Skills button framework-aware

### DIFF
--- a/src/components/HomePage/Header/Header.tsx
+++ b/src/components/HomePage/Header/Header.tsx
@@ -1,11 +1,29 @@
+import React from "react";
 import style from "./Header.module.css";
 import logo from "../../../../static/img/logo-dark.svg";
 import { Logo } from "../../IconComponents";
 import Sparkles from "../../IconComponents/Sparkles";
 import Link from "@docusaurus/Link";
 import ThemeBtn from "../../ThemeBtn/ThemeBtn";
+import { resolveAgentSkillsUrl } from "../../utils/frameworks";
 
 export default function Header() {
+  // The homepage swaps frameworks via history.pushState (no router update), so a
+  // statically-rendered href would go stale and always point at iOS. Resolve the
+  // Agent Skills target from the live URL + localStorage at click time, matching
+  // the shared Agent Skills banner's behavior. The rendered href stays the iOS
+  // default so SSR and first client render agree (no hydration mismatch); the
+  // handlers below correct it before the browser navigates.
+  const refreshHref: React.ReactEventHandler<HTMLAnchorElement> = (e) => {
+    e.currentTarget.href = resolveAgentSkillsUrl();
+  };
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = (e) => {
+    if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+      return;
+    }
+    e.preventDefault();
+    window.location.assign(resolveAgentSkillsUrl());
+  };
   return (
     <header className={style.header}>
       <h1 className={style.hiddenText}>Scandit</h1>
@@ -24,7 +42,13 @@ export default function Header() {
           Sign Up
         </Link>
         <span className={style.delimiter}></span>
-        <Link className={style.btnSkills} to="/sdks/ios/agent-skills">
+        <Link
+          className={style.btnSkills}
+          to="/sdks/ios/agent-skills"
+          onClick={handleClick}
+          onMouseDown={refreshHref}
+          onFocus={refreshHref}
+        >
           <Sparkles iconClass={style.skillsIcon}/><span>Agent Skills</span>
         </Link>
         <ThemeBtn />

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -3,7 +3,13 @@ import { useLocation } from '@docusaurus/router';
 
 import skillsData from '@site/src/data/skills.json';
 import productsData from '@site/src/data/products.json';
-import { parseSdksRoute, frameworkToSlug, FRAMEWORK_STORAGE_KEY } from '../utils/frameworks';
+import {
+  parseSdksRoute,
+  frameworkToSlug,
+  QUERY_FRAMEWORK_TO_PATH,
+  normalizeFrameworkQuery,
+  resolveAgentSkillsUrl,
+} from '../utils/frameworks';
 import { capturePostHogEvent } from './analytics';
 import InstallTabs from './InstallTabs';
 import styles from './styles.module.css';
@@ -55,36 +61,6 @@ const FRAMEWORK_SLUG: Record<string, string> = {
   '.NET Android': 'net-android',
 };
 
-// Maps the ?framework= query slug used on the homepage to an agent-skills URL path.
-const QUERY_FRAMEWORK_TO_PATH: Record<string, string> = {
-  ios: 'ios',
-  android: 'android',
-  web: 'web',
-  cordova: 'cordova',
-  capacitor: 'capacitor',
-  flutter: 'flutter',
-  'react-native': 'react-native',
-  'net-ios': 'net/ios',
-  'net-android': 'net/android',
-};
-
-// The homepage framework selector uses its own identifiers (see
-// frameworkCardsArr) that differ from the QUERY_FRAMEWORK_TO_PATH keys. Map
-// them so ?framework=react / netIos / netAndroid resolve correctly.
-const HOMEPAGE_FRAMEWORK_ALIASES: Record<string, string> = {
-  react: 'react-native',
-  netios: 'net-ios',
-  netandroid: 'net-android',
-};
-
-// Normalizes a raw ?framework= value to a QUERY_FRAMEWORK_TO_PATH key, or ''
-// when it maps to no agent-skills page.
-function normalizeFrameworkQuery(raw: string): string {
-  const lower = (raw || '').toLowerCase();
-  const aliased = HOMEPAGE_FRAMEWORK_ALIASES[lower] || lower;
-  return QUERY_FRAMEWORK_TO_PATH[aliased] ? aliased : '';
-}
-
 // Resolves the framework for the shared callout, preferring the framework in
 // the current path (so "More info" keeps the reader on the framework they are
 // already browsing), then the ?framework= query used by the homepage banner,
@@ -100,24 +76,6 @@ function getSharedFrameworkSlug(pathname: string, search: string): string {
 function getSharedMoreInfoUrl(pathname: string, search: string): string {
   const path = QUERY_FRAMEWORK_TO_PATH[getSharedFrameworkSlug(pathname, search)];
   return `/sdks/${path}/agent-skills`;
-}
-
-// The homepage swaps frameworks with history.pushState, which does NOT update
-// React Router — so useLocation() (and any href derived from it) goes stale.
-// For the banner we therefore resolve the selected framework from the live URL
-// and localStorage at click time instead of trusting the rendered value.
-function resolveLiveBannerMoreInfoUrl(): string {
-  if (typeof window === 'undefined') return '/sdks/ios/agent-skills';
-  const fromQuery = new URLSearchParams(window.location.search).get('framework');
-  const fromStorage = (() => {
-    try {
-      return window.localStorage.getItem(FRAMEWORK_STORAGE_KEY);
-    } catch {
-      return null;
-    }
-  })();
-  const slug = normalizeFrameworkQuery(fromQuery || fromStorage || '') || 'ios';
-  return `/sdks/${QUERY_FRAMEWORK_TO_PATH[slug]}/agent-skills`;
 }
 
 interface CalloutDetailsProps {
@@ -179,7 +137,7 @@ const SharedBody: React.FC<SharedBodyProps> = ({
   liveBanner = false,
 }) => {
   const refreshHref: React.ReactEventHandler<HTMLAnchorElement> = (e) => {
-    e.currentTarget.href = resolveLiveBannerMoreInfoUrl();
+    e.currentTarget.href = resolveAgentSkillsUrl();
   };
   const liveHandlers: React.HTMLAttributes<HTMLAnchorElement> = liveBanner
     ? {
@@ -188,7 +146,7 @@ const SharedBody: React.FC<SharedBodyProps> = ({
             return;
           }
           e.preventDefault();
-          window.location.assign(resolveLiveBannerMoreInfoUrl());
+          window.location.assign(resolveAgentSkillsUrl());
         },
         onMouseDown: refreshHref,
         onFocus: refreshHref,

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -58,3 +58,52 @@ export function parseSdksRoute(pathname: string): SdksRouteInfo {
 
   return { framework, product, lastSegment: last };
 }
+
+// Maps the ?framework= query slug used on the homepage to an agent-skills URL path.
+export const QUERY_FRAMEWORK_TO_PATH: Record<string, string> = {
+  ios: 'ios',
+  android: 'android',
+  web: 'web',
+  cordova: 'cordova',
+  capacitor: 'capacitor',
+  flutter: 'flutter',
+  'react-native': 'react-native',
+  'net-ios': 'net/ios',
+  'net-android': 'net/android',
+};
+
+// The homepage framework selector uses its own identifiers (see frameworkCardsArr)
+// that differ from the QUERY_FRAMEWORK_TO_PATH keys. Map them so
+// ?framework=react / netIos / netAndroid resolve correctly.
+const HOMEPAGE_FRAMEWORK_ALIASES: Record<string, string> = {
+  react: 'react-native',
+  netios: 'net-ios',
+  netandroid: 'net-android',
+};
+
+// Normalizes a raw ?framework= value to a QUERY_FRAMEWORK_TO_PATH key, or ''
+// when it maps to no agent-skills page.
+export function normalizeFrameworkQuery(raw: string): string {
+  const lower = (raw || '').toLowerCase();
+  const aliased = HOMEPAGE_FRAMEWORK_ALIASES[lower] || lower;
+  return QUERY_FRAMEWORK_TO_PATH[aliased] ? aliased : '';
+}
+
+// Resolves the Agent Skills URL for the framework the reader currently has
+// selected on the homepage. The homepage swaps frameworks with
+// history.pushState, which does NOT update React Router — so any href derived
+// from useLocation() (or rendered statically) goes stale. Callers on the
+// homepage should therefore resolve at click time from the live URL +
+// localStorage instead of trusting the rendered value. Falls back to iOS.
+export function resolveAgentSkillsUrl(): string {
+  if (typeof window === 'undefined') return '/sdks/ios/agent-skills';
+  const fromQuery = new URLSearchParams(window.location.search).get('framework');
+  let fromStorage: string | null = null;
+  try {
+    fromStorage = window.localStorage.getItem(FRAMEWORK_STORAGE_KEY);
+  } catch {
+    fromStorage = null;
+  }
+  const slug = normalizeFrameworkQuery(fromQuery || fromStorage || '') || 'ios';
+  return `/sdks/${QUERY_FRAMEWORK_TO_PATH[slug]}/agent-skills`;
+}


### PR DESCRIPTION
The homepage header "Agent Skills" button hardcoded to="/sdks/ios/agent-skills", so it always sent readers to the iOS page regardless of the framework they had selected on the homepage.

The homepage swaps frameworks with history.pushState, which does not update React Router, so any statically-rendered href goes stale. The shared Agent Skills banner already solved this by resolving the target from the live URL + localStorage at click time. This promotes that resolver (resolveLiveBannerMoreInfoUrl) into the shared frameworks util as resolveAgentSkillsUrl and reuses it from both the callout and the header, so the header button now routes to the selected framework's agent-skills page and falls back to iOS only as a last resort.