### PR TITLE
docs: note Agent Skills availability on the iOS page

### DIFF
--- a/docs/sdks/ios/agent-skills.mdx
+++ b/docs/sdks/ios/agent-skills.mdx
@@ -17,4 +17,8 @@ import SkillsPage from '@site/src/components/SkillsPage';
 
 # Agent Skills for iOS
 
+:::warning Not every framework has Agent Skills
+Agent Skills aren't available for Xamarin, Titanium, or Linux. .NET has no general Agent Skills either. Choose [.NET iOS](/sdks/net/ios/agent-skills) or [.NET Android](/sdks/net/android/agent-skills) for your target platform.
+:::
+
 <SkillsPage framework="iOS" />


### PR DESCRIPTION
Add a banner to the iOS Agent Skills page clarifying that Agent Skills aren't available for Xamarin, Titanium, or Linux, and that .NET has no general skills — users must choose .NET iOS or .NET Android. Reduces confusion for developers on frameworks without Agent Skills.