### PR TITLE
docs: partialize SparkScan & MatrixScan Pick intros into shared SSOT blocks

### DIFF
--- a/docs/partials/intro/_about-matrixscan-pick.mdx
+++ b/docs/partials/intro/_about-matrixscan-pick.mdx
@@ -1,0 +1,33 @@
+import Link from '@docusaurus/Link';
+
+export const apiTokens = {
+  'ios': 'ios',
+  'android': 'android',
+  'capacitor': 'capacitor',
+  'cordova': 'cordova',
+  'flutter': 'flutter',
+  'react-native': 'react-native',
+  'net/ios': 'dotnet.ios',
+  'net/android': 'dotnet.android',
+};
+
+MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+
+MatrixScan Pick is implemented through functionality provided by <Link to={`https://docs.scandit.com/data-capture-sdk/${apiTokens[props.framework]}/barcode-capture/api/barcode-pick.html`}><code>BarcodePick</code></Link>.
+
+## UI Overview
+
+* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
+* It highlights items with obvious and colorful visual dots on screen.
+* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
+* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
+* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
+* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
+
+<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
+
+## Supported Symbologies
+
+MatrixScan Find supports all <Link to={`/sdks/${props.framework}/barcode-symbologies/`}>symbologies</Link> **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
+
+If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).

--- a/docs/partials/intro/_about-sparkscan.mdx
+++ b/docs/partials/intro/_about-sparkscan.mdx
@@ -1,0 +1,49 @@
+import Link from '@docusaurus/Link';
+
+SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows, such as inventory management in retail, or goods receiving in logistics.
+
+SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
+
+## UI Overview
+
+The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
+
+Two main elements compose the UI:
+
+![SparkScan UI](/img/sparkscan/features_web.png)
+
+- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
+- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
+
+There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the <Link to={`/sdks/${props.framework}/sparkscan/advanced/`}>Advanced</Link> section.
+
+## Workflow Description
+
+When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
+To start scanning, the user can simply tap on it.
+
+When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
+
+In the default configuration:
+- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
+- Tapping on the trigger button or the mini preview will restart immediately the scanner.
+
+Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
+
+If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
+
+<p align="center">
+  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
+</p>
+
+The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
+
+But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the <Link to={`/sdks/${props.framework}/sparkscan/advanced/#workflow-options`}>Workflow Options</Link> guide to discover more.
+
+## Supported Symbologies
+
+SparkScan supports all of the major symbologies listed here: <Link to={`/sdks/${props.framework}/barcode-symbologies/`}>Barcode Symbologies</Link>.
+
+## AI-Powered Features
+
+SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our <Link to={`/sdks/${props.framework}/ai-powered-barcode-scanning/`}>AI-Powered Barcode Scanning</Link> guide.

--- a/docs/sdks/android/matrixscan-pick/intro.md
+++ b/docs/sdks/android/matrixscan-pick/intro.md
@@ -10,23 +10,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/android/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tapable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* This guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="android"/>

--- a/docs/sdks/android/sparkscan/intro.md
+++ b/docs/sdks/android/sparkscan/intro.md
@@ -10,50 +10,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows, such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="android"/>

--- a/docs/sdks/capacitor/matrixscan-pick/intro.md
+++ b/docs/sdks/capacitor/matrixscan-pick/intro.md
@@ -10,23 +10,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/capacitor/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="capacitor"/>

--- a/docs/sdks/capacitor/sparkscan/intro.md
+++ b/docs/sdks/capacitor/sparkscan/intro.md
@@ -9,50 +9,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="capacitor"/>

--- a/docs/sdks/cordova/matrixscan-pick/intro.md
+++ b/docs/sdks/cordova/matrixscan-pick/intro.md
@@ -10,23 +10,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/cordova/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="cordova"/>

--- a/docs/sdks/cordova/sparkscan/intro.md
+++ b/docs/sdks/cordova/sparkscan/intro.md
@@ -10,50 +10,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="cordova"/>

--- a/docs/sdks/flutter/matrixscan-pick/intro.md
+++ b/docs/sdks/flutter/matrixscan-pick/intro.md
@@ -10,23 +10,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/flutter/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="flutter"/>

--- a/docs/sdks/flutter/sparkscan/intro.md
+++ b/docs/sdks/flutter/sparkscan/intro.md
@@ -10,50 +10,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows, such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="flutter"/>

--- a/docs/sdks/ios/matrixscan-pick/intro.md
+++ b/docs/sdks/ios/matrixscan-pick/intro.md
@@ -10,23 +10,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/ios/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="ios"/>

--- a/docs/sdks/ios/sparkscan/intro.md
+++ b/docs/sdks/ios/sparkscan/intro.md
@@ -11,50 +11,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="ios"/>

--- a/docs/sdks/net/android/matrixscan-pick/intro.md
+++ b/docs/sdks/net/android/matrixscan-pick/intro.md
@@ -9,23 +9,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/dotnet.android/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="net/android"/>

--- a/docs/sdks/net/android/sparkscan/intro.md
+++ b/docs/sdks/net/android/sparkscan/intro.md
@@ -9,50 +9,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="net/android"/>

--- a/docs/sdks/net/ios/matrixscan-pick/intro.md
+++ b/docs/sdks/net/ios/matrixscan-pick/intro.md
@@ -9,23 +9,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/dotnet.ios/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="net/ios"/>

--- a/docs/sdks/net/ios/sparkscan/intro.md
+++ b/docs/sdks/net/ios/sparkscan/intro.md
@@ -9,50 +9,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="net/ios"/>

--- a/docs/sdks/react-native/matrixscan-pick/intro.md
+++ b/docs/sdks/react-native/matrixscan-pick/intro.md
@@ -10,23 +10,6 @@ keywords:
 
 # About MatrixScan Pick
 
-MatrixScan Pick is a pre-built UI that uses augmented reality overlays to highlight specific items that need to be picked. Whereas MatrixScan AR is fully customizable, MatrixScan Pick is a pre-built solution that allows you to add a scan and pick experience with augmented reality to an existing native app, with just a few lines of code.
+import AboutMatrixScanPick from '../../../partials/intro/_about-matrixscan-pick.mdx';
 
-MatrixScan Pick is implemented through functionality provided by [`BarcodePick`](https://docs.scandit.com/data-capture-sdk/react-native/barcode-capture/api/barcode-pick.html).
-
-## UI Overview
-
-* MatrixScan Pick is inspired by the familiar paradigm of a camera, including a shutter button that the user operates in order start and pause the scanning view. The Finish button is used at any time to exit the workflow.
-* It highlights items with obvious and colorful visual dots on screen.
-* When paused, MatrixScan Pick freezes the display at the last view, even if the device is moved. The Play button transitions back to the live view.
-* Textual guidance is displayed from the beginning of the session and as the workflow progresses, informing of the user of changes in item status (i.e. Detected, Ignored, To-Pick, or Picked).
-* Status icons can be defined to provide further information to users for a given barcode. In the live view, the icons are displayed but not tappable. In the frozen view, the status icons can be tapped and expanded to provide additional textual information.
-* The Quick Start Guide takes you through the process to install the full UI. However, you can then customize it by choosing to remove any elements on the screen except for the AR overlays. This allows you to create custom UIs suitable for your own workflows.
-
-<ReactPlayer playing controls width='800' url="/img/batch-scanning/MatrixScanPick.mp4" />
-
-## Supported Symbologies
-
-MatrixScan Find supports all [symbologies](../barcode-symbologies.mdx) **except** DotCode, MaxiCode and postal codes (KIX, RM4SCC).
-
-If you are not familiar with the symbologies that are relevant for your use case, you can use capture presets that are tailored for different verticals (e.g. retail, logistics, etc.).
+<AboutMatrixScanPick framework="react-native"/>

--- a/docs/sdks/react-native/sparkscan/intro.md
+++ b/docs/sdks/react-native/sparkscan/intro.md
@@ -10,50 +10,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying additional scanning modes, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="react-native"/>

--- a/docs/sdks/web/sparkscan/intro.md
+++ b/docs/sdks/web/sparkscan/intro.md
@@ -10,50 +10,6 @@ keywords:
 
 # About SparkScan
 
-SparkScan is our pre-built smartphone scanning interface designed for high-performance barcode scanning. It fits on top of any smartphone application, providing an intuitive user interface for simple, fast and ergonomic scanning in scan-intensive workflows such as inventory management in retail, or goods receiving in logistics.
+import AboutSparkScan from '../../../partials/intro/_about-sparkscan.mdx';
 
-SparkScan bundles multiple scanning features together and addresses many common challenges associated with scanning on smart devices. It is designed to be easily integrated into any application, and can be customized to fit your specific needs.
-
-## UI Overview
-
-The UI elements in SparkScan are intentionally minimalistic, meant to be overlayed on any application without the need to adapt the existing app while offering the best user experience.
-
-Two main elements compose the UI:
-
-![SparkScan UI](/img/sparkscan/features_web.png)
-
-- **Camera preview**: A small camera preview that helps with aiming and shows scan feedback. When not in use, the camera preview is hidden. It can be expanded and hosts easy to access controls (zoom level, flash etc).
-- **Trigger button**: A large-sized, semi-transparent floating button that users can drag to position it in the most ergonomic position. When not in use, the trigger button collapses to occupy less space.
-
-There are additional UI elements available for displaying advanced scanning mode, errors, or providing feedback to the user. These are described in the [Advanced](./advanced.md) section.
-
-## Workflow Description
-
-When SparkScan is started, the UI presents just the trigger button, collapsed. The user can move the trigger button by simply dragging it around: the position of the trigger button is remembered across sessions, so the user can place the button where it's the most comfortable to use.
-To start scanning, the user can simply tap on it.
-
-When the scanner is active, the mini preview is shown. The mini preview too can be placed anywhere in the view by simply pressing on it for a little while and then dragging it around. Also the position of the mini preview is remembered across sessions, so the user can place it where it prefers (e.g. not to cover an important information at the top of the app).
-
-In the default configuration:
-- Upon scan the user will receive audio/haptic feedback confirming the scan, and the mini preview will display the scanned barcode for a small amount of time before fading away.
-- Tapping on the trigger button or the mini preview will restart immediately the scanner.
-
-Upon completing the scanning process (or to interact with the customer app layer), the user can tap in any area outside the trigger button and the mini preview. This collapses the scanner button, going back to the initial state.
-
-If instead of tapping on the trigger button the user taps and holds it pressed, he will be able to scan multiple barcodes in a row. The scanner will stop when the trigger button is released.
-
-<p align="center">
-  <img src="/img/sparkscan/workflow-example.gif" alt="SparkScan Workflow" /><br></br>List building use case using SparkScan.
-</p>
-
-The default workflow just described has been carefully designed as a result of extensive user testing and customer feedback from the field.
-
-But not all use-cases look the same, and your needs may differ for most users. That's why SparkScan comes with a set of options to configure the scanner and to best fit in the desired workflow. Check the [Workflow Options](./advanced.md#workflow-options) guide to discover more.
-
-## Supported Symbologies
-
-SparkScan supports all of the major symbologies listed here: [Barcode Symbologies](../barcode-symbologies.mdx).
-
-## AI-Powered Features
-
-SparkScan includes AI-powered scanning capabilities that enhance accuracy and user experience. These features automatically handle challenging scenarios such as avoiding unintentional scans, selecting barcodes in dense environments, scanning damaged barcodes with OCR fallback, and intelligently filtering duplicate scans. Learn more about these capabilities in our [AI-Powered Barcode Scanning](../ai-powered-barcode-scanning.md) guide.
+<AboutSparkScan framework="web"/>


### PR DESCRIPTION
Collapse the two inline "About" intros that duplicated prose across every framework into single shared partials:
  docs/partials/intro/_about-sparkscan.mdx        (9 frameworks)
  docs/partials/intro/_about-matrixscan-pick.mdx  (8 frameworks)

Their framework-relative links (the reason these resisted partializing) are resolved via a `framework` prop + @docusaurus/Link, since Docusaurus resolves a partial's relative links against the partial's own location, not the importing page. MatrixScan Pick also maps the route framework to its API-reference token (net/ios -> dotnet.ios). Linux/Titanium/Web "not available" stubs left untouched. 