### PR TITLE
docs(android): advertise the upcoming ScanditDesign library [SDC-33034]

### DIFF
--- a/src/components/DesignLibraryNotice/index.tsx
+++ b/src/components/DesignLibraryNotice/index.tsx
@@ -3,24 +3,32 @@ import { useLocation } from "@docusaurus/router";
 import styles from "./styles.module.css";
 
 /**
- * Advance notice, rendered under the breadcrumbs of every Android SDK page,
- * that 8.6 introduces the ScanditDesign library.
+ * Advance notice that 8.6 introduces the ScanditDesign library, rendered under
+ * the breadcrumbs of the two Android pages where a reader is deciding what to
+ * put in their build: the installation guide and the release notes.
  *
- * Scoped to Android because the design library is published for Android only:
- * there is no iOS/web equivalent, and the .NET Android NuGet already bundles
- * the .aar. Versioned docs (/7.6.14/..., /6.28.11/...) carry a path prefix and
- * so never match the pattern below, which keeps the notice on the current docs
- * where 8.6 is the next release.
+ * Android only because the design library is published for Android only: there
+ * is no iOS/web equivalent, and the .NET Android NuGet already bundles the
+ * .aar. The paths below are exact, so the versioned copies of the same pages
+ * (/7.6.14/sdks/android/add-sdk, ...) don't match either — the notice belongs
+ * on the current docs, where 8.6 is the next release.
  *
  * Remove this component (and its render site in theme/DocItem/Layout) once 8.6
  * ships and the requirement is documented in the internal dependencies table.
  */
-const ANDROID_DOCS_PATH = /^\/sdks\/android(\/|$)/;
+const NOTICE_PATHS = new Set([
+  "/sdks/android/add-sdk",
+  "/sdks/android/release-notes",
+]);
 
 export default function DesignLibraryNotice(): JSX.Element | null {
   const { pathname } = useLocation();
+  const route =
+    pathname.length > 1 && pathname.endsWith("/")
+      ? pathname.slice(0, -1)
+      : pathname;
 
-  if (!ANDROID_DOCS_PATH.test(pathname)) {
+  if (!NOTICE_PATHS.has(route)) {
     return null;
   }
 

--- a/src/components/DesignLibraryNotice/index.tsx
+++ b/src/components/DesignLibraryNotice/index.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { useLocation } from "@docusaurus/router";
+import styles from "./styles.module.css";
+
+/**
+ * Advance notice, rendered under the breadcrumbs of every Android SDK page,
+ * that 8.6 introduces the ScanditDesign library.
+ *
+ * Scoped to Android because the design library is published for Android only:
+ * there is no iOS/web equivalent, and the .NET Android NuGet already bundles
+ * the .aar. Versioned docs (/7.6.14/..., /6.28.11/...) carry a path prefix and
+ * so never match the pattern below, which keeps the notice on the current docs
+ * where 8.6 is the next release.
+ *
+ * Remove this component (and its render site in theme/DocItem/Layout) once 8.6
+ * ships and the requirement is documented in the internal dependencies table.
+ */
+const ANDROID_DOCS_PATH = /^\/sdks\/android(\/|$)/;
+
+export default function DesignLibraryNotice(): JSX.Element | null {
+  const { pathname } = useLocation();
+
+  if (!ANDROID_DOCS_PATH.test(pathname)) {
+    return null;
+  }
+
+  return (
+    <aside className={styles.notice}>
+      <p className={styles.title}>Coming in 8.6</p>
+      <p className={styles.body}>
+        The Scandit Data Capture SDK will require a new{" "}
+        <strong>ScanditDesign</strong> library (
+        <code>com.scandit.datacapture:design</code>), which provides the UI
+        components used by the SDK&apos;s views.
+      </p>
+      <p className={styles.body}>
+        Gradle and Maven integrations pull it in automatically; if you add the{" "}
+        <code>.aar</code> files to your project directly, you will need to add{" "}
+        <code>ScanditDesign.aar</code> yourself.
+      </p>
+    </aside>
+  );
+}

--- a/src/components/DesignLibraryNotice/styles.module.css
+++ b/src/components/DesignLibraryNotice/styles.module.css
@@ -1,0 +1,62 @@
+/* Box geometry and colors follow the site's warning admonition
+   (src/css/components/doc-admonition.scss) so this reads as the same kind of
+   yellow bubble; the type scale follows the Agent Skills callout
+   (src/components/SkillsCallout/styles.module.css) so titles and body text
+   match the other boxes. No left accent bar — the docs' bubbles don't use one. */
+.notice {
+  display: block;
+  margin: 0 0 1.5rem 0;
+  padding: 17px 20px;
+  border-radius: 10px;
+  background: var(--light-yellow-40);
+  border: 1px solid var(--light-yellow-80);
+  font-family: var(--font-family, inherit);
+}
+
+.title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.body {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.65;
+}
+
+.body + .body {
+  margin-top: 0.5rem;
+}
+
+.notice code {
+  padding: 0.1rem 0.35rem;
+  background: var(--light-yellow-60);
+  color: var(--light-yellow-120);
+  border: 1px solid var(--light-yellow-80);
+  border-radius: 4px;
+  font-family: var(
+    --third-family,
+    ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Consolas,
+    monospace
+  );
+  font-size: 0.9375rem;
+  vertical-align: baseline;
+}
+
+/* The --light-yellow-* variables are themselves redefined for the dark theme
+   (see custom.scss), so only the container's text color needs an override,
+   matching what doc-admonition.scss does for warning admonitions. */
+html[data-theme="dark"] .notice {
+  background: var(--dark-brown-80);
+  border-color: var(--dark-brown-60);
+  color: var(--dark-brown-40);
+}
+
+html[data-theme="dark"] .notice code {
+  background: var(--dark-brown-100);
+  border-color: var(--dark-brown-60);
+}

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -12,11 +12,14 @@ import DocItemContent from "@theme/DocItem/Content";
 import DocBreadcrumbs from "@theme/DocBreadcrumbs";
 import Unlisted from "@theme/Unlisted";
 import FrameworkSelectorMobile from "@site/src/components/FrameworkSelectorMobile";
+import DesignLibraryNotice from "@site/src/components/DesignLibraryNotice";
 import styles from "./styles.module.css";
 
 /**
- * Swizzled (copy of the stock component) only to render the mobile
- * framework/version selector above the "On this page" mobile TOC.
+ * Swizzled (copy of the stock component) to render the mobile
+ * framework/version selector above the "On this page" mobile TOC, and the
+ * ScanditDesign advance notice under the breadcrumbs (the notice picks its own
+ * pages; see the component).
  */
 function useDocTOC() {
   const { frontMatter, toc } = useDoc();
@@ -48,6 +51,7 @@ export default function DocItemLayout({ children }) {
         <div className={styles.docItemContainer}>
           <article>
             <DocBreadcrumbs />
+            <DesignLibraryNotice />
             <DocVersionBadge />
             <FrameworkSelectorMobile />
             {docTOC.mobile}


### PR DESCRIPTION
[SDC-33034](https://scandit.atlassian.net/browse/SDC-33034)

8.6 introduces a new **ScanditDesign** library (`com.scandit.datacapture:design`) that `ScanditCaptureCore` depends on. Gradle and Maven consumers get it transitively from the published POM, but manual `.aar` integrations have to add `ScanditDesign.aar` themselves — otherwise resource linking fails, or `DependencyChecker` throws at SDK init. This PR gives those users advance warning while 8.5.x is still the current release.

## What it does

A notice rendered under the breadcrumbs of the Android **Installation** and **Release Notes** pages — the two places a reader is deciding what goes into their build:

> **Coming in 8.6**
>
> The Scandit Data Capture SDK will require a new **ScanditDesign** library (`com.scandit.datacapture:design`), which provides the UI components used by the SDK's views.
>
> Gradle and Maven integrations pull it in automatically; if you add the `.aar` files to your project directly, you will need to add `ScanditDesign.aar` yourself.

### Preview

<img width="1073" height="638" alt="Screenshot 2026-07-30 at 16 13 38" src="https://github.com/user-attachments/assets/cf8b1487-4080-4d57-b5e5-02e61430bdc5" />
<img width="1096" height="642" alt="Screenshot 2026-07-30 at 16 13 18" src="https://github.com/user-attachments/assets/d389de89-0656-4c9c-9be0-a14661d48704" />

## Follow-ups (not in this PR)

- **Remove this component at the 8.6 cut**, when #388 lands the requirement in the internal-dependencies table. There is a note to that effect in the component's doc comment.
- **8.6 release notes** still need an entry; suggested text for `### Behavioral Changes` → `#### Core`:
  > The SDK now requires the new ScanditDesign library (`com.scandit.datacapture:design`), which provides the UI components used by the SDK's views. Gradle and Maven integrations resolve it automatically as a dependency of `ScanditCaptureCore`; if you add `.aar` files to your project directly, you must also add `ScanditDesign.aar`.
- #388 edits the **shared** `_internal-deps.mdx`, which iOS, Web, React Native, Flutter, Cordova, Capacitor and .NET pages all import — worth checking there, since the module is Android-only.