### PR TITLE
feat: hide product-picker banner for frameworks without Agent Skills

### DIFF
--- a/docs/sdks/ios/agent-skills.mdx
+++ b/docs/sdks/ios/agent-skills.mdx
@@ -17,8 +17,4 @@ import SkillsPage from '@site/src/components/SkillsPage';
 
 # Agent Skills for iOS
 
-:::warning Not every framework has Agent Skills
-Agent Skills aren't available for Xamarin, Titanium, or Linux. .NET has no general Agent Skills either. Choose [.NET iOS](/sdks/net/ios/agent-skills) or [.NET Android](/sdks/net/android/agent-skills) for your target platform.
-:::
-
 <SkillsPage framework="iOS" />

--- a/src/components/HomePage/Frameworks/CardAdditional.tsx
+++ b/src/components/HomePage/Frameworks/CardAdditional.tsx
@@ -1,6 +1,6 @@
 import { FrameworksName } from "../../constants/frameworksName";
 import { FrameworkCardType } from "../../constants/types";
-import { FRAMEWORK_STORAGE_KEY } from "../../utils/frameworks";
+import { FRAMEWORK_STORAGE_KEY, emitFrameworkChange } from "../../utils/frameworks";
 import style from "./CardAdditional.module.css";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 
@@ -27,6 +27,7 @@ export default function CardAdditional({
     setSelectedFramework();
     handleFrameworkClick();
     localStorage.setItem(FRAMEWORK_STORAGE_KEY, framework.framework);
+    emitFrameworkChange(framework.framework);
   }
 
   return (

--- a/src/components/HomePage/Frameworks/FrameworkCard.tsx
+++ b/src/components/HomePage/Frameworks/FrameworkCard.tsx
@@ -1,6 +1,6 @@
 import { ArrowDropDown } from "../../IconComponents";
 import { FrameworksName } from "../../constants/frameworksName";
-import { FRAMEWORK_STORAGE_KEY } from "../../utils/frameworks";
+import { FRAMEWORK_STORAGE_KEY, emitFrameworkChange } from "../../utils/frameworks";
 import style from "./FrameworkCard.module.css";
 import BrowserOnly from "@docusaurus/BrowserOnly";
 
@@ -17,6 +17,7 @@ export function FrameworkCard({
       "",
       `${window.location.pathname}?framework=${frameworkValue.toString()}`
     );
+    emitFrameworkChange(frameworkValue.toString());
     !hasAdditional && handleFrameworkClick();
   }
 

--- a/src/components/HomePage/Frameworks/Frameworks.tsx
+++ b/src/components/HomePage/Frameworks/Frameworks.tsx
@@ -3,7 +3,7 @@ import { frameworkCards } from "../data/frameworkCardsArr";
 import { FrameworkCard } from "./FrameworkCard";
 import CardAdditional from "./CardAdditional";
 import { FrameworkCardType } from "../../constants/types";
-import { FRAMEWORK_STORAGE_KEY } from "../../utils/frameworks";
+import { FRAMEWORK_STORAGE_KEY, emitFrameworkChange } from "../../utils/frameworks";
 import { useEffect, useState } from "react";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
@@ -18,6 +18,7 @@ export default function Frameworks({ handleFrameworkClick }: FrameworksProps) {
     if (ExecutionEnvironment.canUseDOM) {
       window.history.pushState({}, "", `?framework=${framework.framework}`);
       localStorage.setItem(FRAMEWORK_STORAGE_KEY, framework.framework);
+      emitFrameworkChange(framework.framework);
     }
     setSelectedFramework(framework.framework);
     framework.framework !== "xamarin" &&
@@ -43,6 +44,7 @@ export default function Frameworks({ handleFrameworkClick }: FrameworksProps) {
           }`
         );
         setSelectedFramework(frameworkFromURL);
+        emitFrameworkChange(frameworkFromURL);
       }
     };
     updateSelectedFramework();

--- a/src/components/HomePage/Frameworks/FrameworksMobile.tsx
+++ b/src/components/HomePage/Frameworks/FrameworksMobile.tsx
@@ -4,6 +4,7 @@ import style from "./FrameworksMobile.module.css";
 import { frameworkCards } from "../data/frameworkCardsArr";
 import { FrameworksName } from "../../constants/frameworksName";
 import { ArrowDown } from "../../IconComponents";
+import { emitFrameworkChange } from "../../utils/frameworks";
 
 interface FrameworksMobileProps {
   handleFrameworkClick: () => void;
@@ -19,7 +20,9 @@ export default function FrameworksMobile({
 
   useEffect(() => {
     const paramsURL = Object.fromEntries(new URLSearchParams(window.location.search));
-    setSelectedFramework(paramsURL.framework || "web");
+    const initial = paramsURL.framework || "web";
+    setSelectedFramework(initial);
+    emitFrameworkChange(initial);
   }, []);
 
   useEffect(() => {
@@ -42,6 +45,7 @@ export default function FrameworksMobile({
 
   function selectFramework(framework: string) {
     window.history.pushState({}, "", `?framework=${framework}`);
+    emitFrameworkChange(framework);
     setSelectedFramework(framework);
     framework !== "net" && framework !== "xamarin" && handleFrameworkClick();
   }

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -9,6 +9,9 @@ import {
   QUERY_FRAMEWORK_TO_PATH,
   normalizeFrameworkQuery,
   resolveAgentSkillsUrl,
+  frameworkHasAgentSkills,
+  readSelectedFrameworkRaw,
+  FRAMEWORK_CHANGE_EVENT,
 } from '../utils/frameworks';
 import { capturePostHogEvent } from './analytics';
 import InstallTabs from './InstallTabs';
@@ -169,6 +172,53 @@ const SharedBody: React.FC<SharedBodyProps> = ({
   );
 };
 
+// Shared "product picker" banner. On the homepage the framework is chosen via
+// the selector (history.pushState), and some frameworks have no Agent Skills at
+// all — Xamarin, Titanium, Linux, and bare .NET (which needs a specific
+// platform). For those the banner has nothing to offer, so it hides itself.
+// Visibility is derived from frameworkHasAgentSkills(), so it stays correct
+// automatically if a framework later gains a skills page.
+const SharedCallout: React.FC<{ banner: boolean }> = ({ banner }) => {
+  const { pathname, search } = useLocation();
+  // Start visible so SSR and the first client render agree (no hydration
+  // mismatch); correct on mount and on every subsequent framework change.
+  const [visible, setVisible] = React.useState(true);
+
+  React.useEffect(() => {
+    const update = () =>
+      setVisible(frameworkHasAgentSkills(readSelectedFrameworkRaw()));
+    update();
+    window.addEventListener(FRAMEWORK_CHANGE_EVENT, update);
+    window.addEventListener('popstate', update);
+    return () => {
+      window.removeEventListener(FRAMEWORK_CHANGE_EVENT, update);
+      window.removeEventListener('popstate', update);
+    };
+  }, []);
+
+  if (!visible) return null;
+
+  const sharedFrameworkSlug = getSharedFrameworkSlug(pathname, search);
+  const sharedMoreInfoUrl = getSharedMoreInfoUrl(pathname, search);
+  return (
+    <CalloutDetails
+      heading={PRODUCT_DISAMBIGUATION_HEADING}
+      banner={banner}
+      trackingProps={{
+        variant: 'shared',
+        pathname,
+        framework: sharedFrameworkSlug,
+      }}
+    >
+      <SharedBody
+        sharedFrameworkSlug={sharedFrameworkSlug}
+        sharedMoreInfoUrl={sharedMoreInfoUrl}
+        liveBanner={banner}
+      />
+    </CalloutDetails>
+  );
+};
+
 const SkillsCallout: React.FC<SkillsCalloutProps> = ({
   product,
   framework,
@@ -179,7 +229,7 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({
   frameworkSlug: frameworkSlugProp,
   moreInfoUrl: moreInfoUrlProp,
 }) => {
-  const { pathname, search } = useLocation();
+  const { pathname } = useLocation();
 
   if (variant === 'skill') {
     if (!skillSlug) return null;
@@ -211,25 +261,7 @@ const SkillsCallout: React.FC<SkillsCalloutProps> = ({
   }
 
   if (variant === 'shared') {
-    const sharedFrameworkSlug = getSharedFrameworkSlug(pathname, search);
-    const sharedMoreInfoUrl = getSharedMoreInfoUrl(pathname, search);
-    return (
-      <CalloutDetails
-        heading={PRODUCT_DISAMBIGUATION_HEADING}
-        banner={banner}
-        trackingProps={{
-          variant: 'shared',
-          pathname,
-          framework: sharedFrameworkSlug,
-        }}
-      >
-        <SharedBody
-          sharedFrameworkSlug={sharedFrameworkSlug}
-          sharedMoreInfoUrl={sharedMoreInfoUrl}
-          liveBanner={banner}
-        />
-      </CalloutDetails>
-    );
+    return <SharedCallout banner={banner} />;
   }
 
   const route = parseSdksRoute(pathname);

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -89,6 +89,55 @@ export function normalizeFrameworkQuery(raw: string): string {
   return QUERY_FRAMEWORK_TO_PATH[aliased] ? aliased : '';
 }
 
+// Event the homepage framework selectors fire when the selection changes.
+// The selectors swap frameworks with history.pushState, which fires no event,
+// so the shared Agent Skills banner can't otherwise know it changed. Both
+// selectors dispatch this; the banner listens to toggle its visibility.
+export const FRAMEWORK_CHANGE_EVENT = 'scandit:framework-change';
+
+// Reads the framework the homepage currently has selected: live ?framework=
+// query first, then localStorage. Returns the raw selector value (e.g. 'xamarin',
+// 'netIos') or '' when nothing is set.
+export function readSelectedFrameworkRaw(): string {
+  if (typeof window === 'undefined') return '';
+  const fromQuery = new URLSearchParams(window.location.search).get('framework');
+  let fromStorage: string | null = null;
+  try {
+    fromStorage = window.localStorage.getItem(FRAMEWORK_STORAGE_KEY);
+  } catch {
+    fromStorage = null;
+  }
+  return fromQuery || fromStorage || '';
+}
+
+// Homepage selector slugs the shared product-picker banner hides for, because
+// there is no Agent Skill to route to. Xamarin (and its variants), Titanium and
+// Linux have no skills at all. Bare ".NET" is also hidden: it has no general
+// skill — the reader must pick a platform — so the banner stays hidden until
+// ".NET iOS" or ".NET Android" is selected (those slugs, netios/netandroid, are
+// intentionally NOT in this set, so the banner returns for them).
+const FRAMEWORKS_WITHOUT_AGENT_SKILLS = new Set<string>([
+  'xamarin',
+  'xamarinios',
+  'xamarinandroid',
+  'xamarinforms',
+  'titanium',
+  'linux',
+  'net',
+]);
+
+// True unless the selected framework has no Agent Skills at all. Unknown/empty
+// (the default before any selection) returns true, so the banner shows by default.
+export function frameworkHasAgentSkills(raw: string): boolean {
+  return !FRAMEWORKS_WITHOUT_AGENT_SKILLS.has((raw || '').toLowerCase());
+}
+
+// Notify listeners (the shared Agent Skills banner) that the selection changed.
+export function emitFrameworkChange(framework: string): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(FRAMEWORK_CHANGE_EVENT, { detail: framework }));
+}
+
 // Resolves the Agent Skills URL for the framework the reader currently has
 // selected on the homepage. The homepage swaps frameworks with
 // history.pushState, which does NOT update React Router — so any href derived


### PR DESCRIPTION
The homepage "Not sure which Scandit product fits your use case?" banner offers to install the shared Agent Skills product-picker. For frameworks that have no Agent Skills, it points nowhere useful, so hide it there:

- Xamarin (and its iOS/Android/Forms variants), Titanium, and Linux have no skills at all.
- Bare .NET has no general skill — a platform must be chosen — so the banner stays hidden until .NET iOS or .NET Android is selected.

The banner reappears for every framework that does have skills. Because the homepage swaps frameworks via history.pushState (which fires no event), each selection path now emits a scandit:framework-change event; the banner (in SkillsCallout's shared variant) listens and toggles its visibility. All selection paths notify: the desktop card radio, the sub-framework radio (which stopPropagation'd away from the wrapper), the wrapper div, and the mobile dropdown, plus initial mount.

Also remove the iOS Agent Skills page's availability warning: now that the homepage banner hides itself for frameworks without skills, that page-level note is redundant.

Verified: npm run build passes; banner hides for Xamarin/Titanium/Linux/ bare .NET and shows for iOS/Android/Web/React Native/Flutter/Cordova/ Capacitor/.NET iOS/.NET Android.