### PR TITLE
 fix(search): restore the API reference to search and stop docs-version renames from breaking it

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -30,16 +30,17 @@ jobs:
       - name: Build documentation
         run: yarn build
 
-      # Compares build/search-tags.json (what this build's widget will filter on)
-      # against the live Algolia index. Catches a docs-version rename quietly
-      # dropping content out of search - see scripts/verify-search-tags.cjs.
-      # Not --strict on PRs: a crawl still catching up after a deploy warns
-      # rather than blocking unrelated work.
       # Asserts what the widget actually sends to Algolia: the API reference is
       # reachable on the served version and absent on frozen legacy versions.
       # Both failure modes are silent in production.
       - name: Test search facet filters
         run: yarn test:search-facets
 
+      # Compares build/search-tags.json (what this build's widget will filter on)
+      # against the live Algolia index. Catches a docs-version rename quietly
+      # dropping content out of search - see scripts/verify-search-tags.cjs.
+      # Not --strict on PRs: a crawl still catching up after a deploy, a release
+      # build that renames the served version, or an Algolia outage all warn
+      # rather than blocking unrelated work.
       - name: Verify search tags
         run: yarn verify:search-tags

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,3 +29,11 @@ jobs:
 
       - name: Build documentation
         run: yarn build
+
+      # Compares build/search-tags.json (what this build's widget will filter on)
+      # against the live Algolia index. Catches a docs-version rename quietly
+      # dropping content out of search - see scripts/verify-search-tags.cjs.
+      # Not --strict on PRs: a crawl still catching up after a deploy warns
+      # rather than blocking unrelated work.
+      - name: Verify search tags
+        run: yarn verify:search-tags

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -35,5 +35,11 @@ jobs:
       # dropping content out of search - see scripts/verify-search-tags.cjs.
       # Not --strict on PRs: a crawl still catching up after a deploy warns
       # rather than blocking unrelated work.
+      # Asserts what the widget actually sends to Algolia: the API reference is
+      # reachable on the served version and absent on frozen legacy versions.
+      # Both failure modes are silent in production.
+      - name: Test search facet filters
+        run: yarn test:search-facets
+
       - name: Verify search tags
         run: yarn verify:search-tags

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -42,5 +42,11 @@ jobs:
       # Not --strict on PRs: a crawl still catching up after a deploy, a release
       # build that renames the served version, or an Algolia outage all warn
       # rather than blocking unrelated work.
+      # --strict on main only. On a PR a crawl still catching up, a release build
+      # that renames the served version, or an Algolia outage must not block
+      # unrelated work; on main those same conditions are real and someone is
+      # watching. Without this the script's repeated "--strict still fails"
+      # promise was empty - THIN, transport errors and Algolia-key drift could
+      # not fail any job.
       - name: Verify search tags
-        run: yarn verify:search-tags
+        run: yarn verify:search-tags${{ github.ref == 'refs/heads/main' && ' --strict' || '' }}

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -8,6 +8,24 @@ on:
   push:
     branches:
       - main
+  # The post-crawl --strict run the search-tag gate is designed around.
+  #
+  # Every other trigger fires BEFORE the Algolia crawler has seen the deploy, so
+  # "the index has not caught up" is indistinguishable from "the index is wrong"
+  # and the gate can only warn. Once a day, hours after any merge, that ambiguity
+  # is gone: a tag still holding nothing is really holding nothing. No extra
+  # --strict wiring is needed - a scheduled run's github.ref IS refs/heads/main,
+  # so the expression on the verify step already picks it up.
+  #
+  # Without this, every condition the gate downgrades was downgraded everywhere
+  # and permanently: the release build warns, the push to main warns for the same
+  # pre-crawl reason, and an unreachable API reference would only surface on some
+  # later unrelated PR - in a green log nobody reads.
+  schedule:
+    - cron: "0 6 * * *"
+  # And so it can be run by hand right after a deploy, which is what the gate's
+  # own "re-run after the crawl" messages ask for.
+  workflow_dispatch:
 
 jobs:
   build:
@@ -39,14 +57,16 @@ jobs:
       # Compares build/search-tags.json (what this build's widget will filter on)
       # against the live Algolia index. Catches a docs-version rename quietly
       # dropping content out of search - see scripts/verify-search-tags.cjs.
-      # Not --strict on PRs: a crawl still catching up after a deploy, a release
-      # build that renames the served version, or an Algolia outage all warn
-      # rather than blocking unrelated work.
-      # --strict on main only. On a PR a crawl still catching up, a release build
-      # that renames the served version, or an Algolia outage must not block
-      # unrelated work; on main those same conditions are real and someone is
-      # watching. Without this the script's repeated "--strict still fails"
-      # promise was empty - THIN, transport errors and Algolia-key drift could
-      # not fail any job.
+      # --strict everywhere except pull requests. On a PR, a crawl still catching
+      # up after a deploy, a release build that renames the served version, or an
+      # Algolia outage must not block unrelated work; on main and on the daily
+      # schedule those same conditions are real and someone is watching. Without
+      # any --strict run the script's escape hatches were unconditional, so THIN,
+      # transport errors and Algolia-key drift could not fail any job.
+      #
+      # Safe on push-to-main even though that run is pre-crawl: the pending-release
+      # state is a fact about the index, not a severity preference, so --strict
+      # deliberately does NOT override it (see releasePending in the script). A
+      # release merge warns; it does not go red.
       - name: Verify search tags
         run: yarn verify:search-tags${{ github.ref == 'refs/heads/main' && ' --strict' || '' }}

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -129,6 +129,11 @@ const llmsIgnoreFiles: string[] = [
 // requires lastVersion to be one of the included versions, so previews follow it.
 const DOCS_LAST_VERSION = "8.5.3";
 
+// The version actually served at the root of THIS build. Preview builds only
+// build `current`, so routing a major at a frozen tag would point at pages the
+// build does not contain. Declared once: it was restated at four call sites.
+const effectiveLastVersion = isPreviewBuild ? "current" : DOCS_LAST_VERSION;
+
 const docsVersions: Record<
   string,
   {
@@ -173,11 +178,17 @@ const docVersionTag = (versionName: string): string =>
  * the index and fails the build if the crawler is retagged.
  *
  * Why this exists: while `lastVersion` was "current" the API reference happened
- * to share the guides' tag and rode along for free. Releasing 8.5.3 renamed the
- * guides' version, the shared tag stopped being shared, and ~3,200 API reference
- * pages silently dropped out of every search. Nothing failed - results just got
- * quietly worse. Listing the tag explicitly is what makes it survive the next
- * rename.
+ * to share the guides' tag and rode along for free. That stopped at e92c1b16
+ * (Release 8.6.0-beta.1), which set `lastVersion: "8.5.2"` and made `current`
+ * the unreleased beta - the guides at the root stopped emitting
+ * `docs-default-current`, the shared tag stopped being shared, and ~3,200 API
+ * reference pages silently dropped out of every search. Nothing failed; results
+ * just got quietly worse. 8.5.3 was a later patch bump, not the cause.
+ *
+ * And it is a CYCLE, not a one-off: the root-served tag moves on the
+ * production -> beta transition, on every patch during the beta window, and
+ * again on beta -> production. Listing the tag explicitly is what makes it
+ * survive each turn of that cycle.
  */
 /**
  * The API reference is published per major.minor line, at
@@ -208,11 +219,10 @@ const apiReferenceTag = (versionNumber: string): string =>
  * Both sides read the version out of what they already have: this file out of
  * docsVersions, the crawler out of the URL. Neither hard-codes one, which is the
  * point - tagging the API reference with a docs version NAME is what broke
- * search when releasing 8.5.3 renamed it.
+ * search when the 8.6.0-beta.1 release moved the root-served tag (e92c1b16).
  */
 function buildApiReferenceTags(
   versions: Record<string, { label?: string }>,
-  legacyTag: string,
   lastVersion: string,
 ): Record<string, string[]> {
   const out: Record<string, string[]> = {};
@@ -223,11 +233,6 @@ function buildApiReferenceTags(
     const tags = [
       servedAtRoot ? "api-reference-latest" : apiReferenceTag(number),
     ];
-    // Migration: until the crawler is retagged, the whole API reference still
-    // carries one legacy tag. Keep it on the served version so search works
-    // whichever change lands first; `yarn verify:search-tags` says when the new
-    // tags are populated and this line can go.
-    if (name === lastVersion) tags.push(legacyTag);
     out[docVersionTag(name)] = tags;
   }
   return out;
@@ -295,7 +300,7 @@ const versionTagByMajor = buildVersionTagByMajor(
   docsVersions,
   // Previews only build `current`, so route every major there rather than at
   // frozen tags whose pages that build does not contain.
-  isPreviewBuild ? "current" : DOCS_LAST_VERSION,
+  effectiveLastVersion,
 );
 
 /**
@@ -309,7 +314,7 @@ function searchTagsManifestPlugin() {
     async postBuild({ outDir }: { outDir: string }) {
       const { writeFile } = await import("fs/promises");
       const { join } = await import("path");
-      const lastVersion = isPreviewBuild ? "current" : DOCS_LAST_VERSION;
+      const lastVersion = effectiveLastVersion;
       await writeFile(
         join(outDir, "search-tags.json"),
         JSON.stringify(
@@ -321,7 +326,6 @@ function searchTagsManifestPlugin() {
             lastVersionTag: docVersionTag(lastVersion),
             apiReferenceTagsByVersionTag: buildApiReferenceTags(
               docsVersions,
-              docVersionTag("current"),
               lastVersion,
             ),
             versionTagByMajor,
@@ -351,8 +355,7 @@ const config: Config = {
     // reader on 6.28.11 finds the 6.28 API and never the 8.x one.
     apiReferenceTagsByVersionTag: buildApiReferenceTags(
       docsVersions,
-      docVersionTag("current"),
-      isPreviewBuild ? "current" : DOCS_LAST_VERSION,
+      effectiveLastVersion,
     ),
   },
 
@@ -654,7 +657,7 @@ const config: Config = {
           includeCurrentVersion: true,
           // See DOCS_LAST_VERSION above - declared once, next to docsVersions,
           // so the search tag derivation and the docs plugin cannot disagree.
-          lastVersion: isPreviewBuild ? "current" : DOCS_LAST_VERSION,
+          lastVersion: effectiveLastVersion,
           versions: docsVersions,
         },
         blog: false,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,7 +179,34 @@ const docVersionTag = (versionName: string): string =>
  * quietly worse. Listing the tag explicitly is what makes it survive the next
  * rename.
  */
-const ALWAYS_ON_SEARCH_TAGS: string[] = [docVersionTag("current")];
+const ALWAYS_ON_SEARCH_TAGS: string[] = [
+  // Target state: a stable tag that is not a version name, so no release can
+  // ever rename it out from under the widget. Set this in the Algolia crawler's
+  // /data-capture-sdk/** action (the `docusaurus_tag` field of the record it
+  // returns). Until that crawl lands the tag holds nothing, which the gate
+  // reports as a pending migration rather than a failure.
+  "api-reference",
+  // Current state, kept so search keeps working whichever change lands first.
+  // Drop this entry once `yarn verify:search-tags` shows api-reference
+  // populated - it is also the 8.6.0 beta's own tag, which is why it is a bad
+  // long-term home for the API reference.
+  docVersionTag("current"),
+];
+
+/**
+ * The versions on which always-on content is in scope.
+ *
+ * The API reference documents the current SDK, so a reader on 7.6.14 or 6.28.11
+ * must not get it: measured on a legacy page, pulling it in took one query from
+ * 53 hits to 73, and the 20 extra were 8.x API pages that do not apply there.
+ * Before the 8.5.3 rename this was handled by accident - the API reference
+ * shared the served version's tag, so it appeared there and nowhere else. This
+ * makes that scoping explicit instead of incidental.
+ */
+const ALWAYS_ON_SCOPE_VERSIONS = (lastVersion: string): string[] => [
+  docVersionTag(lastVersion),
+  docVersionTag("current"),
+];
 
 /**
  * Map a major version typed in a query ("v7", "sdk 6") to the tag of the version
@@ -268,6 +295,7 @@ function searchTagsManifestPlugin() {
             // The tag every page at the site root emits.
             lastVersionTag: docVersionTag(lastVersion),
             alwaysOnTags: ALWAYS_ON_SEARCH_TAGS,
+            alwaysOnScopeTags: ALWAYS_ON_SCOPE_VERSIONS(lastVersion),
             versionTagByMajor,
           },
           null,
@@ -291,8 +319,12 @@ const config: Config = {
   customFields: {
     // Major typed in a query -> tag of the version a reader is actually served.
     versionTagByMajor,
-    // Indexed content Docusaurus does not tag for us (the API reference).
+    // Indexed content Docusaurus does not tag for us (the API reference)...
     alwaysOnSearchTags: ALWAYS_ON_SEARCH_TAGS,
+    // ...and the versions it is in scope for. Off on frozen legacy versions.
+    alwaysOnScopeTags: ALWAYS_ON_SCOPE_VERSIONS(
+      isPreviewBuild ? "current" : DOCS_LAST_VERSION,
+    ),
   },
 
   // Set the production url of your site here

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -2,6 +2,8 @@ import { themes as prismThemes } from "prism-react-renderer";
 import type { Config } from "@docusaurus/types";
 import type * as Preset from "@docusaurus/preset-classic";
 import * as dotenv from 'dotenv';
+import * as fs from "fs";
+import * as path from "path";
 import { version } from "react";
 import remarkHideComments from "./src/plugins/remark-hide-comments";
 import remarkOffloadPreviewMedia from "./src/plugins/remark-offload-preview-media";
@@ -180,31 +182,73 @@ if (!docsVersions.current?.label) {
 }
 
 /**
- * Versions whose pages link to the UNVERSIONED API-reference tree.
- *
- * Kept out of `docsVersions` on purpose: that object goes straight to the docs
- * plugin, which rejects unknown keys ("versions.current.apiTree is not
- * allowed").
- *
- * This is a property of the CONTENT, not of which version is served. Counted in
- * the sources on 2026-08-25:
- *
- *   docs/ (current)   2258 links to /data-capture-sdk,     0 versioned
- *   version-8.5.3     2258 links to /data-capture-sdk,     0 versioned
- *   version-7.6.14       0 unversioned, 2883 to /7.6/data-capture-sdk
- *   version-6.28.11      0 unversioned, 3430 to /6.28/data-capture-sdk
+ * Which API-reference tree a docs version's pages link to - READ OUT OF THAT
+ * VERSION'S SOURCES, not declared here.
  *
  * A snapshot keeps linking to the unversioned tree until the freeze process
- * rewrites it to its own line. Deriving this from `lastVersion` was right only
- * by coincidence: the moment 8.5.x stops being served, that rule emits
- * `api-reference-8.5` - a tag nothing links to and the index does not contain -
- * and 8.5 readers get an OR-branch matching zero records, which is the
- * regression this file exists to prevent.
+ * rewrites its links to its own line, so this is a property of the CONTENT and
+ * nothing else. Counted on 2026-08-26:
  *
- * When the 8.5.3 links are rewritten to /8.5/, remove it from this set;
- * `yarn verify:search-tags` then confirms api-reference-8.5 is populated.
+ *   docs/ (current)   210 files link docs.scandit.com/data-capture-sdk, 0 versioned
+ *   version-8.5.3     210 files link docs.scandit.com/data-capture-sdk, 0 versioned
+ *   version-7.6.14      0 unversioned, links docs.scandit.com/7.6/data-capture-sdk
+ *   version-6.28.11     0 unversioned, links docs.scandit.com/6.28/data-capture-sdk
+ *
+ * The two forms are mutually exclusive per version, so the scan is unambiguous.
+ *
+ * Why derived and not listed: every earlier attempt at this value was a second
+ * copy of the served version, and a copy the release script does not know about
+ * is a regression with a release date on it. Deriving it from `lastVersion` was
+ * right only by coincidence - the moment 8.5.x stops being served, that rule
+ * emits `api-reference-8.5`, a tag nothing links to and the index does not hold,
+ * and 8.5 readers get an OR-branch matching zero records. Listing the versions
+ * instead just moved the same bug: scripts/update-version.py rewrites
+ * DOCS_LAST_VERSION and the `"8.5.3":` key, so after the next release the list
+ * would still have said 8.5.3 and ~3,900 API-reference pages would have left
+ * search again. Reading the links means a release changes nothing here, and the
+ * freeze process rewriting 8.5.3's links to /8.5/ is picked up on the next build
+ * with no edit at all.
+ *
+ * Cost: one walk per version, ~185 ms total (early-exit on the first hit, so
+ * only a version that links unversioned reads its whole tree), memoised because
+ * buildApiReferenceTags runs twice per build.
  */
-const UNVERSIONED_API_TREE_VERSIONS = new Set(["current", "8.5.3"]);
+const apiLineCache = new Map<string, boolean>();
+function linksToOwnApiLine(versionName: string, number: string): boolean {
+  const cached = apiLineCache.get(versionName);
+  if (cached !== undefined) return cached;
+  // Docusaurus is always invoked from the site root.
+  const dir =
+    versionName === "current"
+      ? path.join(process.cwd(), "docs")
+      : path.join(process.cwd(), "versioned_docs", `version-${versionName}`);
+  const line = number.split(".").slice(0, 2).join(".");
+  const needle = `docs.scandit.com/${line}/data-capture-sdk`;
+  let found = false;
+  const stack = [dir];
+  while (stack.length && !found) {
+    const current = stack.pop() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue; // a version with no snapshot on disk links nothing
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (
+        /.mdx?$/i.test(entry.name) &&
+        fs.readFileSync(full, "utf8").includes(needle)
+      ) {
+        found = true;
+        break;
+      }
+    }
+  }
+  apiLineCache.set(versionName, found);
+  return found;
+}
 
 /** The only place a `docusaurus_tag` for a docs version is constructed. */
 const docVersionTag = (versionName: string): string =>
@@ -249,6 +293,25 @@ const apiReferenceTag = (versionNumber: string): string =>
  * patch during the beta window, and again on beta -> production. Deriving the
  * mapping is what makes it survive each turn.
  */
+/**
+ * The version NUMBER behind each docs-version tag.
+ *
+ * Exported so scripts/test-search-facets.cjs can check the API-tree mapping
+ * against the sources without guessing: `docs-default-current` carries no number
+ * in its name, and deriving one from `lastVersionMajor` gave "8" where the label
+ * says "8.6.0", so the test could not check /next/ at all.
+ */
+function buildVersionNumberByTag(
+  versions: Record<string, { label?: string }>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [name, cfg] of Object.entries(versions)) {
+    const number = name === "current" ? cfg.label || "" : name;
+    if (number) out[docVersionTag(name)] = number;
+  }
+  return out;
+}
+
 function buildApiReferenceTags(
   versions: Record<string, { label?: string }>,
 ): Record<string, string[]> {
@@ -257,11 +320,11 @@ function buildApiReferenceTags(
     const number = name === "current" ? cfg.label || "" : name;
     if (!number) continue;
     // Keyed off the tree this version's own pages LINK to - see
-    // UNVERSIONED_API_TREE_VERSIONS - not off which version happens to be served.
+    // linksToOwnApiLine - not off which version happens to be served.
     const tags = [
-      UNVERSIONED_API_TREE_VERSIONS.has(name)
-        ? "api-reference-latest"
-        : apiReferenceTag(number),
+      linksToOwnApiLine(name, number)
+        ? apiReferenceTag(number)
+        : "api-reference-latest",
     ];
     out[docVersionTag(name)] = tags;
   }
@@ -367,6 +430,7 @@ function searchTagsManifestPlugin() {
                 : lastVersion,
             ).split(".")[0],
             apiReferenceTagsByVersionTag: buildApiReferenceTags(docsVersions),
+            versionNumberByTag: buildVersionNumberByTag(docsVersions),
             // A preview build contains only `current`, so the gate must not
             // expect the frozen majors' tags from it.
             isPreviewBuild,
@@ -396,6 +460,7 @@ const config: Config = {
     // A docs version's tag -> the API-reference tag(s) that document it, so a
     // reader on 6.28.11 finds the 6.28 API and never the 8.x one.
     apiReferenceTagsByVersionTag: buildApiReferenceTags(docsVersions),
+    versionNumberByTag: buildVersionNumberByTag(docsVersions),
   },
 
   // Set the production url of your site here

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -179,34 +179,49 @@ const docVersionTag = (versionName: string): string =>
  * quietly worse. Listing the tag explicitly is what makes it survive the next
  * rename.
  */
-const ALWAYS_ON_SEARCH_TAGS: string[] = [
-  // Target state: a stable tag that is not a version name, so no release can
-  // ever rename it out from under the widget. Set this in the Algolia crawler's
-  // /data-capture-sdk/** action (the `docusaurus_tag` field of the record it
-  // returns). Until that crawl lands the tag holds nothing, which the gate
-  // reports as a pending migration rather than a failure.
-  "api-reference",
-  // Current state, kept so search keeps working whichever change lands first.
-  // Drop this entry once `yarn verify:search-tags` shows api-reference
-  // populated - it is also the 8.6.0 beta's own tag, which is why it is a bad
-  // long-term home for the API reference.
-  docVersionTag("current"),
-];
+/**
+ * The API reference is published per major.minor line, at
+ * /<major.minor>/data-capture-sdk/<framework>/ - /6.28/, /7.6/, /8.5/, /8.6/.
+ * So it IS versioned, and each docs version has its own.
+ */
+const apiReferenceLine = (versionNumber: string): string =>
+  versionNumber.split(".").slice(0, 2).join(".");
+
+const apiReferenceTag = (versionNumber: string): string =>
+  `api-reference-${apiReferenceLine(versionNumber)}`;
 
 /**
- * The versions on which always-on content is in scope.
+ * The API-reference tag that belongs with each docs version's own tag.
  *
- * The API reference documents the current SDK, so a reader on 7.6.14 or 6.28.11
- * must not get it: measured on a legacy page, pulling it in took one query from
- * 53 hits to 73, and the 20 extra were 8.x API pages that do not apply there.
- * Before the 8.5.3 rename this was handled by accident - the API reference
- * shared the served version's tag, so it appeared there and nowhere else. This
- * makes that scoping explicit instead of incidental.
+ * The Algolia crawler is expected to derive its tag from the URL
+ * (`/8.5/data-capture-sdk/...` -> `api-reference-8.5`), so a docs release never
+ * requires a crawler change, and a new API-reference line never requires an edit
+ * here: both sides read the version out of what they already have.
+ *
+ * That decoupling is the point. Tagging the API reference with a docs version
+ * NAME is what broke search in August 2026 - releasing 8.5.3 renamed the docs
+ * from `docs-default-current` to `docs-default-8.5.3`, the API reference kept
+ * the old name, and ~3,200 pages silently left every result.
  */
-const ALWAYS_ON_SCOPE_VERSIONS = (lastVersion: string): string[] => [
-  docVersionTag(lastVersion),
-  docVersionTag("current"),
-];
+function buildApiReferenceTags(
+  versions: Record<string, { label?: string }>,
+  legacyTag: string,
+  lastVersion: string,
+): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const [name, cfg] of Object.entries(versions)) {
+    const number = name === "current" ? cfg.label || "" : name;
+    if (!number) continue;
+    const tags = [apiReferenceTag(number)];
+    // Migration: the crawler currently stamps the whole (unversioned) API
+    // reference with one legacy tag. Keep it on the served version so search
+    // works whichever change lands first; `yarn verify:search-tags` says when
+    // the new tags are populated and this can go.
+    if (name === lastVersion) tags.push(legacyTag);
+    out[docVersionTag(name)] = tags;
+  }
+  return out;
+}
 
 /**
  * Map a major version typed in a query ("v7", "sdk 6") to the tag of the version
@@ -294,8 +309,11 @@ function searchTagsManifestPlugin() {
             defaultTag: "default",
             // The tag every page at the site root emits.
             lastVersionTag: docVersionTag(lastVersion),
-            alwaysOnTags: ALWAYS_ON_SEARCH_TAGS,
-            alwaysOnScopeTags: ALWAYS_ON_SCOPE_VERSIONS(lastVersion),
+            apiReferenceTagsByVersionTag: buildApiReferenceTags(
+              docsVersions,
+              docVersionTag("current"),
+              lastVersion,
+            ),
             versionTagByMajor,
           },
           null,
@@ -319,10 +337,11 @@ const config: Config = {
   customFields: {
     // Major typed in a query -> tag of the version a reader is actually served.
     versionTagByMajor,
-    // Indexed content Docusaurus does not tag for us (the API reference)...
-    alwaysOnSearchTags: ALWAYS_ON_SEARCH_TAGS,
-    // ...and the versions it is in scope for. Off on frozen legacy versions.
-    alwaysOnScopeTags: ALWAYS_ON_SCOPE_VERSIONS(
+    // A docs version's tag -> the API-reference tag(s) that document it, so a
+    // reader on 6.28.11 finds the 6.28 API and never the 8.x one.
+    apiReferenceTagsByVersionTag: buildApiReferenceTags(
+      docsVersions,
+      docVersionTag("current"),
       isPreviewBuild ? "current" : DOCS_LAST_VERSION,
     ),
   },

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -168,29 +168,6 @@ const docVersionTag = (versionName: string): string =>
   `docs-default-${versionName}`;
 
 /**
- * Content that lives in the same Algolia index but is NOT a Docusaurus docs
- * version, so Docusaurus never emits its tag and the contextual filter never
- * includes it. Today that is the generated API reference under
- * /data-capture-sdk/, which the Algolia crawler stamps `docs-default-current`.
- *
- * This value is owned by the Algolia crawler configuration, not by this repo, so
- * it cannot be derived here - `yarn verify:search-tags` asserts it still matches
- * the index and fails the build if the crawler is retagged.
- *
- * Why this exists: while `lastVersion` was "current" the API reference happened
- * to share the guides' tag and rode along for free. That stopped at e92c1b16
- * (Release 8.6.0-beta.1), which set `lastVersion: "8.5.2"` and made `current`
- * the unreleased beta - the guides at the root stopped emitting
- * `docs-default-current`, the shared tag stopped being shared, and ~3,200 API
- * reference pages silently dropped out of every search. Nothing failed; results
- * just got quietly worse. 8.5.3 was a later patch bump, not the cause.
- *
- * And it is a CYCLE, not a one-off: the root-served tag moves on the
- * production -> beta transition, on every patch during the beta window, and
- * again on beta -> production. Listing the tag explicitly is what makes it
- * survive each turn of that cycle.
- */
-/**
  * The API reference is published per major.minor line, at
  * /<major.minor>/data-capture-sdk/<framework>/ - /6.28/, /7.6/, /8.5/, /8.6/.
  * So it IS versioned, and each docs version has its own.
@@ -219,7 +196,15 @@ const apiReferenceTag = (versionNumber: string): string =>
  * Both sides read the version out of what they already have: this file out of
  * docsVersions, the crawler out of the URL. Neither hard-codes one, which is the
  * point - tagging the API reference with a docs version NAME is what broke
- * search when the 8.6.0-beta.1 release moved the root-served tag (e92c1b16).
+ * search when the 8.6.0-beta.1 release moved the root-served tag (e92c1b16):
+ * that release set `lastVersion: "8.5.2"` and made `current` the unreleased
+ * beta, so the guides at the root stopped emitting `docs-default-current`, the
+ * tag the API reference had been sharing for free. ~3,200 pages left search and
+ * nothing failed. 8.5.3 was a later patch bump, not the cause.
+ *
+ * And it is a CYCLE: the root-served tag moves on production -> beta, on every
+ * patch during the beta window, and again on beta -> production. Deriving the
+ * mapping is what makes it survive each turn.
  */
 function buildApiReferenceTags(
   versions: Record<string, { label?: string }>,
@@ -298,8 +283,10 @@ function buildVersionTagByMajor(
 
 const versionTagByMajor = buildVersionTagByMajor(
   docsVersions,
-  // Previews only build `current`, so route every major there rather than at
-  // frozen tags whose pages that build does not contain.
+  // Previews only build `current`, so the major CONTAINING current is routed
+  // there. Majors that exist only as frozen versions (6, 7) still resolve to
+  // their own tags, which a preview has no pages for - typing "v7" in a preview
+  // returns nothing. Accepted: previews are for reviewing the current tree.
   effectiveLastVersion,
 );
 
@@ -324,6 +311,16 @@ function searchTagsManifestPlugin() {
             defaultTag: "default",
             // The tag every page at the site root emits.
             lastVersionTag: docVersionTag(lastVersion),
+            // The major the site serves, stated rather than parsed out of the
+            // tag. When lastVersion is "current" the tag is
+            // `docs-default-current`, which carries no number, so the gate's
+            // served-major assertion silently no-opped for the entire
+            // production half of every release cycle.
+            lastVersionMajor: String(
+              lastVersion === "current"
+                ? docsVersions.current?.label || ""
+                : lastVersion,
+            ).split(".")[0],
             apiReferenceTagsByVersionTag: buildApiReferenceTags(
               docsVersions,
               lastVersion,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -193,15 +193,22 @@ const apiReferenceTag = (versionNumber: string): string =>
 /**
  * The API-reference tag that belongs with each docs version's own tag.
  *
- * The Algolia crawler is expected to derive its tag from the URL
- * (`/8.5/data-capture-sdk/...` -> `api-reference-8.5`), so a docs release never
- * requires a crawler change, and a new API-reference line never requires an edit
- * here: both sides read the version out of what they already have.
+ * This mirrors how the site actually links, which is the only thing the crawler
+ * can discover (the sitemap carries no /data-capture-sdk/ URLs at all):
  *
- * That decoupling is the point. Tagging the API reference with a docs version
- * NAME is what broke search in August 2026 - releasing 8.5.3 renamed the docs
- * from `docs-default-current` to `docs-default-8.5.3`, the API reference kept
- * the old name, and ~3,200 pages silently left every result.
+ *   - the version served at the root, and the in-development one, link to the
+ *     UNVERSIONED tree, /data-capture-sdk/... -> `api-reference-latest`
+ *   - every frozen version links to its own line,
+ *     /7.6/data-capture-sdk/... -> `api-reference-7.6`
+ *
+ * Nothing links to /8.5/data-capture-sdk/, so mapping the served version at
+ * `api-reference-8.5` would point at a tree the crawler never reaches - and the
+ * current API reference would drop out of search exactly as it did in August.
+ *
+ * Both sides read the version out of what they already have: this file out of
+ * docsVersions, the crawler out of the URL. Neither hard-codes one, which is the
+ * point - tagging the API reference with a docs version NAME is what broke
+ * search when releasing 8.5.3 renamed it.
  */
 function buildApiReferenceTags(
   versions: Record<string, { label?: string }>,
@@ -212,11 +219,14 @@ function buildApiReferenceTags(
   for (const [name, cfg] of Object.entries(versions)) {
     const number = name === "current" ? cfg.label || "" : name;
     if (!number) continue;
-    const tags = [apiReferenceTag(number)];
-    // Migration: the crawler currently stamps the whole (unversioned) API
-    // reference with one legacy tag. Keep it on the served version so search
-    // works whichever change lands first; `yarn verify:search-tags` says when
-    // the new tags are populated and this can go.
+    const servedAtRoot = name === lastVersion || name === "current";
+    const tags = [
+      servedAtRoot ? "api-reference-latest" : apiReferenceTag(number),
+    ];
+    // Migration: until the crawler is retagged, the whole API reference still
+    // carries one legacy tag. Keep it on the served version so search works
+    // whichever change lands first; `yarn verify:search-tags` says when the new
+    // tags are populated and this line can go.
     if (name === lastVersion) tags.push(legacyTag);
     out[docVersionTag(name)] = tags;
   }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -106,9 +106,29 @@ const llmsIgnoreFiles: string[] = [
   ),
 ];
 
-// Single source of truth for docs versions (consumed by the preset below and by
-// the search widget's version-routing map). `current` is the live version; its
-// major comes from `label`. Frozen versions are keyed by their version string.
+// ---------------------------------------------------------------------------
+// SINGLE SOURCE OF TRUTH: docs versions and every `docusaurus_tag` derived
+// from them.
+//
+// Docusaurus stamps each page with `docusaurus_tag: docs-<pluginId>-<versionName>`
+// built from the version NAME - the key in `docsVersions` below - and never
+// from `label` (see docVersionSearchTag in @docusaurus/theme-common). The search
+// widget filters every query on the tag of the version it is served from, so
+// each of those strings is a load-bearing identity, and a release that renames a
+// version silently changes what search can reach.
+//
+// Therefore: nothing outside this block may write a `docs-default-*` literal, and
+// nothing may restate `lastVersion`. Everything below is derived, exported through
+// `customFields`, and consumed by src/theme/SearchBar. `yarn verify:search-tags`
+// checks the derived values against the live Algolia index, because a value
+// derived correctly from the wrong assumption is still wrong.
+// ---------------------------------------------------------------------------
+
+// The version served at the site root. Must be a key of `docsVersions`.
+// Preview builds restrict `onlyIncludeVersions` to ["current"], and Docusaurus
+// requires lastVersion to be one of the included versions, so previews follow it.
+const DOCS_LAST_VERSION = "8.5.3";
+
 const docsVersions: Record<
   string,
   {
@@ -138,13 +158,42 @@ const docsVersions: Record<
   },
 };
 
-// Derive the search widget's "major version typed in a query -> docusaurus_tag"
-// map from docsVersions so it can never drift from the actual versions. The
-// crawler stamps docusaurus_tag as `docs-default-<versionName>` (current ->
-// docs-default-current). Newest patch wins per major, and `current` always
-// wins its own major. Exposed via customFields and read in SearchBar.
+/** The only place a `docusaurus_tag` for a docs version is constructed. */
+const docVersionTag = (versionName: string): string =>
+  `docs-default-${versionName}`;
+
+/**
+ * Content that lives in the same Algolia index but is NOT a Docusaurus docs
+ * version, so Docusaurus never emits its tag and the contextual filter never
+ * includes it. Today that is the generated API reference under
+ * /data-capture-sdk/, which the Algolia crawler stamps `docs-default-current`.
+ *
+ * This value is owned by the Algolia crawler configuration, not by this repo, so
+ * it cannot be derived here - `yarn verify:search-tags` asserts it still matches
+ * the index and fails the build if the crawler is retagged.
+ *
+ * Why this exists: while `lastVersion` was "current" the API reference happened
+ * to share the guides' tag and rode along for free. Releasing 8.5.3 renamed the
+ * guides' version, the shared tag stopped being shared, and ~3,200 API reference
+ * pages silently dropped out of every search. Nothing failed - results just got
+ * quietly worse. Listing the tag explicitly is what makes it survive the next
+ * rename.
+ */
+const ALWAYS_ON_SEARCH_TAGS: string[] = [docVersionTag("current")];
+
+/**
+ * Map a major version typed in a query ("v7", "sdk 6") to the tag of the version
+ * a reader on that line is actually served.
+ *
+ * Priority per major: the site's `lastVersion` first, then the newest RELEASED
+ * version, and an `unreleased` version only when nothing else covers the major.
+ * The previous rule let `current` win its major unconditionally, which was
+ * correct only while `lastVersion` was "current"; once 8.6.0-beta became current
+ * and 8.5.3 became lastVersion, "v8" routed readers at the unreleased beta's tag.
+ */
 function buildVersionTagByMajor(
-  versions: Record<string, { label?: string }>,
+  versions: Record<string, { label?: string; banner: string }>,
+  lastVersion: string,
 ): Record<string, string> {
   const comparePatch = (a: string, b: string): number => {
     const pa = a.split(".").map(Number);
@@ -154,27 +203,81 @@ function buildVersionTagByMajor(
     }
     return 0;
   };
-  const best: Record<string, { label: string; isCurrent: boolean }> = {};
-  const out: Record<string, string> = {};
+
+  type Candidate = {
+    name: string;
+    label: string;
+    isLast: boolean;
+    unreleased: boolean;
+  };
+  const byMajor: Record<string, Candidate[]> = {};
+
   for (const [name, cfg] of Object.entries(versions)) {
-    const isCurrent = name === "current";
-    const label = isCurrent ? cfg.label || "" : name;
+    // The tag comes from the name; the number a user would type comes from the
+    // label for `current` and from the name itself for frozen versions.
+    const label = name === "current" ? cfg.label || "" : name;
     const major = label.split(".")[0];
     if (!major) continue;
-    const cur = best[major];
-    if (
-      !cur ||
-      isCurrent ||
-      (!cur.isCurrent && comparePatch(label, cur.label) > 0)
-    ) {
-      best[major] = { label, isCurrent };
-      out[major] = `docs-default-${name}`;
-    }
+    (byMajor[major] = byMajor[major] || []).push({
+      name,
+      label,
+      isLast: name === lastVersion,
+      unreleased: cfg.banner === "unreleased",
+    });
+  }
+
+  const out: Record<string, string> = {};
+  for (const [major, candidates] of Object.entries(byMajor)) {
+    const winner = candidates.slice().sort(
+      (a, b) =>
+        Number(b.isLast) - Number(a.isLast) ||
+        Number(a.unreleased) - Number(b.unreleased) ||
+        comparePatch(b.label, a.label),
+    )[0];
+    out[major] = docVersionTag(winner.name);
   }
   return out;
 }
 
-const versionTagByMajor = buildVersionTagByMajor(docsVersions);
+const versionTagByMajor = buildVersionTagByMajor(
+  docsVersions,
+  // Previews only build `current`, so route every major there rather than at
+  // frozen tags whose pages that build does not contain.
+  isPreviewBuild ? "current" : DOCS_LAST_VERSION,
+);
+
+/**
+ * Writes build/search-tags.json: the docusaurus_tag values this build actually
+ * makes reachable through search. `yarn verify:search-tags` diffs it against the
+ * live Algolia index; see scripts/verify-search-tags.cjs.
+ */
+function searchTagsManifestPlugin() {
+  return {
+    name: "search-tags-manifest",
+    async postBuild({ outDir }: { outDir: string }) {
+      const { writeFile } = await import("fs/promises");
+      const { join } = await import("path");
+      const lastVersion = isPreviewBuild ? "current" : DOCS_LAST_VERSION;
+      await writeFile(
+        join(outDir, "search-tags.json"),
+        JSON.stringify(
+          {
+            lastVersion,
+            // Always in Docusaurus's contextual filter.
+            defaultTag: "default",
+            // The tag every page at the site root emits.
+            lastVersionTag: docVersionTag(lastVersion),
+            alwaysOnTags: ALWAYS_ON_SEARCH_TAGS,
+            versionTagByMajor,
+          },
+          null,
+          2,
+        ) + "\n",
+        "utf8",
+      );
+    },
+  };
+}
 
 const config: Config = {
   title: "Scandit Developer Documentation",
@@ -183,10 +286,13 @@ const config: Config = {
   favicon: "img/sdk_icon.png",
   trailingSlash: true,
 
-  // Derived from docsVersions; read by the search widget (SearchBar) to route a
-  // version typed in a query to the right docusaurus_tag without a hardcoded map.
+  // The search widget's whole view of docusaurus_tag, derived above and passed
+  // through so SearchBar never constructs one of these strings itself.
   customFields: {
+    // Major typed in a query -> tag of the version a reader is actually served.
     versionTagByMajor,
+    // Indexed content Docusaurus does not tag for us (the API reference).
+    alwaysOnSearchTags: ALWAYS_ON_SEARCH_TAGS,
   },
 
   // Set the production url of your site here
@@ -452,6 +558,10 @@ const config: Config = {
     },
   ],
   ...(isPreviewBuild ? [stripPreviewMediaPlugin] : []),
+  // Publish the exact tag set the built widget filters on, so the search-tag
+  // gate can check a real build artifact instead of re-deriving the same
+  // assumption from this file and agreeing with itself.
+  searchTagsManifestPlugin,
 ],
 
   presets: [
@@ -481,11 +591,9 @@ const config: Config = {
           },
           showLastUpdateTime: false,
           includeCurrentVersion: true,
-          // Preview builds restrict onlyIncludeVersions to just "current" above,
-          // and Docusaurus requires lastVersion to be one of the included
-          // versions — so it must follow onlyIncludeVersions here rather than
-          // staying pinned to the real released version.
-          lastVersion: isPreviewBuild ? "current" : "8.5.3",
+          // See DOCS_LAST_VERSION above - declared once, next to docsVersions,
+          // so the search tag derivation and the docs plugin cannot disagree.
+          lastVersion: isPreviewBuild ? "current" : DOCS_LAST_VERSION,
           versions: docsVersions,
         },
         blog: false,

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -134,6 +134,12 @@ const DOCS_LAST_VERSION = "8.5.3";
 // build does not contain. Declared once: it was restated at four call sites.
 const effectiveLastVersion = isPreviewBuild ? "current" : DOCS_LAST_VERSION;
 
+// `current.label` is load-bearing, not decoration: it is the only source of the
+// served major once lastVersion becomes "current", and buildApiReferenceTags
+// skips any version whose number it cannot resolve. An empty label would drop
+// /next/ readers' API reference and silently no-op the gate's served-major
+// assertion - the exact hole lastVersionMajor was added to close. Asserted at
+// config load so it fails the build rather than degrading search.
 const docsVersions: Record<
   string,
   {
@@ -162,6 +168,43 @@ const docsVersions: Record<
     badge: false,
   },
 };
+
+if (!docsVersions.current?.label) {
+  throw new Error(
+    "docsVersions.current.label is empty. It is the only source of the served " +
+      "major once lastVersion becomes \"current\", and buildApiReferenceTags " +
+      "skips a version whose number it cannot resolve - so an empty label " +
+      "silently drops /next/ readers' API reference and no-ops the gate's " +
+      "served-major check. Set it to the release the beta is heading for.",
+  );
+}
+
+/**
+ * Versions whose pages link to the UNVERSIONED API-reference tree.
+ *
+ * Kept out of `docsVersions` on purpose: that object goes straight to the docs
+ * plugin, which rejects unknown keys ("versions.current.apiTree is not
+ * allowed").
+ *
+ * This is a property of the CONTENT, not of which version is served. Counted in
+ * the sources on 2026-08-25:
+ *
+ *   docs/ (current)   2258 links to /data-capture-sdk,     0 versioned
+ *   version-8.5.3     2258 links to /data-capture-sdk,     0 versioned
+ *   version-7.6.14       0 unversioned, 2883 to /7.6/data-capture-sdk
+ *   version-6.28.11      0 unversioned, 3430 to /6.28/data-capture-sdk
+ *
+ * A snapshot keeps linking to the unversioned tree until the freeze process
+ * rewrites it to its own line. Deriving this from `lastVersion` was right only
+ * by coincidence: the moment 8.5.x stops being served, that rule emits
+ * `api-reference-8.5` - a tag nothing links to and the index does not contain -
+ * and 8.5 readers get an OR-branch matching zero records, which is the
+ * regression this file exists to prevent.
+ *
+ * When the 8.5.3 links are rewritten to /8.5/, remove it from this set;
+ * `yarn verify:search-tags` then confirms api-reference-8.5 is populated.
+ */
+const UNVERSIONED_API_TREE_VERSIONS = new Set(["current", "8.5.3"]);
 
 /** The only place a `docusaurus_tag` for a docs version is constructed. */
 const docVersionTag = (versionName: string): string =>
@@ -208,15 +251,17 @@ const apiReferenceTag = (versionNumber: string): string =>
  */
 function buildApiReferenceTags(
   versions: Record<string, { label?: string }>,
-  lastVersion: string,
 ): Record<string, string[]> {
   const out: Record<string, string[]> = {};
   for (const [name, cfg] of Object.entries(versions)) {
     const number = name === "current" ? cfg.label || "" : name;
     if (!number) continue;
-    const servedAtRoot = name === lastVersion || name === "current";
+    // Keyed off the tree this version's own pages LINK to - see
+    // UNVERSIONED_API_TREE_VERSIONS - not off which version happens to be served.
     const tags = [
-      servedAtRoot ? "api-reference-latest" : apiReferenceTag(number),
+      UNVERSIONED_API_TREE_VERSIONS.has(name)
+        ? "api-reference-latest"
+        : apiReferenceTag(number),
     ];
     out[docVersionTag(name)] = tags;
   }
@@ -321,10 +366,10 @@ function searchTagsManifestPlugin() {
                 ? docsVersions.current?.label || ""
                 : lastVersion,
             ).split(".")[0],
-            apiReferenceTagsByVersionTag: buildApiReferenceTags(
-              docsVersions,
-              lastVersion,
-            ),
+            apiReferenceTagsByVersionTag: buildApiReferenceTags(docsVersions),
+            // A preview build contains only `current`, so the gate must not
+            // expect the frozen majors' tags from it.
+            isPreviewBuild,
             versionTagByMajor,
           },
           null,
@@ -350,10 +395,7 @@ const config: Config = {
     versionTagByMajor,
     // A docs version's tag -> the API-reference tag(s) that document it, so a
     // reader on 6.28.11 finds the 6.28 API and never the 8.x one.
-    apiReferenceTagsByVersionTag: buildApiReferenceTags(
-      docsVersions,
-      effectiveLastVersion,
-    ),
+    apiReferenceTagsByVersionTag: buildApiReferenceTags(docsVersions),
   },
 
   // Set the production url of your site here

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -196,6 +196,14 @@ if (!docsVersions.current?.label) {
  *
  * The two forms are mutually exclusive per version, so the scan is unambiguous.
  *
+ * One thing this does NOT buy: the tag vocabulary is derived here, but the
+ * records come from the Algolia crawler. When 8.5.3's links are rewritten to
+ * /8.5/, this file correctly derives `api-reference-8.5` and the index will not
+ * hold it until the crawler has an action for that path. `yarn
+ * verify:search-tags` reports exactly that - WARN on PRs, FAIL on main - rather
+ * than letting 8.5 readers silently lose their API reference, but the crawler
+ * change is a real separate step, not a free consequence of the rewrite.
+ *
  * Why derived and not listed: every earlier attempt at this value was a second
  * copy of the served version, and a copy the release script does not know about
  * is a regression with a release date on it. Deriving it from `lastVersion` was
@@ -207,7 +215,7 @@ if (!docsVersions.current?.label) {
  * would still have said 8.5.3 and ~3,900 API-reference pages would have left
  * search again. Reading the links means a release changes nothing here, and the
  * freeze process rewriting 8.5.3's links to /8.5/ is picked up on the next build
- * with no edit at all.
+ * with no edit in this file.
  *
  * Cost: one walk per version, ~185 ms total (early-exit on the first hit, so
  * only a version that links unversioned reads its whole tree), memoised because

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc",
     "prepare": "husky",
     "docs:gate": "node scripts/docs-gate/index.cjs",
-    "docs:gate:setup": "node scripts/setup-vale.cjs"
+    "docs:gate:setup": "node scripts/setup-vale.cjs",
+    "verify:search-tags": "node scripts/verify-search-tags.cjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepare": "husky",
     "docs:gate": "node scripts/docs-gate/index.cjs",
     "docs:gate:setup": "node scripts/setup-vale.cjs",
-    "verify:search-tags": "node scripts/verify-search-tags.cjs"
+    "verify:search-tags": "node scripts/verify-search-tags.cjs",
+    "test:search-facets": "node scripts/test-search-facets.cjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.4.0",

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -99,8 +99,12 @@ assert.ok(MAP && Object.keys(MAP).length, "manifest has no version-tag map");
 const servedTag = manifest.lastVersionTag;
 assert.ok(MAP[servedTag], `manifest maps no API tree for the served ${servedTag}`);
 
-// Frozen versions, newest first. Asserted rather than assumed: with fewer than
-// two, the legacy-isolation checks below would silently assert on undefined.
+// Frozen versions, newest first. One is required, because the whole point of
+// these tests is that a frozen version does not get the current API reference.
+// Two are NOT required: end-of-lifing 6.28 is routine housekeeping, and failing
+// `yarn test:search-facets` with "expected at least two frozen versions" would
+// block it for a reason that has nothing to do with search correctness. The
+// second check is skipped instead.
 const frozen = Object.keys(MAP)
   .filter((t) => t !== servedTag && t !== "docs-default-current")
   .sort((a, b) => {
@@ -110,8 +114,8 @@ const frozen = Object.keys(MAP)
     return 0;
   });
 assert.ok(
-  frozen.length >= 2,
-  `expected at least two frozen versions in the manifest, got ${frozen.length}`,
+  frozen.length >= 1,
+  "expected at least one frozen version in the manifest, got none",
 );
 
 const tag = (t) => `docusaurus_tag:${t}`;
@@ -125,6 +129,16 @@ const API628 = tag(MAP[frozen[frozen.length - 1]][0]);
 
 const tagsOf = (filters) => filters.find(Array.isArray) || [];
 let passed = 0;
+let skipped = 0;
+/** Run a check only when the site's version set makes it meaningful. */
+function maybeCheck(condition, label, fn) {
+  if (!condition) {
+    skipped += 1;
+    console.log(`  --  ${label} (skipped: only one frozen version)`);
+    return;
+  }
+  check(label, fn);
+}
 function check(label, fn) {
   fn();
   passed += 1;
@@ -145,7 +159,7 @@ check("a legacy version gets ITS API reference, not the current one", () => {
   assert.ok(!tags.includes(APILATEST), "and must not get the current one");
 });
 
-check("the oldest version too", () => {
+maybeCheck(frozen.length >= 2, "the oldest version too", () => {
   const tags = tagsOf(withApiReferenceTags(["language:en", [DEFAULT, OLDEST]], MAP));
   assert.ok(tags.includes(API628) && !tags.includes(APILATEST));
 });
@@ -264,4 +278,4 @@ for (const versionTag of Object.keys(MAP)) {
   });
 }
 
-console.log(`\n${passed} passed\n`);
+console.log(`\n${passed} passed${skipped ? `, ${skipped} skipped` : ""}\n`);

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -9,7 +9,11 @@
  * Neither throws, so only an assertion catches it.
  *
  * The functions are read out of the shipped module rather than copied here - a
- * copy would keep passing after the real one changed.
+ * copy would keep passing after the real one changed. The same now goes for
+ * their INPUT: the version-tag map is read out of build/search-tags.json, the
+ * artefact the widget itself consumes. A hand-written map made this file unable
+ * to catch the one bug it exists to catch - after a release it would keep
+ * asserting against 8.5.3 while the build emitted 8.5.4, and print "passed".
  */
 const fs = require("fs");
 const path = require("path");
@@ -72,25 +76,52 @@ for (const [name, fn] of Object.entries({
   assert.strictEqual(typeof fn, "function", `${name} did not extract cleanly`);
 }
 
-const SERVED = "docusaurus_tag:docs-default-8.5.3";
-const LEGACY = "docusaurus_tag:docs-default-7.6.14";
-const OLDEST = "docusaurus_tag:docs-default-6.28.11";
-const DEFAULT = "docusaurus_tag:default";
-const APILATEST = "docusaurus_tag:api-reference-latest";
-const API76 = "docusaurus_tag:api-reference-7.6";
-const API628 = "docusaurus_tag:api-reference-6.28";
+// What THIS build derived. Written by the search-tag manifest plugin in
+// docusaurus.config.ts, so a release that renames a version renames it here too
+// and every assertion below follows automatically.
+const MANIFEST = path.join(__dirname, "..", "build", "search-tags.json");
+if (!fs.existsSync(MANIFEST)) {
+  console.error(
+    "\nbuild/search-tags.json is missing - run `yarn build` first.\n" +
+      "This test asserts against what the build actually derived; a fixture\n" +
+      "typed in here could not catch the config drifting.\n",
+  );
+  process.exit(1);
+}
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, "utf8"));
 
-// Exactly what docusaurus.config.ts derives from docsVersions.
-const MAP = {
-  // The served version maps to the unversioned tree alone. The migration shim
-  // that also pushed the legacy docs-default-current tag onto it is gone, so
-  // that tag appears here only as a KEY (the /next/ tree's own entry, below) and
-  // never as a value.
-  "docs-default-8.5.3": ["api-reference-latest"],
-  "docs-default-7.6.14": ["api-reference-7.6"],
-  "docs-default-6.28.11": ["api-reference-6.28"],
-  "docs-default-current": ["api-reference-latest"],
-};
+// The served version maps to the unversioned tree alone. The migration shim that
+// also pushed the legacy docs-default-current tag onto it is gone, so that tag
+// appears only as a KEY (the /next/ tree's own entry) and never as a value.
+const MAP = manifest.apiReferenceTagsByVersionTag;
+assert.ok(MAP && Object.keys(MAP).length, "manifest has no version-tag map");
+
+const servedTag = manifest.lastVersionTag;
+assert.ok(MAP[servedTag], `manifest maps no API tree for the served ${servedTag}`);
+
+// Frozen versions, newest first. Asserted rather than assumed: with fewer than
+// two, the legacy-isolation checks below would silently assert on undefined.
+const frozen = Object.keys(MAP)
+  .filter((t) => t !== servedTag && t !== "docs-default-current")
+  .sort((a, b) => {
+    const num = (t) => t.replace(/^docs-default-/, "").split(".").map(Number);
+    const [x, y] = [num(a), num(b)];
+    for (let i = 0; i < 3; i += 1) if ((y[i] || 0) !== (x[i] || 0)) return (y[i] || 0) - (x[i] || 0);
+    return 0;
+  });
+assert.ok(
+  frozen.length >= 2,
+  `expected at least two frozen versions in the manifest, got ${frozen.length}`,
+);
+
+const tag = (t) => `docusaurus_tag:${t}`;
+const SERVED = tag(servedTag);
+const LEGACY = tag(frozen[0]);
+const OLDEST = tag(frozen[frozen.length - 1]);
+const DEFAULT = "docusaurus_tag:default";
+const APILATEST = tag("api-reference-latest");
+const API76 = tag(MAP[frozen[0]][0]);
+const API628 = tag(MAP[frozen[frozen.length - 1]][0]);
 
 const tagsOf = (filters) => filters.find(Array.isArray) || [];
 let passed = 0;
@@ -157,5 +188,80 @@ check("no duplicate tag when the page already carries it", () => {
   const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED, APILATEST]], MAP);
   assert.strictEqual(tagsOf(out).filter((t) => t === APILATEST).length, 1);
 });
+
+// ---------------------------------------------------------------------------
+// The map itself, against the ground truth it claims to describe.
+//
+// Everything above tests how the map is USED. This tests whether the map is
+// RIGHT, and it is the check that catches the whole bug class: an API tag is
+// correct only if that version's pages actually link to that tree. Deliberately
+// implemented differently from the config's scan (count both link forms per
+// version, rather than early-exit on one) so the two cannot share a mistake.
+//
+// What this would have caught: while the mapping was a hard-coded list of
+// versions, the release script renamed DOCS_LAST_VERSION and the docsVersions
+// key but not the list, so the next release emitted api-reference-8.5 for pages
+// that link to the unversioned tree - a tag the crawler never produces, and
+// ~3,900 API-reference pages gone from search with every test still green.
+// ---------------------------------------------------------------------------
+function linkFormsIn(versionTag) {
+  const name = versionTag.replace(/^docs-default-/, "");
+  const dir =
+    name === "current"
+      ? path.join(__dirname, "..", "docs")
+      : path.join(__dirname, "..", "versioned_docs", `version-${name}`);
+  // Stated by the build. `docs-default-current` has no number in its name, so
+  // guessing one meant /next/ was never really checked.
+  const number = (manifest.versionNumberByTag || {})[versionTag];
+  assert.ok(number, `manifest states no version number for ${versionTag}`);
+  const line = number.split(".").slice(0, 2).join(".");
+  const own = `docs.scandit.com/${line}/data-capture-sdk`;
+  const unversioned = "docs.scandit.com/data-capture-sdk";
+  let ownHits = 0;
+  let unversionedHits = 0;
+  const stack = [dir];
+  while (stack.length) {
+    const current = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return null; // no snapshot on disk
+    }
+    for (const entry of entries) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) stack.push(full);
+      else if (/\.mdx?$/i.test(entry.name)) {
+        const text = fs.readFileSync(full, "utf8");
+        if (text.includes(own)) ownHits += 1;
+        if (text.includes(unversioned)) unversionedHits += 1;
+      }
+    }
+  }
+  return { ownHits, unversionedHits, line };
+}
+
+for (const versionTag of Object.keys(MAP)) {
+  check(`${versionTag} is mapped to the tree its own pages link to`, () => {
+    const forms = linkFormsIn(versionTag);
+    if (!forms) return; // version not checked out; nothing to contradict
+    const { ownHits, unversionedHits, line } = forms;
+    assert.ok(
+      ownHits === 0 || unversionedHits === 0,
+      `${versionTag} links to BOTH trees (${unversionedHits} unversioned, ` +
+        `${ownHits} to /${line}/). The config's scan early-exits on the first ` +
+        `own-line hit, which assumes these are mutually exclusive.`,
+    );
+    const expected = ownHits > 0 ? `api-reference-${line}` : "api-reference-latest";
+    assert.deepStrictEqual(
+      MAP[versionTag],
+      [expected],
+      `${versionTag}'s pages link to ${expected === "api-reference-latest" ? "the unversioned tree" : `/${line}/`}` +
+        `, so search must filter on ${expected} - the build derived ` +
+        `${JSON.stringify(MAP[versionTag])}. Readers on this version would get an ` +
+        `OR-branch matching a tag the crawler never emits.`,
+    );
+  });
+}
 
 console.log(`\n${passed} passed\n`);

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -18,6 +18,15 @@ const assert = require("assert");
 const SRC = path.join(__dirname, "..", "src", "theme", "SearchBar", "index.js");
 const src = fs.readFileSync(SRC, "utf8");
 
+/**
+ * Pull a function's source out of the module by counting braces.
+ *
+ * Deliberately naive: no string, template-literal, comment or regex awareness.
+ * It works because every brace in the extracted functions is balanced, and the
+ * assertion below turns the failure mode from a confusing SyntaxError inside
+ * eval() into a named one. If an unbalanced brace ever appears inside a string
+ * or comment in one of these functions, this is what to fix.
+ */
 function extract(name) {
   const start = src.indexOf(`function ${name}(`);
   assert.notStrictEqual(start, -1, `${name} not found in SearchBar - test is stale`);
@@ -53,6 +62,15 @@ const API_TAG_PREFIX = extractConst("API_TAG_PREFIX");
 const apiTagsFor = eval(`(${extract("apiTagsFor")})`);
 const withApiReferenceTags = eval(`(${extract("withApiReferenceTags")})`);
 const rewriteVersionTag = eval(`(${extract("rewriteVersionTag")})`);
+// Named guard for the brace-counting limitation in extract(): if any of the
+// three came back truncated, eval would have thrown something unrelated-looking.
+for (const [name, fn] of Object.entries({
+  apiTagsFor,
+  withApiReferenceTags,
+  rewriteVersionTag,
+})) {
+  assert.strictEqual(typeof fn, "function", `${name} did not extract cleanly`);
+}
 
 const SERVED = "docusaurus_tag:docs-default-8.5.3";
 const LEGACY = "docusaurus_tag:docs-default-7.6.14";
@@ -64,11 +82,10 @@ const API628 = "docusaurus_tag:api-reference-6.28";
 
 // Exactly what docusaurus.config.ts derives from docsVersions.
 const MAP = {
-  // No docs-default-current here: the migration shim that pushed the legacy tag
-  // onto the served version is gone. The crawler retag is done - the live index
-  // holds api-reference-latest with 3,407 pages and docs-default-current with a
-  // single stale record, which the gate should flag for purging rather than
-  // treat as reachable content.
+  // The served version maps to the unversioned tree alone. The migration shim
+  // that also pushed the legacy docs-default-current tag onto it is gone, so
+  // that tag appears here only as a KEY (the /next/ tree's own entry, below) and
+  // never as a value.
   "docs-default-8.5.3": ["api-reference-latest"],
   "docs-default-7.6.14": ["api-reference-7.6"],
   "docs-default-6.28.11": ["api-reference-6.28"],

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -36,15 +36,26 @@ function extract(name) {
 }
 
 const EMPTY_TAG_LIST = [];
-const withAlwaysOnTags = eval(`(${extract("withAlwaysOnTags")})`);
+const API_TAG_PREFIX = "docusaurus_tag:api-reference-";
+const apiTagsFor = eval(`(${extract("apiTagsFor")})`);
+const withApiReferenceTags = eval(`(${extract("withApiReferenceTags")})`);
 const rewriteVersionTag = eval(`(${extract("rewriteVersionTag")})`);
 
-const API = "docusaurus_tag:docs-default-current";
 const SERVED = "docusaurus_tag:docs-default-8.5.3";
 const LEGACY = "docusaurus_tag:docs-default-7.6.14";
+const OLDEST = "docusaurus_tag:docs-default-6.28.11";
 const DEFAULT = "docusaurus_tag:default";
-const alwaysOn = [API];
-const scope = [SERVED, "docusaurus_tag:docs-default-current"];
+const API85 = "docusaurus_tag:api-reference-8.5";
+const API76 = "docusaurus_tag:api-reference-7.6";
+const API628 = "docusaurus_tag:api-reference-6.28";
+
+// Exactly what docusaurus.config.ts derives from docsVersions.
+const MAP = {
+  "docs-default-8.5.3": ["api-reference-8.5", "docs-default-current"],
+  "docs-default-7.6.14": ["api-reference-7.6"],
+  "docs-default-6.28.11": ["api-reference-6.28"],
+  "docs-default-current": ["api-reference-8.6"],
+};
 
 const tagsOf = (filters) => filters.find(Array.isArray) || [];
 let passed = 0;
@@ -56,39 +67,47 @@ function check(label, fn) {
 
 console.log("\nsearch facet filters\n");
 
-check("served version pulls the API reference in", () => {
-  const out = withAlwaysOnTags(["language:en", [DEFAULT, SERVED]], alwaysOn, scope);
-  assert.ok(tagsOf(out).includes(API));
+check("served version gets its own API reference", () => {
+  const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED]], MAP);
+  assert.ok(tagsOf(out).includes(API85));
 });
 
-check("frozen legacy version does NOT pull it in", () => {
-  const out = withAlwaysOnTags(["language:en", [DEFAULT, LEGACY]], alwaysOn, scope);
-  assert.ok(!tagsOf(out).includes(API), "legacy readers must not get current-SDK API pages");
+check("a legacy version gets ITS API reference, not the current one", () => {
+  const out = withApiReferenceTags(["language:en", [DEFAULT, LEGACY]], MAP);
+  const tags = tagsOf(out);
+  assert.ok(tags.includes(API76), "7.6 reader must get the 7.6 API reference");
+  assert.ok(!tags.includes(API85), "and must not get the 8.5 one");
+});
+
+check("the oldest version too", () => {
+  const tags = tagsOf(withApiReferenceTags(["language:en", [DEFAULT, OLDEST]], MAP));
+  assert.ok(tags.includes(API628) && !tags.includes(API85));
 });
 
 check("extra tags join the OR group, never the top-level AND", () => {
-  const out = withAlwaysOnTags(["language:en", [DEFAULT, SERVED]], alwaysOn, scope);
+  const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED]], MAP);
   assert.strictEqual(out.length, 2, "a top-level entry would AND and match nothing");
   assert.ok(tagsOf(out).includes(DEFAULT) && tagsOf(out).includes(SERVED));
 });
 
-check("no duplicate tag when always-on equals the page's own tag", () => {
-  const out = withAlwaysOnTags(["language:en", [DEFAULT, API]], alwaysOn, scope);
-  assert.strictEqual(tagsOf(out).filter((t) => t === API).length, 1);
+check("an unknown version tag adds nothing rather than guessing", () => {
+  const out = withApiReferenceTags(["language:en", [DEFAULT, "docusaurus_tag:docs-default-9.9.9"]], MAP);
+  assert.ok(!tagsOf(out).some((t) => t.startsWith(API_TAG_PREFIX)));
 });
 
-check("empty scope means everywhere (back-compatible default)", () => {
-  const out = withAlwaysOnTags(["language:en", [DEFAULT, LEGACY]], alwaysOn, []);
-  assert.ok(tagsOf(out).includes(API));
-});
-
-check("typing a version swaps the page tag but keeps the API reference", () => {
-  const filters = ["language:en", [DEFAULT, SERVED, API]];
-  const out = rewriteVersionTag(filters, "docs-default-7.6.14", alwaysOn);
+check("typing a version moves the guides AND the API reference together", () => {
+  const filters = ["language:en", [DEFAULT, SERVED, API85]];
+  const out = rewriteVersionTag(filters, "docs-default-7.6.14", MAP);
   const tags = tagsOf(out);
-  assert.ok(tags.includes("docusaurus_tag:docs-default-7.6.14"), "page tag must be swapped");
-  assert.ok(tags.includes(API), "always-on tag must survive the swap");
+  assert.ok(tags.includes(LEGACY), "page tag must be swapped");
+  assert.ok(tags.includes(API76), "API reference must follow to 7.6");
+  assert.ok(!tags.includes(API85), "the 8.5 API reference must be dropped");
   assert.ok(tags.includes(DEFAULT), "the OR group must not collapse");
+});
+
+check("no duplicate tag when the page already carries it", () => {
+  const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED, API85]], MAP);
+  assert.strictEqual(tagsOf(out).filter((t) => t === API85).length, 1);
 });
 
 console.log(`\n${passed} passed\n`);

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -45,16 +45,16 @@ const SERVED = "docusaurus_tag:docs-default-8.5.3";
 const LEGACY = "docusaurus_tag:docs-default-7.6.14";
 const OLDEST = "docusaurus_tag:docs-default-6.28.11";
 const DEFAULT = "docusaurus_tag:default";
-const API85 = "docusaurus_tag:api-reference-8.5";
+const APILATEST = "docusaurus_tag:api-reference-latest";
 const API76 = "docusaurus_tag:api-reference-7.6";
 const API628 = "docusaurus_tag:api-reference-6.28";
 
 // Exactly what docusaurus.config.ts derives from docsVersions.
 const MAP = {
-  "docs-default-8.5.3": ["api-reference-8.5", "docs-default-current"],
+  "docs-default-8.5.3": ["api-reference-latest", "docs-default-current"],
   "docs-default-7.6.14": ["api-reference-7.6"],
   "docs-default-6.28.11": ["api-reference-6.28"],
-  "docs-default-current": ["api-reference-8.6"],
+  "docs-default-current": ["api-reference-latest"],
 };
 
 const tagsOf = (filters) => filters.find(Array.isArray) || [];
@@ -67,21 +67,21 @@ function check(label, fn) {
 
 console.log("\nsearch facet filters\n");
 
-check("served version gets its own API reference", () => {
+check("served version gets the unversioned tree the site links to", () => {
   const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED]], MAP);
-  assert.ok(tagsOf(out).includes(API85));
+  assert.ok(tagsOf(out).includes(APILATEST));
 });
 
 check("a legacy version gets ITS API reference, not the current one", () => {
   const out = withApiReferenceTags(["language:en", [DEFAULT, LEGACY]], MAP);
   const tags = tagsOf(out);
   assert.ok(tags.includes(API76), "7.6 reader must get the 7.6 API reference");
-  assert.ok(!tags.includes(API85), "and must not get the 8.5 one");
+  assert.ok(!tags.includes(APILATEST), "and must not get the current one");
 });
 
 check("the oldest version too", () => {
   const tags = tagsOf(withApiReferenceTags(["language:en", [DEFAULT, OLDEST]], MAP));
-  assert.ok(tags.includes(API628) && !tags.includes(API85));
+  assert.ok(tags.includes(API628) && !tags.includes(APILATEST));
 });
 
 check("extra tags join the OR group, never the top-level AND", () => {
@@ -96,18 +96,18 @@ check("an unknown version tag adds nothing rather than guessing", () => {
 });
 
 check("typing a version moves the guides AND the API reference together", () => {
-  const filters = ["language:en", [DEFAULT, SERVED, API85]];
+  const filters = ["language:en", [DEFAULT, SERVED, APILATEST]];
   const out = rewriteVersionTag(filters, "docs-default-7.6.14", MAP);
   const tags = tagsOf(out);
   assert.ok(tags.includes(LEGACY), "page tag must be swapped");
   assert.ok(tags.includes(API76), "API reference must follow to 7.6");
-  assert.ok(!tags.includes(API85), "the 8.5 API reference must be dropped");
+  assert.ok(!tags.includes(APILATEST), "the current API reference must be dropped");
   assert.ok(tags.includes(DEFAULT), "the OR group must not collapse");
 });
 
 check("no duplicate tag when the page already carries it", () => {
-  const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED, API85]], MAP);
-  assert.strictEqual(tagsOf(out).filter((t) => t === API85).length, 1);
+  const out = withApiReferenceTags(["language:en", [DEFAULT, SERVED, APILATEST]], MAP);
+  assert.strictEqual(tagsOf(out).filter((t) => t === APILATEST).length, 1);
 });
 
 console.log(`\n${passed} passed\n`);

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -35,8 +35,21 @@ function extract(name) {
   throw new Error(`could not read ${name}`);
 }
 
-const EMPTY_TAG_LIST = [];
-const API_TAG_PREFIX = "docusaurus_tag:api-reference-";
+/**
+ * Read a module-level const out of the source too.
+ *
+ * Declaring these locally made the eval'd functions close over the TEST's copy,
+ * which defeats the whole point stated above: API_TAG_PREFIX is exactly the
+ * constant whose change would otherwise go unnoticed here.
+ */
+function extractConst(name) {
+  const m = new RegExp(`const ${name}\\s*=\\s*([^;]+);`).exec(src);
+  assert.ok(m, `${name} not found in SearchBar - test is stale`);
+  return eval(`(${m[1]})`);
+}
+
+const EMPTY_TAG_LIST = extractConst("EMPTY_TAG_LIST");
+const API_TAG_PREFIX = extractConst("API_TAG_PREFIX");
 const apiTagsFor = eval(`(${extract("apiTagsFor")})`);
 const withApiReferenceTags = eval(`(${extract("withApiReferenceTags")})`);
 const rewriteVersionTag = eval(`(${extract("rewriteVersionTag")})`);
@@ -51,7 +64,12 @@ const API628 = "docusaurus_tag:api-reference-6.28";
 
 // Exactly what docusaurus.config.ts derives from docsVersions.
 const MAP = {
-  "docs-default-8.5.3": ["api-reference-latest", "docs-default-current"],
+  // No docs-default-current here: the migration shim that pushed the legacy tag
+  // onto the served version is gone. The crawler retag is done - the live index
+  // holds api-reference-latest with 3,407 pages and docs-default-current with a
+  // single stale record, which the gate should flag for purging rather than
+  // treat as reachable content.
+  "docs-default-8.5.3": ["api-reference-latest"],
   "docs-default-7.6.14": ["api-reference-7.6"],
   "docs-default-6.28.11": ["api-reference-6.28"],
   "docs-default-current": ["api-reference-latest"],
@@ -103,6 +121,19 @@ check("typing a version moves the guides AND the API reference together", () => 
   assert.ok(tags.includes(API76), "API reference must follow to 7.6");
   assert.ok(!tags.includes(APILATEST), "the current API reference must be dropped");
   assert.ok(tags.includes(DEFAULT), "the OR group must not collapse");
+  // The assertion the original test was missing. tagsOf() only inspects the
+  // nested OR group, so a stray top-level entry was invisible to every check
+  // above - and a top-level entry ANDs the API tag against the whole query,
+  // which returns zero guides. Same guard as the test at line 89.
+  assert.strictEqual(
+    out.length,
+    2,
+    "a top-level entry would AND the API tag and match nothing",
+  );
+  assert.ok(
+    out.every((f) => !String(f).startsWith(API_TAG_PREFIX)),
+    "no API tag may sit at the top level",
+  );
 });
 
 check("no duplicate tag when the page already carries it", () => {

--- a/scripts/test-search-facets.cjs
+++ b/scripts/test-search-facets.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * Behavioural test for the facet filters the search widget sends.
+ *
+ * These two functions decide what a reader can find, and both failure modes are
+ * silent: too narrow and content vanishes from search (the 8.5.3 regression),
+ * too wide and a legacy-version reader gets results that do not apply to them.
+ * Neither throws, so only an assertion catches it.
+ *
+ * The functions are read out of the shipped module rather than copied here - a
+ * copy would keep passing after the real one changed.
+ */
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+
+const SRC = path.join(__dirname, "..", "src", "theme", "SearchBar", "index.js");
+const src = fs.readFileSync(SRC, "utf8");
+
+function extract(name) {
+  const start = src.indexOf(`function ${name}(`);
+  assert.notStrictEqual(start, -1, `${name} not found in SearchBar - test is stale`);
+  let depth = 0;
+  let started = false;
+  for (let i = start; i < src.length; i += 1) {
+    if (src[i] === "{") {
+      depth += 1;
+      started = true;
+    } else if (src[i] === "}") {
+      depth -= 1;
+      if (started && depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(`could not read ${name}`);
+}
+
+const EMPTY_TAG_LIST = [];
+const withAlwaysOnTags = eval(`(${extract("withAlwaysOnTags")})`);
+const rewriteVersionTag = eval(`(${extract("rewriteVersionTag")})`);
+
+const API = "docusaurus_tag:docs-default-current";
+const SERVED = "docusaurus_tag:docs-default-8.5.3";
+const LEGACY = "docusaurus_tag:docs-default-7.6.14";
+const DEFAULT = "docusaurus_tag:default";
+const alwaysOn = [API];
+const scope = [SERVED, "docusaurus_tag:docs-default-current"];
+
+const tagsOf = (filters) => filters.find(Array.isArray) || [];
+let passed = 0;
+function check(label, fn) {
+  fn();
+  passed += 1;
+  console.log(`  ok  ${label}`);
+}
+
+console.log("\nsearch facet filters\n");
+
+check("served version pulls the API reference in", () => {
+  const out = withAlwaysOnTags(["language:en", [DEFAULT, SERVED]], alwaysOn, scope);
+  assert.ok(tagsOf(out).includes(API));
+});
+
+check("frozen legacy version does NOT pull it in", () => {
+  const out = withAlwaysOnTags(["language:en", [DEFAULT, LEGACY]], alwaysOn, scope);
+  assert.ok(!tagsOf(out).includes(API), "legacy readers must not get current-SDK API pages");
+});
+
+check("extra tags join the OR group, never the top-level AND", () => {
+  const out = withAlwaysOnTags(["language:en", [DEFAULT, SERVED]], alwaysOn, scope);
+  assert.strictEqual(out.length, 2, "a top-level entry would AND and match nothing");
+  assert.ok(tagsOf(out).includes(DEFAULT) && tagsOf(out).includes(SERVED));
+});
+
+check("no duplicate tag when always-on equals the page's own tag", () => {
+  const out = withAlwaysOnTags(["language:en", [DEFAULT, API]], alwaysOn, scope);
+  assert.strictEqual(tagsOf(out).filter((t) => t === API).length, 1);
+});
+
+check("empty scope means everywhere (back-compatible default)", () => {
+  const out = withAlwaysOnTags(["language:en", [DEFAULT, LEGACY]], alwaysOn, []);
+  assert.ok(tagsOf(out).includes(API));
+});
+
+check("typing a version swaps the page tag but keeps the API reference", () => {
+  const filters = ["language:en", [DEFAULT, SERVED, API]];
+  const out = rewriteVersionTag(filters, "docs-default-7.6.14", alwaysOn);
+  const tags = tagsOf(out);
+  assert.ok(tags.includes("docusaurus_tag:docs-default-7.6.14"), "page tag must be swapped");
+  assert.ok(tags.includes(API), "always-on tag must survive the swap");
+  assert.ok(tags.includes(DEFAULT), "the OR group must not collapse");
+});
+
+console.log(`\n${passed} passed\n`);

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -91,17 +91,20 @@ def extract_current_banner(config_path: Path) -> str:
     return match.group(1) if match else 'none'
 
 
+# The served version is declared once, as DOCS_LAST_VERSION in
+# docusaurus.config.ts; the docs plugin and the search-tag derivation both read
+# that constant. Editing the `lastVersion:` line instead would leave the
+# constant stale and the two would disagree - which is what the constant exists
+# to prevent.
+LAST_VERSION_CONST = r'(const DOCS_LAST_VERSION\s*=\s*)"([^"]+)"'
+
+
 def extract_last_version(config_path: Path) -> str:
     content = config_path.read_text()
-    line_match = re.search(r'lastVersion:[^\n]*', content)
-    if not line_match:
-        raise ValueError("Could not extract lastVersion from docusaurus.config.ts")
-    # lastVersion may be a plain string or `isPreviewBuild ? "current" : "X"` —
-    # in both cases the real (non-preview) value is the last quoted string.
-    values = re.findall(r'"([^"]+)"', line_match.group(0))
-    if not values:
-        raise ValueError("Could not extract lastVersion from docusaurus.config.ts")
-    version = values[-1]
+    match = re.search(LAST_VERSION_CONST, content)
+    if not match:
+        raise ValueError("Could not extract DOCS_LAST_VERSION from docusaurus.config.ts")
+    version = match.group(2)
     if version == "current":
         raise ValueError("Already in production state (lastVersion is 'current')")
     return version
@@ -231,7 +234,7 @@ def update_config_version_entry(config_path: Path, old_version: str, new_version
     content = config_path.read_text()
     content = re.sub(rf'"{re.escape(old_version)}":', f'"{new_version}":', content)
     content = re.sub(
-        rf'(lastVersion:\s*(?:isPreviewBuild\s*\?\s*["\']current["\']\s*:\s*)?)["\']{re.escape(old_version)}["\']',
+        rf'(const DOCS_LAST_VERSION\s*=\s*)"{re.escape(old_version)}"',
         rf'\g<1>"{new_version}"',
         content,
     )
@@ -322,7 +325,7 @@ def update_config_for_minor_beta(config_path: Path, current_version: str, new_ve
     content = config_path.read_text()
 
     content = re.sub(
-        r'(lastVersion:\s*(?:isPreviewBuild\s*\?\s*["\']current["\']\s*:\s*)?)["\']current["\']',
+        r'(const DOCS_LAST_VERSION\s*=\s*)"current"',
         rf'\g<1>"{current_version}"',
         content,
     )
@@ -378,7 +381,7 @@ def update_config_for_minor_production(config_path: Path, version: str) -> None:
     content = config_path.read_text()
 
     content = re.sub(
-        r'(lastVersion:\s*(?:isPreviewBuild\s*\?\s*["\']current["\']\s*:\s*)?)["\'][^"\']+["\']',
+        r'(const DOCS_LAST_VERSION\s*=\s*)"[^"]+"',
         r'\g<1>"current"',
         content,
     )

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -94,9 +94,34 @@ async function readManifest(source) {
 }
 
 /** The public Algolia keys live in two files; prove they still agree. */
+/**
+ * Mark an error as "the gate verified nothing", so the transport tolerance can
+ * never swallow it.
+ *
+ * Matching on message text was not enough: "no `algolia:` block found" is a
+ * plain Error and matched no pattern, so moving the algolia block into its own
+ * themeConfig module - a routine refactor - would have made every PR print
+ * "search-tag gate could not run" and pass green, with the credential check, the
+ * served-major check, the build-emission scan and every Algolia comparison
+ * skipped. A flag on the error is structural; a regex over prose is not.
+ */
+function fatal(message) {
+  const err = new Error(message);
+  err.fatal = true;
+  return err;
+}
+
 function assertConfigInSync() {
   const configPath = path.join(__dirname, "..", "docusaurus.config.ts");
-  const full = fs.readFileSync(configPath, "utf8");
+  let full;
+  try {
+    full = fs.readFileSync(configPath, "utf8");
+  } catch (err) {
+    throw fatal(
+      `cannot read docusaurus.config.ts (${err.message}) - the credentials this ` +
+        `script hard-codes cannot be checked against it.`,
+    );
+  }
   // Scoped to the `algolia:` block. A file-wide match takes the FIRST appId /
   // apiKey / indexName anywhere - including one in a comment or an unrelated
   // block - and this check is in FATAL_PATTERNS, so a false positive fails CI
@@ -104,7 +129,7 @@ function assertConfigInSync() {
   const start = full.indexOf("algolia:");
   const src = start === -1 ? full : full.slice(start);
   if (start === -1) {
-    throw new Error(
+    throw fatal(
       "no `algolia:` block found in docusaurus.config.ts - this script cannot " +
         "verify the credentials it hard-codes. Update both.",
     );
@@ -112,7 +137,7 @@ function assertConfigInSync() {
   for (const [key, expected] of Object.entries(ALGOLIA)) {
     const found = new RegExp(`${key}:\\s*"([^"]+)"`).exec(src);
     if (!found || found[1] !== expected) {
-      throw new Error(
+      throw fatal(
         `Algolia ${key} in docusaurus.config.ts (${found ? found[1] : "missing"}) ` +
           `does not match this script (${expected}). Update both.`,
       );
@@ -128,12 +153,29 @@ function assertConfigInSync() {
  * is the only way a derived value gets checked - the drift that caused this gate
  * to exist was a config that was internally consistent and still wrong.
  */
-function tagsEmittedByBuild(buildDir, expected, fileCap = 4000) {
+// The <meta name="docusaurus_tag"> sits in <head>; measured across the whole
+// build the deepest one is at byte 1165. Reading a 4 KB head instead of the
+// whole file is what makes an exhaustive walk affordable - 123 MB of full reads
+// was the reason a cap existed at all.
+const HEAD_BYTES = 4096;
+
+function headOf(file) {
+  const fd = fs.openSync(file, "r");
+  try {
+    const buf = Buffer.alloc(HEAD_BYTES);
+    const n = fs.readSync(fd, buf, 0, HEAD_BYTES, 0);
+    return buf.slice(0, n).toString("utf8");
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function tagsEmittedByBuild(buildDir, expected) {
   const found = new Set();
   const wanted = new Set(expected);
   const stack = [buildDir];
   let seen = 0;
-  while (stack.length && seen < fileCap && found.size < wanted.size) {
+  while (stack.length && found.size < wanted.size) {
     const dir = stack.pop();
     let entries;
     try {
@@ -147,9 +189,7 @@ function tagsEmittedByBuild(buildDir, expected, fileCap = 4000) {
         stack.push(full);
       } else if (e.name === "index.html") {
         seen += 1;
-        const m = /name="docusaurus_tag" content="([^"]+)"/.exec(
-          fs.readFileSync(full, "utf8"),
-        );
+        const m = /name="docusaurus_tag" content="([^"]+)"/.exec(headOf(full));
         // Only tags we are looking for count toward the early exit; the build
         // also emits tags for versions the manifest does not route to.
         if (m && wanted.has(m[1])) found.add(m[1]);
@@ -157,12 +197,13 @@ function tagsEmittedByBuild(buildDir, expected, fileCap = 4000) {
       }
     }
   }
-  // `exhausted` distinguishes "walked the whole build" from "hit the cap". With
-  // an arbitrary stack.pop() order, a cap reached before every wanted tag was
-  // seen makes absence meaningless - reporting it as config drift blames the
-  // config for a truncated walk. Today's build is ~2,250 pages against a 4,000
-  // cap, so this is headroom for about two more frozen versions.
-  return { found, exhausted: !(seen >= fileCap && found.size < wanted.size) };
+  // No cap, so absence is now proof. The previous 4,000-file cap was BELOW the
+  // build's real size (4,397 index.html files today), and the early exit means
+  // only the failure case walks the whole tree - so a tag the build never emits
+  // always hit the cap, always came back "inconclusive", and the FAIL branch
+  // this function exists to feed could not fire at all. It reported a state it
+  // was written to catch as a state it could not judge.
+  return { found, seen };
 }
 
 async function algolia(body) {
@@ -305,22 +346,16 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
           manifest.lastVersionTag,
           ...Object.values(manifest.versionTagByMajor || {}),
         ];
-    const { found: emitted, exhausted } = tagsEmittedByBuild(buildDir, expected);
+    const { found: emitted, seen } = tagsEmittedByBuild(buildDir, expected);
     const notEmitted = expected.filter((t) => !emitted.has(t));
-    if (notEmitted.length && exhausted) {
+    if (notEmitted.length) {
       console.error(
         `\nFAIL: the config names tags this build never emits:\n` +
           notEmitted.map((t) => `  ${t}`).join("\n") +
-          `\n  docsVersions / lastVersion and the tag derivation disagree.\n`,
+          `\n  Scanned all ${seen} pages in the build; these tags are on none of\n` +
+          `  them. docsVersions / lastVersion and the tag derivation disagree.\n`,
       );
       process.exitCode = 1;
-    } else if (notEmitted.length) {
-      console.error(
-        `\nINCONCLUSIVE: stopped scanning the build before finding:\n` +
-          notEmitted.map((t) => `  ${t}`).join("\n") +
-          `\n  The file cap was reached, so absence proves nothing here.\n` +
-          `  Raise the cap in tagsEmittedByBuild if the build has grown.\n`,
-      );
     }
   }
 
@@ -376,7 +411,7 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   //
   // Detected rather than declared: if the served tag has no records at all, the
   // index predates this build. Post-crawl the same conditions are real problems
-  // and fail as before, and --strict fails either way so main and the schedule
+  // and fail as before, and --strict fails either way so main
   // still see them.
   //
   // The test is "holds no meaningful content", NOT "is absent from the index".
@@ -412,6 +447,24 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   const releasePending =
     !!manifest.lastVersionTag && servedThin && otherDocsTagsHealthy;
 
+  // Honest about what this cannot decide. releasePending has no time bound, and
+  // a crawler that STALLS on the served version while the frozen ones stay
+  // healthy looks identical to a release whose crawl has not run yet. The
+  // suppression is therefore kept as narrow as possible - it excuses the served
+  // docs tag and nothing else, so the API trees and the frozen versions are
+  // still checked - but distinguishing a stall from a release needs the previous
+  // crawl state, which a single CI run does not have. Repetition is the tell: a
+  // pending release clears on the next crawl, a stall does not.
+  if (releasePending) {
+    console.error(
+      `\nNOTE: treating "${manifest.lastVersionTag}" as a release whose crawl has` + NL +
+        `  not run yet, so its own page count is not being judged. If this same` + NL +
+        `  line appears on consecutive runs days apart, it is not a release - the` + NL +
+        `  crawl for the served version has stalled, and that is what the standing` + NL +
+        `  Algolia monitor exists to catch.` + NL,
+    );
+  }
+
   if (servedThin && !otherDocsTagsHealthy) {
     console.error(
       `\nNOTE: the served tag "${manifest.lastVersionTag}" is thin AND no other` + NL +
@@ -424,13 +477,31 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // definition of that state, not a separate problem. Without this, --strict on
   // main turned every post-release build red until the crawl finished - the one
   // change this gate is documented as not blocking.
-  const thin = releasePending
-    ? []
-    : [manifest.lastVersionTag]
-        .filter(
-          (tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD,
-        )
-        .map((tag) => [tag, counts[tag]]);
+  // Every docs version a reader can actually be ROUTED to, not just the served
+  // one. If docs-default-7.6.14 drops from 342 pages to 4, it stays in
+  // `routable` so `unreachable` skips it, `missing` only fires at zero, and
+  // `thinApiTags` covers API trees only - so 7.6 readers lost nearly every guide
+  // result and this printed "every tag with content is reachable". Same argument
+  // the file already makes for API tags; docs tags were simply left out of it.
+  // versionTagByMajor is the right set: those are the tags a version query and
+  // the contextual filter can send someone to. docs-default-current is not in it
+  // and must not be - the /next/ tree is deliberately not crawled, so its single
+  // stale record is not a collapse.
+  const routableDocsTags = [
+    ...new Set(
+      [
+        manifest.lastVersionTag,
+        ...Object.values(manifest.versionTagByMajor || {}),
+      ].filter(Boolean),
+    ),
+  ];
+  const thin = routableDocsTags
+    // The served tag being thin IS the pending-release state, not a finding.
+    .filter((tag) => !(releasePending && tag === manifest.lastVersionTag))
+    .filter(
+      (tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD,
+    )
+    .map((tag) => [tag, counts[tag]]);
   // An always-on tag that holds nothing is a migration in flight, not a broken
   // build: the repo can name the crawler's target tag before the crawler emits
   // it, or the other way round. Either order must keep CI green as long as one
@@ -493,9 +564,19 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // OR-branch filters on a zero-record tag and 2,501 pages leave 7.6 search -
   // the exact August regression class. This used to print only a NOTE and exit 0,
   // because `alwaysOnEmpty` required EVERY api tag to be empty at once and
-  // `missing` explicitly excluded them. Skipped while a release is pending: a
-  // brand-new version's API tag has not been crawled yet either.
-  const emptyApiTags = releasePending || alwaysOnEmpty ? [] : pendingAlwaysOn;
+  // `missing` explicitly excluded them.
+  //
+  // NOT suppressed by releasePending any more. That suppression assumed a
+  // release introduces an uncrawled API tag, which stopped being true once the
+  // mapping was derived from the links: a patch release maps to
+  // api-reference-latest, which already exists. Meanwhile releasePending has no
+  // time bound - a crawler that STALLS on the root version rather than dying
+  // keeps the served tag thin while 7.6 and 6.28 stay healthy, so it stayed true
+  // indefinitely and took thin, thinApiTags and emptyApiTags down with it. The
+  // one case it did cover - a frozen version's links rewritten to its own line
+  // before the crawler knows that line - is handled by the strict gate below
+  // instead, which reports it everywhere and blocks only where it can be acted on.
+  const emptyApiTags = alwaysOnEmpty ? [] : pendingAlwaysOn;
 
   // ...and a tag that still exists but has collapsed. emptyApiTags only tests
   // `=== undefined`, `missing` excludes API tags by construction, `unreachable`
@@ -504,18 +585,18 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // "OK: every tag with content is reachable." A partial collapse is the same
   // regression class as a total one; 7.6 readers just lose most of the API
   // reference instead of all of it.
-  const thinApiTags = releasePending
-    ? []
-    : alwaysOn
-        .filter(
-          (tag) =>
-            counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD,
-        )
-        .map((tag) => [tag, counts[tag]]);
+  const thinApiTags = alwaysOn
+    .filter(
+      (tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD,
+    )
+    .map((tag) => [tag, counts[tag]]);
   if (thinApiTags.length) {
-    failed = true;
+    // Strict-gated like `thin`, for the same reason: no PR author can fix a
+    // partial crawl, and failing unrelated work adds no detection. main and any
+    // manual re-run still go red, which is where someone can act.
+    if (strict) failed = true;
     console.error(
-      `\nFAIL: API-reference tag(s) hold far too little to be a whole tree:` + NL +
+      `\n${strict ? "FAIL" : "WARN"}: API-reference tag(s) hold far too little to be a whole tree:` + NL +
         thinApiTags
           .map(([t, n]) => `  "${t}" -> ${n} pages (floor ${THIN_PAGE_THRESHOLD})`)
           .join(NL) + NL +
@@ -525,12 +606,21 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
     );
   }
   if (emptyApiTags.length) {
-    failed = true;
+    // Strict-gated, because the fix is usually OUTSIDE this repo. The tag
+    // vocabulary is derived here from the links, but the records are produced by
+    // the Algolia crawler: the moment a frozen version's links are rewritten to
+    // its own line, this repo correctly derives api-reference-<line> and the
+    // crawler has never heard of it. Hard-failing every PR until someone edits
+    // an external crawler config blocks work that cannot fix it, so PRs warn and
+    // main goes red - the same split `thin` and `thinApiTags` use.
+    if (strict) failed = true;
     console.error(
-      `\nFAIL: API-reference tag(s) the widget filters on hold nothing:` + NL +
+      `\n${strict ? "FAIL" : "WARN"}: API-reference tag(s) the widget filters on hold nothing:` + NL +
         emptyApiTags.map((t) => `  "${t}" -> 0 records`).join(NL) + NL +
         `  Readers on those versions get an OR-branch matching nothing, so that` + NL +
-        `  version's API reference is absent from search.` + NL,
+        `  version's API reference is absent from search.` + NL +
+        `  If the version's links were just rewritten to its own line, the Algolia` + NL +
+        `  crawler needs an action for that path before this can go green.` + NL,
     );
   }
 
@@ -562,7 +652,11 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
     );
     for (const [tag, n] of thin) console.error(`  "${tag}" -> ${n} pages`);
     console.error(
-      `  Usually the crawler catching up after a deploy; re-run once it has.`,
+      thin.every(([tag]) => tag === manifest.lastVersionTag)
+        ? `  Usually the crawler catching up after a deploy; re-run once it has.`
+        : `  A version other than the served one is thin, so "the crawl is still\n` +
+            `  catching up" does not explain it: a frozen version's pages have not\n` +
+            `  changed. Check the crawler's path rules for that version.`,
     );
     if (strict) failed = true;
   }
@@ -573,7 +667,10 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
 
 // A network failure is not a content failure. An Algolia outage, a rate limit or
 // a sandboxed runner would otherwise block merging unrelated docs PRs. Under
-// --strict (main, or the schedule, where someone is watching) it still fails.
+// --strict (main, where someone is watching) it still fails. There is no
+// scheduled run in this repo; the standing Algolia check that catches a crawl
+// finishing later lives outside CI, so "re-run after the crawl" means a manual
+// re-run or the next push to main.
 // Faults the gate must never swallow. These are deterministic config errors, not
 // a flaky network, and treating them as transport meant the gate could degrade to
 // a complete no-op while printing a line nobody reads and passing CI.
@@ -600,7 +697,10 @@ main().catch((err) => {
     err instanceof ReferenceError ||
     (err instanceof TypeError && !isTransportTypeError) ||
     err instanceof SyntaxError;
-  const deterministic = isBug || FATAL_PATTERNS.some((re) => re.test(message));
+  const deterministic =
+    !!(err && err.fatal) ||
+    isBug ||
+    FATAL_PATTERNS.some((re) => re.test(message));
   console.error(`\nsearch-tag gate could not run: ${message}\n`);
   // A transport failure exits 0 unless --strict, so an Algolia outage cannot
   // block an unrelated docs PR. A deterministic config fault always fails.

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -63,8 +63,18 @@ const DEFAULT_MANIFEST = path.join(__dirname, "..", "build", "search-tags.json")
 
 const argv = process.argv.slice(2);
 const strict = argv.includes("--strict");
-const manifestArg =
-  argv.includes("--manifest") ? argv[argv.indexOf("--manifest") + 1] : null;
+// A missing value used to leave manifestArg undefined, which silently fell back
+// to the local build AND re-enabled the build-emission scan - so a CI invocation
+// whose path variable expanded empty checked a different source and printed OK.
+let manifestArg = null;
+if (argv.includes("--manifest")) {
+  const value = argv[argv.indexOf("--manifest") + 1];
+  if (!value || value.startsWith("--")) {
+    console.error("\n--manifest needs a path or URL.\n");
+    process.exit(1);
+  }
+  manifestArg = value;
+}
 
 async function readManifest(source) {
   if (source && /^https?:\/\//.test(source)) {
@@ -86,7 +96,19 @@ async function readManifest(source) {
 /** The public Algolia keys live in two files; prove they still agree. */
 function assertConfigInSync() {
   const configPath = path.join(__dirname, "..", "docusaurus.config.ts");
-  const src = fs.readFileSync(configPath, "utf8");
+  const full = fs.readFileSync(configPath, "utf8");
+  // Scoped to the `algolia:` block. A file-wide match takes the FIRST appId /
+  // apiKey / indexName anywhere - including one in a comment or an unrelated
+  // block - and this check is in FATAL_PATTERNS, so a false positive fails CI
+  // unconditionally.
+  const start = full.indexOf("algolia:");
+  const src = start === -1 ? full : full.slice(start);
+  if (start === -1) {
+    throw new Error(
+      "no `algolia:` block found in docusaurus.config.ts - this script cannot " +
+        "verify the credentials it hard-codes. Update both.",
+    );
+  }
   for (const [key, expected] of Object.entries(ALGOLIA)) {
     const found = new RegExp(`${key}:\\s*"([^"]+)"`).exec(src);
     if (!found || found[1] !== expected) {
@@ -273,10 +295,16 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // Against a local build: does the site really emit the tags the config claims?
   const buildDir = path.dirname(DEFAULT_MANIFEST);
   if (!manifestArg && fs.existsSync(buildDir)) {
-    const expected = [
-      manifest.lastVersionTag,
-      ...Object.values(manifest.versionTagByMajor || {}),
-    ];
+    // A preview build sets onlyIncludeVersions: ["current"], so it contains no
+    // frozen pages and the frozen majors' tags are legitimately absent. Expecting
+    // them produced "the config names tags this build never emits" against a
+    // correct config.
+    const expected = manifest.isPreviewBuild
+      ? [manifest.lastVersionTag]
+      : [
+          manifest.lastVersionTag,
+          ...Object.values(manifest.versionTagByMajor || {}),
+        ];
     const { found: emitted, exhausted } = tagsEmittedByBuild(buildDir, expected);
     const notEmitted = expected.filter((t) => !emitted.has(t));
     if (notEmitted.length && exhausted) {
@@ -323,28 +351,20 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // through no path at all is orphaned.
   const unreachable = rows.filter(
     ([tag, n]) =>
-      !reachable.has(tag) && !routable.has(tag) && n >= ORPHAN_PAGE_THRESHOLD,
+      !reachable.has(tag) &&
+      !routable.has(tag) &&
+      // `contextual` was built for exactly this and then not consulted here, so
+      // a tag could print as `contextual` in the table and be listed under
+      // "cannot reach" in the same run. It bites for real at the next
+      // minor-production release: docs-default-8.5.x loses major 8 to
+      // docs-default-current in versionTagByMajor, drops out of `routable`,
+      // stays in `contextual`, and hard-fails every PR once the crawler has
+      // populated the new served tag and releasePending stops masking it.
+      !contextual.has(tag) &&
+      n >= ORPHAN_PAGE_THRESHOLD,
   );
   // `default` legitimately holds only a handful of non-doc pages, so thinness is
   // only meaningful for the tags that carry the docs themselves.
-  const thin = [manifest.lastVersionTag]
-    .filter((tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD)
-    .map((tag) => [tag, counts[tag]]);
-  // An always-on tag that holds nothing is a migration in flight, not a broken
-  // build: the repo can name the crawler's target tag before the crawler emits
-  // it, or the other way round. Either order must keep CI green as long as one
-  // always-on tag still carries the content.
-  // Flatten the per-version API-reference map: every tag it names must exist.
-  const apiMap = manifest.apiReferenceTagsByVersionTag || {};
-  const alwaysOn = [...new Set(Object.values(apiMap).flat())];
-  // API-reference tags are reported by the migration check above, so they are
-  // excluded here rather than counted twice.
-  const apiTags = new Set(alwaysOn);
-  // Deduped: lastVersionTag is also in `routable`, so it printed twice.
-  const missing = [
-    ...new Set([manifest.defaultTag, manifest.lastVersionTag, ...routable]),
-  ].filter((tag) => tag && !apiTags.has(tag) && counts[tag] === undefined);
-
   // Is this the build that renames the version served at the root?
   //
   // On that build the config names a tag the index cannot possibly hold yet -
@@ -376,6 +396,34 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   const releasePending =
     !!manifest.lastVersionTag &&
     (servedCount === undefined || servedCount < THIN_PAGE_THRESHOLD);
+
+  // Skipped while a release is pending: the served tag being thin is the
+  // definition of that state, not a separate problem. Without this, --strict on
+  // main turned every post-release build red until the crawl finished - the one
+  // change this gate is documented as not blocking.
+  const thin = releasePending
+    ? []
+    : [manifest.lastVersionTag]
+        .filter(
+          (tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD,
+        )
+        .map((tag) => [tag, counts[tag]]);
+  // An always-on tag that holds nothing is a migration in flight, not a broken
+  // build: the repo can name the crawler's target tag before the crawler emits
+  // it, or the other way round. Either order must keep CI green as long as one
+  // always-on tag still carries the content.
+  // Flatten the per-version API-reference map: every tag it names must exist.
+  const apiMap = manifest.apiReferenceTagsByVersionTag || {};
+  const alwaysOn = [...new Set(Object.values(apiMap).flat())];
+  // API-reference tags are reported by the migration check above, so they are
+  // excluded here rather than counted twice.
+  const apiTags = new Set(alwaysOn);
+  // Deduped: lastVersionTag is also in `routable`, so it printed twice.
+  const missing = [
+    ...new Set([manifest.defaultTag, manifest.lastVersionTag, ...routable]),
+  ].filter((tag) => tag && !apiTags.has(tag) && counts[tag] === undefined);
+
+
   const pendingAlwaysOn = alwaysOn.filter((tag) => counts[tag] === undefined);
   const alwaysOnEmpty = alwaysOn.length > 0 && pendingAlwaysOn.length === alwaysOn.length;
 
@@ -384,7 +432,10 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   if (unreachable.length) {
     // While a release is pending, the outgoing version's tag is unreachable by
     // construction: this build renamed it and the index has not caught up.
-    const hard = strict || !releasePending;
+    // releasePending is a fact about the index, not a severity preference, so
+    // --strict does NOT override it: on main, right after a release, the index
+    // genuinely cannot have caught up yet.
+    const hard = !releasePending;
     if (hard) failed = true;
     console.error(
       `\n${hard ? "FAIL" : "WARN"}: indexed content the search widget cannot reach.`,
@@ -438,7 +489,7 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
     const onlyTheNewServedTag =
       releasePending &&
       missing.every((tag) => tag === manifest.lastVersionTag);
-    const hard = strict || !onlyTheNewServedTag;
+    const hard = !onlyTheNewServedTag;
     if (hard) failed = true;
     console.error(
       `\n${hard ? "FAIL" : "WARN"}: the widget filters on tags that hold nothing at all.`,
@@ -480,7 +531,15 @@ const FATAL_PATTERNS = [
 
 main().catch((err) => {
   const message = err && err.message ? err.message : String(err);
-  const deterministic = FATAL_PATTERNS.some((re) => re.test(message));
+  // A ReferenceError / TypeError / SyntaxError is a defect in this script, not a
+  // flaky network. One of them (a temporal-dead-zone read of releasePending) was
+  // swallowed as a transport failure and exited 0, so the gate crashed and CI
+  // stayed green.
+  const isBug =
+    err instanceof ReferenceError ||
+    err instanceof TypeError ||
+    err instanceof SyntaxError;
+  const deterministic = isBug || FATAL_PATTERNS.some((re) => re.test(message));
   console.error(`\nsearch-tag gate could not run: ${message}\n`);
   // A transport failure exits 0 unless --strict, so an Algolia outage cannot
   // block an unrelated docs PR. A deterministic config fault always fails.

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -50,6 +50,8 @@ const ORPHAN_PAGE_THRESHOLD = 50;
 // A tag the widget targets is expected to carry at least this many pages.
 const THIN_PAGE_THRESHOLD = 100;
 
+const NL = "\n";
+
 const DEFAULT_MANIFEST = path.join(__dirname, "..", "build", "search-tags.json");
 
 const argv = process.argv.slice(2);
@@ -259,9 +261,15 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   const thin = [manifest.lastVersionTag, ...(manifest.alwaysOnTags || [])]
     .filter((tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD)
     .map((tag) => [tag, counts[tag]]);
-  const missing = [...reachable, ...routable].filter(
-    (tag) => counts[tag] === undefined,
-  );
+  // An always-on tag that holds nothing is a migration in flight, not a broken
+  // build: the repo can name the crawler's target tag before the crawler emits
+  // it, or the other way round. Either order must keep CI green as long as one
+  // always-on tag still carries the content.
+  const alwaysOn = manifest.alwaysOnTags || [];
+  const missing = [manifest.defaultTag, manifest.lastVersionTag, ...routable]
+    .filter((tag) => tag && counts[tag] === undefined);
+  const pendingAlwaysOn = alwaysOn.filter((tag) => counts[tag] === undefined);
+  const alwaysOnEmpty = alwaysOn.length > 0 && pendingAlwaysOn.length === alwaysOn.length;
 
   let failed = process.exitCode === 1;
 
@@ -275,6 +283,16 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
       `\n  Either the widget must include the tag (alwaysOnSearchTags in\n` +
         `  docusaurus.config.ts) or the crawler must stop emitting it.`,
     );
+  }
+
+  if (pendingAlwaysOn.length) {
+    console.error(
+      `\n${alwaysOnEmpty ? "FAIL" : "NOTE"}: always-on tag(s) hold nothing yet: ` +
+        `${pendingAlwaysOn.join(", ")}.` + NL +
+        `  Expected while the Algolia crawler is being retagged. ` +
+        `${alwaysOnEmpty ? "No always-on tag has content - the API reference is unreachable." : "Another always-on tag still carries the content."}` + NL,
+    );
+    if (alwaysOnEmpty) failed = true;
   }
 
   if (missing.length) {

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -214,11 +214,22 @@ async function main() {
   // reader on 7.6.14 gets api-reference-7.6 from that page's own contextual
   // filter. Not in `reachable` (which is about the served version), but calling
   // these "typed-only" in the report understated them - no typing is involved.
-  const contextual = new Set(
-    Object.entries(manifest.apiReferenceTagsByVersionTag || {})
+  const contextual = new Set([
+    // A frozen version's own API tags.
+    ...Object.entries(manifest.apiReferenceTagsByVersionTag || {})
       .filter(([versionTag]) => versionTag !== manifest.lastVersionTag)
       .flatMap(([, tags]) => tags),
-  );
+    // And the docs-version tags themselves. A reader on /next/ or on a frozen
+    // version reaches that version's pages through their own contextual filter,
+    // exactly like the API tags above. Without this, docs-default-current (the
+    // /next/ tree) reads UNREACHABLE - tolerable today only because the index
+    // holds one stale record, but every PR would hard-fail the moment the
+    // crawler indexes 50 of them, blaming a config that is correct. Same for a
+    // second frozen version sharing a major with the routed winner.
+    ...Object.keys(manifest.apiReferenceTagsByVersionTag || {}).filter(
+      (tag) => tag !== manifest.lastVersionTag,
+    ),
+  ]);
   // Reached only when a reader types a version. Checked for existence, but a tag
   // being routable does NOT make its content reachable by ordinary search.
   const routable = new Set([
@@ -231,10 +242,21 @@ async function main() {
   // and 8.5.3 became lastVersion, "v8" pointed at the beta's tag instead - and
   // because that tag also held the API reference, it still returned results, so
   // nothing looked broken. This is the check that catches it deterministically.
-  const servedMajor = String(manifest.lastVersionTag).replace(
-    /^docs-default-/,
-    "",
-  ).split(".")[0];
+  // Stated by the build, not parsed out of the tag. `docs-default-current`
+  // carries no number, so the old derivation produced "current", looked up
+  // versionTagByMajor["current"], found undefined and silently checked nothing -
+  // for the entire production half of every release cycle. The fallback keeps a
+  // manifest written before this field existed working.
+  const servedMajor = String(
+    manifest.lastVersionMajor ||
+      String(manifest.lastVersionTag).replace(/^docs-default-/, "").split(".")[0],
+  );
+  if (!manifest.lastVersionMajor) {
+    console.error(
+      `\nNOTE: manifest has no lastVersionMajor, so the served-major check is` +
+        ` derived from the tag and cannot verify a "current" lastVersion.\n`,
+    );
+  }
   const routedForServedMajor = (manifest.versionTagByMajor || {})[servedMajor];
   if (routedForServedMajor && routedForServedMajor !== manifest.lastVersionTag) {
     console.error(
@@ -336,8 +358,24 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // index predates this build. Post-crawl the same conditions are real problems
   // and fail as before, and --strict fails either way so main and the schedule
   // still see them.
+  //
+  // The test is "holds no meaningful content", NOT "is absent from the index".
+  // `=== undefined` was wrong on the beta -> production build: that one sets
+  // DOCS_LAST_VERSION = "current", so lastVersionTag becomes
+  // docs-default-current - which the index already holds with ONE stale record
+  // (a leftover /sdks/linux/barcode-capture/get-started/ from when current was
+  // served). releasePending came out false, the outgoing docs-default-8.5.3 with
+  // its 559 pages tripped `unreachable`, and the build failed with no path to
+  // green. That is one of the three cycle events named above.
+  //
+  // Nothing is masked by the wider test: a served tag genuinely below the
+  // threshold is what the THIN check reports, and it reports it either way.
+  const servedCount = manifest.lastVersionTag
+    ? counts[manifest.lastVersionTag]
+    : undefined;
   const releasePending =
-    !!manifest.lastVersionTag && counts[manifest.lastVersionTag] === undefined;
+    !!manifest.lastVersionTag &&
+    (servedCount === undefined || servedCount < THIN_PAGE_THRESHOLD);
   const pendingAlwaysOn = alwaysOn.filter((tag) => counts[tag] === undefined);
   const alwaysOnEmpty = alwaysOn.length > 0 && pendingAlwaysOn.length === alwaysOn.length;
 
@@ -359,8 +397,9 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
         ? `\n  This build renames the served version to "${manifest.lastVersionTag}",\n` +
             `  which the index does not hold yet, so the outgoing tag is expected to be\n` +
             `  unreachable until the deploy is crawled. Re-run then, or use --strict.`
-        : `\n  Either the widget must include the tag (alwaysOnSearchTags in\n` +
-            `  docusaurus.config.ts) or the crawler must stop emitting it.`,
+        : `\n  Either give the tag a home in buildApiReferenceTags / docsVersions\n` +
+            `  (docusaurus.config.ts) so the widget filters on it, or stop the\n` +
+            `  Algolia crawler emitting it. There is no alwaysOnSearchTags option.`,
     );
   }
 
@@ -372,6 +411,24 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
         `${alwaysOnEmpty ? "No always-on tag has content - the API reference is unreachable." : "Another always-on tag still carries the content."}` + NL,
     );
     if (alwaysOnEmpty) failed = true;
+  }
+
+  // A SINGLE empty API-reference tag is already a hole, not a migration in
+  // flight. If the crawler stops emitting api-reference-7.6, every 7.6 reader's
+  // OR-branch filters on a zero-record tag and 2,501 pages leave 7.6 search -
+  // the exact August regression class. This used to print only a NOTE and exit 0,
+  // because `alwaysOnEmpty` required EVERY api tag to be empty at once and
+  // `missing` explicitly excluded them. Skipped while a release is pending: a
+  // brand-new version's API tag has not been crawled yet either.
+  const emptyApiTags = releasePending || alwaysOnEmpty ? [] : pendingAlwaysOn;
+  if (emptyApiTags.length) {
+    failed = true;
+    console.error(
+      `\nFAIL: API-reference tag(s) the widget filters on hold nothing:` + NL +
+        emptyApiTags.map((t) => `  "${t}" -> 0 records`).join(NL) + NL +
+        `  Readers on those versions get an OR-branch matching nothing, so that` + NL +
+        `  version's API reference is absent from search.` + NL,
+    );
   }
 
   if (missing.length) {
@@ -413,9 +470,19 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
 // A network failure is not a content failure. An Algolia outage, a rate limit or
 // a sandboxed runner would otherwise block merging unrelated docs PRs. Under
 // --strict (main, or the schedule, where someone is watching) it still fails.
+// Faults the gate must never swallow. These are deterministic config errors, not
+// a flaky network, and treating them as transport meant the gate could degrade to
+// a complete no-op while printing a line nobody reads and passing CI.
+const FATAL_PATTERNS = [
+  /does not match this script/i, // assertConfigInSync: Algolia key drift
+  /No search-tag manifest/i, // the manifest plugin stopped running
+];
+
 main().catch((err) => {
-  console.error(`\nsearch-tag gate could not run: ${err.message}\n`);
-  // Exit 0 unless --strict: a transport failure is not a content failure, and
-  // must not block an unrelated docs PR. --strict runs (main, schedule) still fail.
-  process.exit(strict ? 1 : 0);
+  const message = err && err.message ? err.message : String(err);
+  const deterministic = FATAL_PATTERNS.some((re) => re.test(message));
+  console.error(`\nsearch-tag gate could not run: ${message}\n`);
+  // A transport failure exits 0 unless --strict, so an Algolia outage cannot
+  // block an unrelated docs PR. A deterministic config fault always fails.
+  process.exit(deterministic || strict ? 1 : 0);
 });

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -185,11 +185,16 @@ async function main() {
   const reachable = new Set([
     manifest.defaultTag,
     manifest.lastVersionTag,
-    ...(manifest.alwaysOnTags || []),
+    // The API reference for the served version. The other versions' API tags
+    // are reachable from those versions' pages, so they count as routable.
+    ...((manifest.apiReferenceTagsByVersionTag || {})[manifest.lastVersionTag] || []),
   ]);
   // Reached only when a reader types a version. Checked for existence, but a tag
   // being routable does NOT make its content reachable by ordinary search.
-  const routable = new Set(Object.values(manifest.versionTagByMajor || {}));
+  const routable = new Set([
+    ...Object.values(manifest.versionTagByMajor || {}),
+    ...Object.values(manifest.apiReferenceTagsByVersionTag || {}).flat(),
+  ]);
 
   // Checked before any network call: typing the major the site is serving must
   // route to the version the site is serving. When 8.6.0-beta became `current`
@@ -258,16 +263,21 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   );
   // `default` legitimately holds only a handful of non-doc pages, so thinness is
   // only meaningful for the tags that carry the docs themselves.
-  const thin = [manifest.lastVersionTag, ...(manifest.alwaysOnTags || [])]
+  const thin = [manifest.lastVersionTag]
     .filter((tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD)
     .map((tag) => [tag, counts[tag]]);
   // An always-on tag that holds nothing is a migration in flight, not a broken
   // build: the repo can name the crawler's target tag before the crawler emits
   // it, or the other way round. Either order must keep CI green as long as one
   // always-on tag still carries the content.
-  const alwaysOn = manifest.alwaysOnTags || [];
+  // Flatten the per-version API-reference map: every tag it names must exist.
+  const apiMap = manifest.apiReferenceTagsByVersionTag || {};
+  const alwaysOn = [...new Set(Object.values(apiMap).flat())];
+  // API-reference tags are reported by the migration check above, so they are
+  // excluded here rather than counted twice.
+  const apiTags = new Set(alwaysOn);
   const missing = [manifest.defaultTag, manifest.lastVersionTag, ...routable]
-    .filter((tag) => tag && counts[tag] === undefined);
+    .filter((tag) => tag && !apiTags.has(tag) && counts[tag] === undefined);
   const pendingAlwaysOn = alwaysOn.filter((tag) => counts[tag] === undefined);
   const alwaysOnEmpty = alwaysOn.length > 0 && pendingAlwaysOn.length === alwaysOn.length;
 

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -5,11 +5,18 @@
  * The search widget filters every query on `docusaurus_tag`, and Docusaurus
  * builds that tag from the version NAME. So renaming a docs version - which is
  * what every release does - changes what search can reach, without changing a
- * single URL and without breaking anything loudly. In August 2026 releasing
- * 8.5.3 renamed the guides from `docs-default-current` to `docs-default-8.5.3`;
+ * single URL and without breaking anything loudly. In August 2026 e92c1b16
+ * (Release 8.6.0-beta.1) set `lastVersion: "8.5.2"` and made `current` the
+ * unreleased beta, so the guides at the root stopped emitting
+ * `docs-default-current` (8.5.3 was a later patch bump, not the cause);
  * the API reference kept the old tag, stopped sharing one with the guides, and
  * ~3,200 pages silently left every search result. Nothing failed. Results just
  * got worse.
+ *
+ * And it is a CYCLE, not a one-off. The root-served tag moves three times per
+ * release train: production -> beta, every patch during the beta window, and
+ * beta -> production. So the build that renames it is a NORMAL event this gate
+ * has to stay green through - see `releasePending` below.
  *
  * This gate exists so that cannot happen quietly again. It does NOT re-derive
  * the tags from docusaurus.config.ts - a derivation checked against itself
@@ -128,7 +135,12 @@ function tagsEmittedByBuild(buildDir, expected, fileCap = 4000) {
       }
     }
   }
-  return found;
+  // `exhausted` distinguishes "walked the whole build" from "hit the cap". With
+  // an arbitrary stack.pop() order, a cap reached before every wanted tag was
+  // seen makes absence meaningless - reporting it as config drift blames the
+  // config for a truncated walk. Today's build is ~2,250 pages against a 4,000
+  // cap, so this is headroom for about two more frozen versions.
+  return { found, exhausted: !(seen >= fileCap && found.size < wanted.size) };
 }
 
 async function algolia(body) {
@@ -155,22 +167,31 @@ async function algolia(body) {
  * `distinct` setting and is what a reader actually sees.
  */
 async function pagesByTag() {
+  const FACET_CAP = 1000; // Algolia's maximum. Ten tags today; above the cap an
+  // absent tag would read as undefined and land in `missing` as a false FAIL.
   const { facets } = await algolia({
     query: "",
     hitsPerPage: 0,
     facets: ["docusaurus_tag"],
-    maxValuesPerFacet: 100,
+    maxValuesPerFacet: FACET_CAP,
   });
   const tags = Object.keys((facets && facets.docusaurus_tag) || {});
   const counts = {};
+  // Bounded concurrency rather than one request per tag at once: an unbounded
+  // fan-out is what trips Algolia's rate limit, and a 429 here surfaces as a
+  // transport error that used to fail CI.
+  const CONCURRENCY = 4;
+  const queue = [...tags];
   await Promise.all(
-    tags.map(async (tag) => {
-      const { nbHits } = await algolia({
-        query: "",
-        hitsPerPage: 0,
-        facetFilters: [[`docusaurus_tag:${tag}`]],
-      });
-      counts[tag] = nbHits;
+    Array.from({ length: Math.min(CONCURRENCY, queue.length) }, async () => {
+      for (let tag = queue.pop(); tag !== undefined; tag = queue.pop()) {
+        const { nbHits } = await algolia({
+          query: "",
+          hitsPerPage: 0,
+          facetFilters: [[`docusaurus_tag:${tag}`]],
+        });
+        counts[tag] = nbHits;
+      }
     }),
   );
   return counts;
@@ -189,6 +210,15 @@ async function main() {
     // are reachable from those versions' pages, so they count as routable.
     ...((manifest.apiReferenceTagsByVersionTag || {})[manifest.lastVersionTag] || []),
   ]);
+  // Reachable WITHOUT typing anything, but only from another version's pages: a
+  // reader on 7.6.14 gets api-reference-7.6 from that page's own contextual
+  // filter. Not in `reachable` (which is about the served version), but calling
+  // these "typed-only" in the report understated them - no typing is involved.
+  const contextual = new Set(
+    Object.entries(manifest.apiReferenceTagsByVersionTag || {})
+      .filter(([versionTag]) => versionTag !== manifest.lastVersionTag)
+      .flatMap(([, tags]) => tags),
+  );
   // Reached only when a reader types a version. Checked for existence, but a tag
   // being routable does NOT make its content reachable by ordinary search.
   const routable = new Set([
@@ -225,15 +255,22 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
       manifest.lastVersionTag,
       ...Object.values(manifest.versionTagByMajor || {}),
     ];
-    const emitted = tagsEmittedByBuild(buildDir, expected);
+    const { found: emitted, exhausted } = tagsEmittedByBuild(buildDir, expected);
     const notEmitted = expected.filter((t) => !emitted.has(t));
-    if (notEmitted.length) {
+    if (notEmitted.length && exhausted) {
       console.error(
         `\nFAIL: the config names tags this build never emits:\n` +
           notEmitted.map((t) => `  ${t}`).join("\n") +
           `\n  docsVersions / lastVersion and the tag derivation disagree.\n`,
       );
       process.exitCode = 1;
+    } else if (notEmitted.length) {
+      console.error(
+        `\nINCONCLUSIVE: stopped scanning the build before finding:\n` +
+          notEmitted.map((t) => `  ${t}`).join("\n") +
+          `\n  The file cap was reached, so absence proves nothing here.\n` +
+          `  Raise the cap in tagsEmittedByBuild if the build has grown.\n`,
+      );
     }
   }
 
@@ -247,9 +284,14 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
       `  ${String(n).padStart(6)}  ${
         reachable.has(tag)
           ? "reachable  "
-          : routable.has(tag)
-            ? "typed-only "
-            : "UNREACHABLE"
+          : contextual.has(tag)
+            ? // Reachable without typing anything: a reader on 7.6 gets
+              // api-reference-7.6 from that page's own contextual filter. Calling
+              // it "typed-only" understated it in the operator-facing report.
+              "contextual "
+            : routable.has(tag)
+              ? "typed-only "
+              : "UNREACHABLE"
       }  ${tag}`,
     );
   }
@@ -276,22 +318,49 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // API-reference tags are reported by the migration check above, so they are
   // excluded here rather than counted twice.
   const apiTags = new Set(alwaysOn);
-  const missing = [manifest.defaultTag, manifest.lastVersionTag, ...routable]
-    .filter((tag) => tag && !apiTags.has(tag) && counts[tag] === undefined);
+  // Deduped: lastVersionTag is also in `routable`, so it printed twice.
+  const missing = [
+    ...new Set([manifest.defaultTag, manifest.lastVersionTag, ...routable]),
+  ].filter((tag) => tag && !apiTags.has(tag) && counts[tag] === undefined);
+
+  // Is this the build that renames the version served at the root?
+  //
+  // On that build the config names a tag the index cannot possibly hold yet -
+  // nothing is deployed, nothing is crawled - and the OUTGOING version's tag is
+  // still in the index with no config entry pointing at it. Both look exactly
+  // like the failures this gate is for, so treating them as failures made every
+  // release PR red with no path to green until after deploy plus crawl. That is
+  // the one change this gate exists to protect, so it must not block it.
+  //
+  // Detected rather than declared: if the served tag has no records at all, the
+  // index predates this build. Post-crawl the same conditions are real problems
+  // and fail as before, and --strict fails either way so main and the schedule
+  // still see them.
+  const releasePending =
+    !!manifest.lastVersionTag && counts[manifest.lastVersionTag] === undefined;
   const pendingAlwaysOn = alwaysOn.filter((tag) => counts[tag] === undefined);
   const alwaysOnEmpty = alwaysOn.length > 0 && pendingAlwaysOn.length === alwaysOn.length;
 
   let failed = process.exitCode === 1;
 
   if (unreachable.length) {
-    failed = true;
-    console.error(`\nFAIL: indexed content the search widget cannot reach.`);
+    // While a release is pending, the outgoing version's tag is unreachable by
+    // construction: this build renamed it and the index has not caught up.
+    const hard = strict || !releasePending;
+    if (hard) failed = true;
+    console.error(
+      `\n${hard ? "FAIL" : "WARN"}: indexed content the search widget cannot reach.`,
+    );
     for (const [tag, n] of unreachable) {
       console.error(`  ${n} pages tagged "${tag}" are in the index but filtered out of every query.`);
     }
     console.error(
-      `\n  Either the widget must include the tag (alwaysOnSearchTags in\n` +
-        `  docusaurus.config.ts) or the crawler must stop emitting it.`,
+      releasePending && !strict
+        ? `\n  This build renames the served version to "${manifest.lastVersionTag}",\n` +
+            `  which the index does not hold yet, so the outgoing tag is expected to be\n` +
+            `  unreachable until the deploy is crawled. Re-run then, or use --strict.`
+        : `\n  Either the widget must include the tag (alwaysOnSearchTags in\n` +
+            `  docusaurus.config.ts) or the crawler must stop emitting it.`,
     );
   }
 
@@ -306,10 +375,24 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   }
 
   if (missing.length) {
-    failed = true;
-    console.error(`\nFAIL: the widget filters on tags that hold nothing at all.`);
+    // A tag missing ONLY because this build just named it is the release flow
+    // working, not a broken config. Anything else missing is still a hard fail
+    // even mid-release.
+    const onlyTheNewServedTag =
+      releasePending &&
+      missing.every((tag) => tag === manifest.lastVersionTag);
+    const hard = strict || !onlyTheNewServedTag;
+    if (hard) failed = true;
+    console.error(
+      `\n${hard ? "FAIL" : "WARN"}: the widget filters on tags that hold nothing at all.`,
+    );
     for (const tag of missing) console.error(`  "${tag}" -> 0 records`);
-    console.error(`  A tag that matches nothing means those queries return nothing.`);
+    console.error(
+      onlyTheNewServedTag && !strict
+        ? `  Expected: this build introduces "${manifest.lastVersionTag}". The crawler\n` +
+            `  populates it after deploy. Re-run then, or use --strict.`
+        : `  A tag that matches nothing means those queries return nothing.`,
+    );
   }
 
   if (thin.length) {
@@ -327,7 +410,12 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   process.exit(failed ? 1 : 0);
 }
 
+// A network failure is not a content failure. An Algolia outage, a rate limit or
+// a sandboxed runner would otherwise block merging unrelated docs PRs. Under
+// --strict (main, or the schedule, where someone is watching) it still fails.
 main().catch((err) => {
   console.error(`\nsearch-tag gate could not run: ${err.message}\n`);
-  process.exit(1);
+  // Exit 0 unless --strict: a transport failure is not a content failure, and
+  // must not block an unrelated docs PR. --strict runs (main, schedule) still fail.
+  process.exit(strict ? 1 : 0);
 });

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -411,7 +411,8 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   //
   // Detected rather than declared: if the served tag has no records at all, the
   // index predates this build. Post-crawl the same conditions are real problems
-  // and fail as before, and --strict fails either way so main
+  // and fail as before, and --strict fails either way so main and the daily
+  // scheduled run
   // still see them.
   //
   // The test is "holds no meaningful content", NOT "is absent from the index".
@@ -459,9 +460,9 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
     console.error(
       `\nNOTE: treating "${manifest.lastVersionTag}" as a release whose crawl has` + NL +
         `  not run yet, so its own page count is not being judged. If this same` + NL +
-        `  line appears on consecutive runs days apart, it is not a release - the` + NL +
-        `  crawl for the served version has stalled, and that is what the standing` + NL +
-        `  Algolia monitor exists to catch.` + NL,
+        `  line appears on consecutive daily runs, it is not a release - the crawl` + NL +
+        `  for the served version has stalled. The scheduled --strict run is where` + NL +
+        `  that shows up, because it is the only one that fires post-crawl.` + NL,
     );
   }
 
@@ -667,10 +668,9 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
 
 // A network failure is not a content failure. An Algolia outage, a rate limit or
 // a sandboxed runner would otherwise block merging unrelated docs PRs. Under
-// --strict (main, where someone is watching) it still fails. There is no
-// scheduled run in this repo; the standing Algolia check that catches a crawl
-// finishing later lives outside CI, so "re-run after the crawl" means a manual
-// re-run or the next push to main.
+// --strict (main, and the daily scheduled run where someone is watching) it
+// still fails. "Re-run after the crawl" is served by that scheduled run, or by
+// triggering the workflow by hand - see .github/workflows/build-docs.yml.
 // Faults the gate must never swallow. These are deterministic config errors, not
 // a flaky network, and treating them as transport meant the gate could degrade to
 // a complete no-op while printing a line nobody reads and passing CI.

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * Search-tag gate.
+ *
+ * The search widget filters every query on `docusaurus_tag`, and Docusaurus
+ * builds that tag from the version NAME. So renaming a docs version - which is
+ * what every release does - changes what search can reach, without changing a
+ * single URL and without breaking anything loudly. In August 2026 releasing
+ * 8.5.3 renamed the guides from `docs-default-current` to `docs-default-8.5.3`;
+ * the API reference kept the old tag, stopped sharing one with the guides, and
+ * ~3,200 pages silently left every search result. Nothing failed. Results just
+ * got worse.
+ *
+ * This gate exists so that cannot happen quietly again. It does NOT re-derive
+ * the tags from docusaurus.config.ts - a derivation checked against itself
+ * always agrees. It compares two independent real sources:
+ *
+ *   1. build/search-tags.json - what this build's widget will actually filter on
+ *      (written by the search-tags-manifest plugin in docusaurus.config.ts).
+ *   2. The live Algolia index - what is actually in there, and under which tag.
+ *
+ * Failure modes it separates:
+ *   - UNREACHABLE  a tag holds real content the widget cannot match. A config
+ *                  bug. Deterministic. Exits non-zero.
+ *   - THIN         a tag the widget targets holds too few pages. Usually the
+ *                  crawler still catching up after a deploy. Warns, and only
+ *                  fails under --strict, so a mid-crawl window cannot block PRs.
+ *
+ * Usage:
+ *   node scripts/verify-search-tags.cjs [--strict] [--manifest <path|url>]
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+// Public, search-only credentials - the same ones the widget ships to browsers.
+// Kept in step with the `algolia` block in docusaurus.config.ts by the
+// assertConfigInSync() check below, so this copy cannot drift unnoticed.
+const ALGOLIA = {
+  appId: "RYKD97E6SH",
+  apiKey: "8372250579ef3ea82cc637a28e50f73f",
+  indexName: "scandit",
+};
+
+// A tag holding at least this many distinct pages is real content, not a
+// leftover husk from an old version name. Below it, an unreachable tag is
+// reported but tolerated.
+const ORPHAN_PAGE_THRESHOLD = 50;
+
+// A tag the widget targets is expected to carry at least this many pages.
+const THIN_PAGE_THRESHOLD = 100;
+
+const DEFAULT_MANIFEST = path.join(__dirname, "..", "build", "search-tags.json");
+
+const argv = process.argv.slice(2);
+const strict = argv.includes("--strict");
+const manifestArg =
+  argv.includes("--manifest") ? argv[argv.indexOf("--manifest") + 1] : null;
+
+async function readManifest(source) {
+  if (source && /^https?:\/\//.test(source)) {
+    const res = await fetch(source);
+    if (!res.ok) throw new Error(`GET ${source} -> ${res.status}`);
+    return res.json();
+  }
+  const file = source || DEFAULT_MANIFEST;
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `No search-tag manifest at ${file}.\n` +
+        `Run \`yarn build\` first, or point at a deployed site:\n` +
+        `  node scripts/verify-search-tags.cjs --manifest https://docs.scandit.com/search-tags.json`,
+    );
+  }
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+/** The public Algolia keys live in two files; prove they still agree. */
+function assertConfigInSync() {
+  const configPath = path.join(__dirname, "..", "docusaurus.config.ts");
+  const src = fs.readFileSync(configPath, "utf8");
+  for (const [key, expected] of Object.entries(ALGOLIA)) {
+    const found = new RegExp(`${key}:\\s*"([^"]+)"`).exec(src);
+    if (!found || found[1] !== expected) {
+      throw new Error(
+        `Algolia ${key} in docusaurus.config.ts (${found ? found[1] : "missing"}) ` +
+          `does not match this script (${expected}). Update both.`,
+      );
+    }
+  }
+}
+
+/**
+ * Read the docusaurus_tag values the build actually emits.
+ *
+ * The manifest states what this build BELIEVES it serves. This reads what it
+ * really wrote into the HTML. They are the same fact from two directions, which
+ * is the only way a derived value gets checked - the drift that caused this gate
+ * to exist was a config that was internally consistent and still wrong.
+ */
+function tagsEmittedByBuild(buildDir, expected, fileCap = 4000) {
+  const found = new Set();
+  const wanted = new Set(expected);
+  const stack = [buildDir];
+  let seen = 0;
+  while (stack.length && seen < fileCap && found.size < wanted.size) {
+    const dir = stack.pop();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        stack.push(full);
+      } else if (e.name === "index.html") {
+        seen += 1;
+        const m = /name="docusaurus_tag" content="([^"]+)"/.exec(
+          fs.readFileSync(full, "utf8"),
+        );
+        // Only tags we are looking for count toward the early exit; the build
+        // also emits tags for versions the manifest does not route to.
+        if (m && wanted.has(m[1])) found.add(m[1]);
+        if (found.size >= wanted.size) break;
+      }
+    }
+  }
+  return found;
+}
+
+async function algolia(body) {
+  const res = await fetch(
+    `https://${ALGOLIA.appId}-dsn.algolia.net/1/indexes/${ALGOLIA.indexName}/query`,
+    {
+      method: "POST",
+      headers: {
+        "X-Algolia-API-Key": ALGOLIA.apiKey,
+        "X-Algolia-Application-Id": ALGOLIA.appId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    },
+  );
+  if (!res.ok) throw new Error(`Algolia ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+/**
+ * Distinct pages per tag. The index stores one record per heading, so a raw
+ * facet count is several times the page count and reads far healthier than the
+ * widget's own result count. nbHits under a facet filter applies the index's
+ * `distinct` setting and is what a reader actually sees.
+ */
+async function pagesByTag() {
+  const { facets } = await algolia({
+    query: "",
+    hitsPerPage: 0,
+    facets: ["docusaurus_tag"],
+    maxValuesPerFacet: 100,
+  });
+  const tags = Object.keys((facets && facets.docusaurus_tag) || {});
+  const counts = {};
+  await Promise.all(
+    tags.map(async (tag) => {
+      const { nbHits } = await algolia({
+        query: "",
+        hitsPerPage: 0,
+        facetFilters: [[`docusaurus_tag:${tag}`]],
+      });
+      counts[tag] = nbHits;
+    }),
+  );
+  return counts;
+}
+
+async function main() {
+  assertConfigInSync();
+  const manifest = await readManifest(manifestArg);
+
+  // What EVERY query reaches, with nothing typed. This is the set that matters:
+  // a tag reachable only when the reader happens to type "v8" is not reachable.
+  const reachable = new Set([
+    manifest.defaultTag,
+    manifest.lastVersionTag,
+    ...(manifest.alwaysOnTags || []),
+  ]);
+  // Reached only when a reader types a version. Checked for existence, but a tag
+  // being routable does NOT make its content reachable by ordinary search.
+  const routable = new Set(Object.values(manifest.versionTagByMajor || {}));
+
+  // Checked before any network call: typing the major the site is serving must
+  // route to the version the site is serving. When 8.6.0-beta became `current`
+  // and 8.5.3 became lastVersion, "v8" pointed at the beta's tag instead - and
+  // because that tag also held the API reference, it still returned results, so
+  // nothing looked broken. This is the check that catches it deterministically.
+  const servedMajor = String(manifest.lastVersionTag).replace(
+    /^docs-default-/,
+    "",
+  ).split(".")[0];
+  const routedForServedMajor = (manifest.versionTagByMajor || {})[servedMajor];
+  if (routedForServedMajor && routedForServedMajor !== manifest.lastVersionTag) {
+    console.error(
+      `
+FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site ` +
+        `serves "${manifest.lastVersionTag}".
+` +
+        `  Fix buildVersionTagByMajor in docusaurus.config.ts.
+`,
+    );
+    process.exitCode = 1;
+  }
+
+  // Against a local build: does the site really emit the tags the config claims?
+  const buildDir = path.dirname(DEFAULT_MANIFEST);
+  if (!manifestArg && fs.existsSync(buildDir)) {
+    const expected = [
+      manifest.lastVersionTag,
+      ...Object.values(manifest.versionTagByMajor || {}),
+    ];
+    const emitted = tagsEmittedByBuild(buildDir, expected);
+    const notEmitted = expected.filter((t) => !emitted.has(t));
+    if (notEmitted.length) {
+      console.error(
+        `\nFAIL: the config names tags this build never emits:\n` +
+          notEmitted.map((t) => `  ${t}`).join("\n") +
+          `\n  docsVersions / lastVersion and the tag derivation disagree.\n`,
+      );
+      process.exitCode = 1;
+    }
+  }
+
+  const counts = await pagesByTag();
+  const rows = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+
+  console.log(`\nIndex "${ALGOLIA.indexName}" - distinct pages per docusaurus_tag`);
+  console.log(`Site serves: ${manifest.lastVersionTag} (lastVersion ${manifest.lastVersion})\n`);
+  for (const [tag, n] of rows) {
+    console.log(
+      `  ${String(n).padStart(6)}  ${
+        reachable.has(tag)
+          ? "reachable  "
+          : routable.has(tag)
+            ? "typed-only "
+            : "UNREACHABLE"
+      }  ${tag}`,
+    );
+  }
+
+  // A frozen version's tag is deliberately out of scope while you read another
+  // version - that is what contextual search is for. Only content reachable
+  // through no path at all is orphaned.
+  const unreachable = rows.filter(
+    ([tag, n]) =>
+      !reachable.has(tag) && !routable.has(tag) && n >= ORPHAN_PAGE_THRESHOLD,
+  );
+  // `default` legitimately holds only a handful of non-doc pages, so thinness is
+  // only meaningful for the tags that carry the docs themselves.
+  const thin = [manifest.lastVersionTag, ...(manifest.alwaysOnTags || [])]
+    .filter((tag) => counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD)
+    .map((tag) => [tag, counts[tag]]);
+  const missing = [...reachable, ...routable].filter(
+    (tag) => counts[tag] === undefined,
+  );
+
+  let failed = process.exitCode === 1;
+
+  if (unreachable.length) {
+    failed = true;
+    console.error(`\nFAIL: indexed content the search widget cannot reach.`);
+    for (const [tag, n] of unreachable) {
+      console.error(`  ${n} pages tagged "${tag}" are in the index but filtered out of every query.`);
+    }
+    console.error(
+      `\n  Either the widget must include the tag (alwaysOnSearchTags in\n` +
+        `  docusaurus.config.ts) or the crawler must stop emitting it.`,
+    );
+  }
+
+  if (missing.length) {
+    failed = true;
+    console.error(`\nFAIL: the widget filters on tags that hold nothing at all.`);
+    for (const tag of missing) console.error(`  "${tag}" -> 0 records`);
+    console.error(`  A tag that matches nothing means those queries return nothing.`);
+  }
+
+  if (thin.length) {
+    console.error(
+      `\n${strict ? "FAIL" : "WARN"}: tags below ${THIN_PAGE_THRESHOLD} pages.`,
+    );
+    for (const [tag, n] of thin) console.error(`  "${tag}" -> ${n} pages`);
+    console.error(
+      `  Usually the crawler catching up after a deploy; re-run once it has.`,
+    );
+    if (strict) failed = true;
+  }
+
+  if (!failed) console.log(`\nOK: every tag with content is reachable.\n`);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(`\nsearch-tag gate could not run: ${err.message}\n`);
+  process.exit(1);
+});

--- a/scripts/verify-search-tags.cjs
+++ b/scripts/verify-search-tags.cjs
@@ -393,9 +393,32 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   const servedCount = manifest.lastVersionTag
     ? counts[manifest.lastVersionTag]
     : undefined;
+  const servedThin =
+    servedCount === undefined || servedCount < THIN_PAGE_THRESHOLD;
+
+  // Corroboration, because "the served tag is thin" is equally true when the
+  // crawler is broken - and releasePending suppresses unreachable, thin and
+  // emptyApiTags, so believing it during an outage silences the gate at exactly
+  // the moment search is most broken. A release in flight moves ONE tag; an
+  // outage collapses all of them. If no OTHER docs-version tag still holds
+  // content, this is not a release.
+  const otherDocsTagsHealthy = Object.keys(
+    manifest.apiReferenceTagsByVersionTag || {},
+  ).some(
+    (tag) =>
+      tag !== manifest.lastVersionTag &&
+      (counts[tag] || 0) >= THIN_PAGE_THRESHOLD,
+  );
   const releasePending =
-    !!manifest.lastVersionTag &&
-    (servedCount === undefined || servedCount < THIN_PAGE_THRESHOLD);
+    !!manifest.lastVersionTag && servedThin && otherDocsTagsHealthy;
+
+  if (servedThin && !otherDocsTagsHealthy) {
+    console.error(
+      `\nNOTE: the served tag "${manifest.lastVersionTag}" is thin AND no other` + NL +
+        `  docs version holds content either. That is an index-wide failure, not a` + NL +
+        `  release in flight, so nothing below is being excused as "crawl pending".` + NL,
+    );
+  }
 
   // Skipped while a release is pending: the served tag being thin is the
   // definition of that state, not a separate problem. Without this, --strict on
@@ -444,10 +467,11 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
       console.error(`  ${n} pages tagged "${tag}" are in the index but filtered out of every query.`);
     }
     console.error(
-      releasePending && !strict
+      releasePending
         ? `\n  This build renames the served version to "${manifest.lastVersionTag}",\n` +
             `  which the index does not hold yet, so the outgoing tag is expected to be\n` +
-            `  unreachable until the deploy is crawled. Re-run then, or use --strict.`
+            `  unreachable until the deploy is crawled. Re-run after the crawl.\n` +
+            `  --strict does NOT turn this into a failure: the state is real.`
         : `\n  Either give the tag a home in buildApiReferenceTags / docsVersions\n` +
             `  (docusaurus.config.ts) so the widget filters on it, or stop the\n` +
             `  Algolia crawler emitting it. There is no alwaysOnSearchTags option.`,
@@ -472,6 +496,34 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
   // `missing` explicitly excluded them. Skipped while a release is pending: a
   // brand-new version's API tag has not been crawled yet either.
   const emptyApiTags = releasePending || alwaysOnEmpty ? [] : pendingAlwaysOn;
+
+  // ...and a tag that still exists but has collapsed. emptyApiTags only tests
+  // `=== undefined`, `missing` excludes API tags by construction, `unreachable`
+  // skips them as contextual, and `thin` only ever looked at the served version -
+  // so api-reference-7.6 dropping from 2,501 pages to 4 printed
+  // "OK: every tag with content is reachable." A partial collapse is the same
+  // regression class as a total one; 7.6 readers just lose most of the API
+  // reference instead of all of it.
+  const thinApiTags = releasePending
+    ? []
+    : alwaysOn
+        .filter(
+          (tag) =>
+            counts[tag] !== undefined && counts[tag] < THIN_PAGE_THRESHOLD,
+        )
+        .map((tag) => [tag, counts[tag]]);
+  if (thinApiTags.length) {
+    failed = true;
+    console.error(
+      `\nFAIL: API-reference tag(s) hold far too little to be a whole tree:` + NL +
+        thinApiTags
+          .map(([t, n]) => `  "${t}" -> ${n} pages (floor ${THIN_PAGE_THRESHOLD})`)
+          .join(NL) + NL +
+        `  Each of these trees is thousands of pages. This few means the crawl is` + NL +
+        `  partial or its extractor is dropping records - readers on that version` + NL +
+        `  can no longer find most of their API reference.` + NL,
+    );
+  }
   if (emptyApiTags.length) {
     failed = true;
     console.error(
@@ -496,9 +548,10 @@ FAIL: typing "v${servedMajor}" routes to "${routedForServedMajor}", but the site
     );
     for (const tag of missing) console.error(`  "${tag}" -> 0 records`);
     console.error(
-      onlyTheNewServedTag && !strict
+      onlyTheNewServedTag
         ? `  Expected: this build introduces "${manifest.lastVersionTag}". The crawler\n` +
-            `  populates it after deploy. Re-run then, or use --strict.`
+            `  populates it after deploy. Re-run after the crawl; --strict does NOT\n` +
+            `  turn this into a failure, because the state is real.`
         : `  A tag that matches nothing means those queries return nothing.`,
     );
   }
@@ -535,9 +588,17 @@ main().catch((err) => {
   // flaky network. One of them (a temporal-dead-zone read of releasePending) was
   // swallowed as a transport failure and exited 0, so the gate crashed and CI
   // stayed green.
+  // Node's fetch (undici) rejects with a TypeError for DNS, connection and TLS
+  // failures - "TypeError: fetch failed", with the real cause attached - so
+  // treating every TypeError as a defect made the documented transport tolerance
+  // unreachable for the most common transport failure: one DNS blip on a runner
+  // would block an unrelated docs PR. Those carry a `cause`; a real defect in
+  // this script (reading a property of undefined) does not.
+  const isTransportTypeError =
+    err instanceof TypeError && (err.message === "fetch failed" || !!err.cause);
   const isBug =
     err instanceof ReferenceError ||
-    err instanceof TypeError ||
+    (err instanceof TypeError && !isTransportTypeError) ||
     err instanceof SyntaxError;
   const deterministic = isBug || FATAL_PATTERNS.some((re) => re.test(message));
   console.error(`\nsearch-tag gate could not run: ${message}\n`);

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -178,7 +178,7 @@ function rewriteVersionTag(facetFilters, targetTag, apiMap) {
   const targetApi = ((apiMap && apiMap[targetTag]) || []).map(
     (t) => `docusaurus_tag:${t}`,
   );
-  const swap = (f) => {
+  const swap = (f, depth) => {
     if (typeof f === "string") {
       // Swap only the tag of the version the page is served from. Leave
       // docusaurus_tag:default (framework-agnostic / non-doc pages) and any
@@ -193,9 +193,27 @@ function rewriteVersionTag(facetFilters, targetTag, apiMap) {
     // Swap the whole API-reference set for the target version's, keeping
     // docusaurus_tag:default and anything else in the OR group untouched.
     const rest = f.filter((t) => !String(t).startsWith(API_TAG_PREFIX));
-    return [...rest.map(swap), ...targetApi];
+    const mapped = rest.map((t) => swap(t, depth + 1));
+    // WHERE the API tags are appended is the whole correctness of this function,
+    // and getting it wrong is silent both ways:
+    //
+    //   - at depth 0, facetFilters entries are ANDed, so appending there makes
+    //     every hit have to carry the API tag and filters out every guide page.
+    //     Typing "v7" then returns nothing but 7.6 API pages.
+    //   - in a nested group that is NOT the docusaurus_tag group - the
+    //     `["language:en"]` group, say - appending ORs the API tag against the
+    //     language filter and quietly widens it.
+    //
+    // So: nested only, and only the group that already carries the page's own
+    // docusaurus_tag.
+    const isTagOrGroup =
+      depth > 0 && f.some((t) => String(t).startsWith("docusaurus_tag:"));
+    if (!isTagOrGroup) return mapped;
+    // Dedupe: a version tag can appear more than once in the incoming group, and
+    // both copies swap to the same target.
+    return [...new Set([...mapped, ...targetApi])];
   };
-  return swap(facetFilters);
+  return swap(facetFilters, 0);
 }
 // Remove the framework tokens (and, when it actually routes, the version marker)
 // from the query TEXT sent to Algolia. Routing is unaffected - it's driven by the

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -158,6 +158,14 @@ function withApiReferenceTags(contextualFilters, map) {
   let injected = false;
   const out = contextualFilters.map((entry) => {
     if (injected || !Array.isArray(entry)) return entry;
+    // Gate on CONTENT, not position. This used to latch on the first array it
+    // saw, which works only because useAlgoliaContextualFacetFilters happens to
+    // return the language filter as a bare string. If Docusaurus ever wraps it
+    // (`["language:en"]`), or a config filter gets prepended, the API tags would
+    // land in that group instead - silently dropped from the tag OR, which is
+    // the whole regression coming back. Every test here passes a string first,
+    // so nothing would have caught it.
+    if (!entry.some((t) => String(t).startsWith("docusaurus_tag:"))) return entry;
     const extra = apiTagsFor(entry, map).filter((t) => !entry.includes(t));
     injected = true;
     return extra.length ? [...entry, ...extra] : entry;
@@ -192,7 +200,15 @@ function rewriteVersionTag(facetFilters, targetTag, apiMap) {
     if (!Array.isArray(f)) return f;
     // Swap the whole API-reference set for the target version's, keeping
     // docusaurus_tag:default and anything else in the OR group untouched.
-    const rest = f.filter((t) => !String(t).startsWith(API_TAG_PREFIX));
+    // Only STRINGS are tested against the prefix. String() on a nested array
+    // joins its elements, so an OR group whose first element is an
+    // `api-reference-*` tag stringified to "docusaurus_tag:api-reference-…,…"
+    // and the entire group was dropped from the top-level AND - removing the
+    // docusaurus_tag filter altogether and returning every version's results.
+    // Safe today only because the tags are appended last and `default` is first.
+    const rest = f.filter(
+      (t) => Array.isArray(t) || !String(t).startsWith(API_TAG_PREFIX),
+    );
     const mapped = rest.map((t) => swap(t, depth + 1));
     // WHERE the API tags are appended is the whole correctness of this function,
     // and getting it wrong is silent both ways:

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -137,31 +137,32 @@ const EMPTY_VERSION_MAP = {};
 const EMPTY_TAG_LIST = [];
 // `useAlgoliaContextualFacetFilters` returns [languageFilter, [tagFilter, ...]]:
 // a top-level AND whose one nested array is the OR group of docusaurus_tags.
-// Indexed content that Docusaurus never tags for this build (the API reference,
-// see alwaysOnSearchTags in docusaurus.config.ts) has to join that OR group -
-// appending it at the top level would AND it against the page's own tag and
-// match nothing at all.
-// `scopeFilters` limits WHERE the extra tags apply: the API reference documents
-// the current SDK, so a reader on a frozen legacy version must not get it (on a
-// 7.6.14 page it took one query from 53 hits to 73, all 20 extras inapplicable).
-// Injecting only when the page's own tag is in scope keeps legacy search clean.
-function withAlwaysOnTags(contextualFilters, tagFilters, scopeFilters) {
-  if (!tagFilters.length) return contextualFilters;
-  const inScope =
-    !scopeFilters.length ||
-    contextualFilters.some(
-      (entry) =>
-        Array.isArray(entry) && entry.some((t) => scopeFilters.includes(t)),
-    );
-  if (!inScope) return contextualFilters;
+// The API reference lives in the same index but Docusaurus never tags it, so it
+// has to join that OR group - appending at the top level would AND it against
+// the page's own tag and match nothing at all.
+//
+// It is joined per version: the API reference is published per major.minor line,
+// so a reader on 6.28.11 gets the 6.28 API reference and never the 8.x one.
+// `map` comes from customFields (built in docusaurus.config.ts) and is keyed by
+// the docs tag the page itself carries.
+const API_TAG_PREFIX = "docusaurus_tag:api-reference-";
+function apiTagsFor(tagGroup, map) {
+  for (const entry of tagGroup) {
+    const tags = map[String(entry).replace("docusaurus_tag:", "")];
+    if (tags) return tags.map((t) => `docusaurus_tag:${t}`);
+  }
+  return EMPTY_TAG_LIST;
+}
+function withApiReferenceTags(contextualFilters, map) {
+  if (!map || !Object.keys(map).length) return contextualFilters;
   let injected = false;
   const out = contextualFilters.map((entry) => {
     if (injected || !Array.isArray(entry)) return entry;
+    const extra = apiTagsFor(entry, map).filter((t) => !entry.includes(t));
     injected = true;
-    return [...entry, ...tagFilters.filter((t) => !entry.includes(t))];
+    return extra.length ? [...entry, ...extra] : entry;
   });
-  // No OR group to join (contextual search returned only flat entries): add one.
-  return injected ? out : [...out, tagFilters];
+  return out;
 }
 function versionTagInQuery(query, versionTagByMajor) {
   const q = (query || "").toLowerCase();
@@ -171,21 +172,28 @@ function versionTagInQuery(query, versionTagByMajor) {
   const m = q.match(/\b(?:version|ver|v|sdk)\s*\.?\s*(\d+)\b/);
   return m ? versionTagByMajor[m[1]] || null : null;
 }
-function rewriteVersionTag(facetFilters, targetTag, keepTags = EMPTY_TAG_LIST) {
-  const keep = new Set(keepTags);
+function rewriteVersionTag(facetFilters, targetTag, apiMap) {
+  // Typing "v7" must move the API reference to 7.x as well, or the reader gets
+  // 7.6 guides beside 8.5 API pages.
+  const targetApi = ((apiMap && apiMap[targetTag]) || []).map(
+    (t) => `docusaurus_tag:${t}`,
+  );
   const swap = (f) => {
     if (typeof f === "string") {
       // Swap only the tag of the version the page is served from. Leave
-      // docusaurus_tag:default (framework-agnostic / non-doc pages), the
-      // always-on tags (API reference - see alwaysOnSearchTags in
-      // docusaurus.config.ts) and any other entry untouched, so the contextual
-      // OR isn't collapsed and that content still matches when a version is
-      // typed.
-      return f.startsWith("docusaurus_tag:docs-") && !keep.has(f)
+      // docusaurus_tag:default (framework-agnostic / non-doc pages) and any
+      // other entry untouched, so the contextual OR isn't collapsed and those
+      // pages still match when a version is typed. API-reference tags are
+      // handled separately below, because they must follow the version too.
+      return f.startsWith("docusaurus_tag:docs-")
         ? `docusaurus_tag:${targetTag}`
         : f;
     }
-    return Array.isArray(f) ? f.map(swap) : f;
+    if (!Array.isArray(f)) return f;
+    // Swap the whole API-reference set for the target version's, keeping
+    // docusaurus_tag:default and anything else in the OR group untouched.
+    const rest = f.filter((t) => !String(t).startsWith(API_TAG_PREFIX));
+    return [...rest.map(swap), ...targetApi];
   };
   return swap(facetFilters);
 }
@@ -302,21 +310,9 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
     siteConfig.customFields?.versionTagByMajor || EMPTY_VERSION_MAP;
   // Indexed content Docusaurus does not tag for this build (API reference).
   // Stable reference from siteConfig, so it is safe in memo dependencies.
-  const alwaysOnTagFilters = useMemo(
-    () =>
-      (siteConfig.customFields?.alwaysOnSearchTags || EMPTY_TAG_LIST).map(
-        (tag) => `docusaurus_tag:${tag}`,
-      ),
-    [siteConfig.customFields],
-  );
-  // Versions those tags are in scope for; empty means "everywhere".
-  const alwaysOnScopeFilters = useMemo(
-    () =>
-      (siteConfig.customFields?.alwaysOnScopeTags || EMPTY_TAG_LIST).map(
-        (tag) => `docusaurus_tag:${tag}`,
-      ),
-    [siteConfig.customFields],
-  );
+  // Docs version tag -> the API-reference tag(s) documenting that version.
+  const apiReferenceTags =
+    siteConfig.customFields?.apiReferenceTagsByVersionTag || EMPTY_VERSION_MAP;
   const processSearchResultUrl = useSearchResultUrlProcessor();
   const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
   const configFacetFilters = props.searchParameters?.facetFilters ?? [];
@@ -359,11 +355,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
     ? // Merge contextual search filters with config filters, after widening the
       // contextual tag OR group with the tags Docusaurus cannot know about.
       mergeFacetFilters(
-        withAlwaysOnTags(
-          contextualSearchFacetFilters,
-          alwaysOnTagFilters,
-          alwaysOnScopeFilters,
-        ),
+        withApiReferenceTags(contextualSearchFacetFilters, apiReferenceTags),
         configFacetFilters,
       )
     : // ... or use config facetFilters
@@ -621,7 +613,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
                   params.facetFilters = rewriteVersionTag(
                     params.facetFilters,
                     targetTag,
-                    alwaysOnTagFilters
+                    apiReferenceTags
                   );
                 }
                 if (analyticsPing) {
@@ -716,7 +708,7 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
       siteMetadata.docusaurusVersion,
       captureSearchDebounced,
       versionTagByMajor,
-      alwaysOnTagFilters,
+      apiReferenceTags,
     ]
   );
   useDocSearchKeyboardEvents({

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -141,8 +141,19 @@ const EMPTY_TAG_LIST = [];
 // see alwaysOnSearchTags in docusaurus.config.ts) has to join that OR group -
 // appending it at the top level would AND it against the page's own tag and
 // match nothing at all.
-function withAlwaysOnTags(contextualFilters, tagFilters) {
+// `scopeFilters` limits WHERE the extra tags apply: the API reference documents
+// the current SDK, so a reader on a frozen legacy version must not get it (on a
+// 7.6.14 page it took one query from 53 hits to 73, all 20 extras inapplicable).
+// Injecting only when the page's own tag is in scope keeps legacy search clean.
+function withAlwaysOnTags(contextualFilters, tagFilters, scopeFilters) {
   if (!tagFilters.length) return contextualFilters;
+  const inScope =
+    !scopeFilters.length ||
+    contextualFilters.some(
+      (entry) =>
+        Array.isArray(entry) && entry.some((t) => scopeFilters.includes(t)),
+    );
+  if (!inScope) return contextualFilters;
   let injected = false;
   const out = contextualFilters.map((entry) => {
     if (injected || !Array.isArray(entry)) return entry;
@@ -298,6 +309,14 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
       ),
     [siteConfig.customFields],
   );
+  // Versions those tags are in scope for; empty means "everywhere".
+  const alwaysOnScopeFilters = useMemo(
+    () =>
+      (siteConfig.customFields?.alwaysOnScopeTags || EMPTY_TAG_LIST).map(
+        (tag) => `docusaurus_tag:${tag}`,
+      ),
+    [siteConfig.customFields],
+  );
   const processSearchResultUrl = useSearchResultUrlProcessor();
   const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
   const configFacetFilters = props.searchParameters?.facetFilters ?? [];
@@ -340,7 +359,11 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
     ? // Merge contextual search filters with config filters, after widening the
       // contextual tag OR group with the tags Docusaurus cannot know about.
       mergeFacetFilters(
-        withAlwaysOnTags(contextualSearchFacetFilters, alwaysOnTagFilters),
+        withAlwaysOnTags(
+          contextualSearchFacetFilters,
+          alwaysOnTagFilters,
+          alwaysOnScopeFilters,
+        ),
         configFacetFilters,
       )
     : // ... or use config facetFilters

--- a/src/theme/SearchBar/index.js
+++ b/src/theme/SearchBar/index.js
@@ -127,10 +127,31 @@ function frameworksInQuery(query) {
   }
   return found;
 }
-// Major version typed in the query -> the newest docusaurus_tag on that line.
-// The map is derived from docsVersions in docusaurus.config.ts and passed in via
-// customFields (versionTagByMajor), so it can never drift from the real versions.
+// Major version typed in the query -> the docusaurus_tag of the version a reader
+// on that line is actually served. Derived from docsVersions + lastVersion in
+// docusaurus.config.ts and passed in via customFields. Being derived is not the
+// same as being right: this map was derived correctly from the wrong assumption
+// (that `current` is always the newest release) and pointed "v8" at an
+// unreleased beta for four days. `yarn verify:search-tags` is what checks it.
 const EMPTY_VERSION_MAP = {};
+const EMPTY_TAG_LIST = [];
+// `useAlgoliaContextualFacetFilters` returns [languageFilter, [tagFilter, ...]]:
+// a top-level AND whose one nested array is the OR group of docusaurus_tags.
+// Indexed content that Docusaurus never tags for this build (the API reference,
+// see alwaysOnSearchTags in docusaurus.config.ts) has to join that OR group -
+// appending it at the top level would AND it against the page's own tag and
+// match nothing at all.
+function withAlwaysOnTags(contextualFilters, tagFilters) {
+  if (!tagFilters.length) return contextualFilters;
+  let injected = false;
+  const out = contextualFilters.map((entry) => {
+    if (injected || !Array.isArray(entry)) return entry;
+    injected = true;
+    return [...entry, ...tagFilters.filter((t) => !entry.includes(t))];
+  });
+  // No OR group to join (contextual search returned only flat entries): add one.
+  return injected ? out : [...out, tagFilters];
+}
 function versionTagInQuery(query, versionTagByMajor) {
   const q = (query || "").toLowerCase();
   // Only an explicit version marker ("version 6", "ver 6", "v6", "sdk 6").
@@ -139,14 +160,17 @@ function versionTagInQuery(query, versionTagByMajor) {
   const m = q.match(/\b(?:version|ver|v|sdk)\s*\.?\s*(\d+)\b/);
   return m ? versionTagByMajor[m[1]] || null : null;
 }
-function rewriteVersionTag(facetFilters, targetTag) {
+function rewriteVersionTag(facetFilters, targetTag, keepTags = EMPTY_TAG_LIST) {
+  const keep = new Set(keepTags);
   const swap = (f) => {
     if (typeof f === "string") {
-      // Swap only the versioned docs tag (docusaurus_tag:docs-*). Leave
-      // docusaurus_tag:default (framework-agnostic / non-doc pages) and any
-      // other entry untouched, so the contextual OR isn't collapsed and those
-      // pages still match when a version is typed.
-      return f.startsWith("docusaurus_tag:docs-")
+      // Swap only the tag of the version the page is served from. Leave
+      // docusaurus_tag:default (framework-agnostic / non-doc pages), the
+      // always-on tags (API reference - see alwaysOnSearchTags in
+      // docusaurus.config.ts) and any other entry untouched, so the contextual
+      // OR isn't collapsed and that content still matches when a version is
+      // typed.
+      return f.startsWith("docusaurus_tag:docs-") && !keep.has(f)
         ? `docusaurus_tag:${targetTag}`
         : f;
     }
@@ -265,6 +289,15 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   // Version-routing map derived at build time from docsVersions (see config).
   const versionTagByMajor =
     siteConfig.customFields?.versionTagByMajor || EMPTY_VERSION_MAP;
+  // Indexed content Docusaurus does not tag for this build (API reference).
+  // Stable reference from siteConfig, so it is safe in memo dependencies.
+  const alwaysOnTagFilters = useMemo(
+    () =>
+      (siteConfig.customFields?.alwaysOnSearchTags || EMPTY_TAG_LIST).map(
+        (tag) => `docusaurus_tag:${tag}`,
+      ),
+    [siteConfig.customFields],
+  );
   const processSearchResultUrl = useSearchResultUrlProcessor();
   const contextualSearchFacetFilters = useAlgoliaContextualFacetFilters();
   const configFacetFilters = props.searchParameters?.facetFilters ?? [];
@@ -304,8 +337,12 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
   }, [currentUrl]);
 
   const facetFilters = contextualSearch
-    ? // Merge contextual search filters with config filters
-      mergeFacetFilters(contextualSearchFacetFilters, configFacetFilters)
+    ? // Merge contextual search filters with config filters, after widening the
+      // contextual tag OR group with the tags Docusaurus cannot know about.
+      mergeFacetFilters(
+        withAlwaysOnTags(contextualSearchFacetFilters, alwaysOnTagFilters),
+        configFacetFilters,
+      )
     : // ... or use config facetFilters
       configFacetFilters;
 
@@ -560,7 +597,8 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
                 if (targetTag && params.facetFilters) {
                   params.facetFilters = rewriteVersionTag(
                     params.facetFilters,
-                    targetTag
+                    targetTag,
+                    alwaysOnTagFilters
                   );
                 }
                 if (analyticsPing) {
@@ -651,7 +689,12 @@ function DocSearch({ contextualSearch, externalUrlRegex, ...props }) {
       };
       return searchClient;
     },
-    [siteMetadata.docusaurusVersion, captureSearchDebounced, versionTagByMajor]
+    [
+      siteMetadata.docusaurusVersion,
+      captureSearchDebounced,
+      versionTagByMajor,
+      alwaysOnTagFilters,
+    ]
   );
   useDocSearchKeyboardEvents({
     isOpen,


### PR DESCRIPTION
## What was broken

Releasing 8.5.3 renamed the docs version, so `docusaurus_tag` on every page at
the site root changed from `docs-default-current` to `docs-default-8.5.3` —
while not a single URL changed.

Two consequences, both silent:

1. The API reference lives in the same index but is not a Docusaurus version, so
   it carried the tag `docs-default-current`. While that tag matched the guides'
   tag, it was found alongside them for free. After the rename ~3,200 pages left
   every result. A query with 106 matching pages in the index returned 86.
2. `buildVersionTagByMajor` let `current` win its major unconditionally. With
   8.6.0-beta as `current` and 8.5.3 as `lastVersion`, typing "v8" sent readers
   at the unreleased beta's tag — and it still returned results, so nothing
   looked wrong.

The monitoring could only report "too few records".

## What this changes

- `docusaurus.config.ts` is the only place versions are declared and tags are
  built. `DOCS_LAST_VERSION` is declared once beside `docsVersions` (it used to
  be restated in the preset), and `docVersionTag` is the only constructor of
  `docs-default-*` strings.
- `buildVersionTagByMajor` follows `lastVersion` and skips unreleased versions.
- The API reference is mapped per version instead of bolted on: each docs
  version gets the API tree it belongs with — `7.6.14 → api-reference-7.6`,
  `6.28.11 → api-reference-6.28`, and the version served at the root → the
  unversioned tree. A reader on 6.28.11 no longer gets 8.x API pages.
- Fixes a regression introduced in this same PR: hoisting `DOCS_LAST_VERSION`
  left `scripts/update-version.py` reading the `lastVersion:` line, so the next
  release would have aborted with "Already in production state". Verified by
  running a real release end to end.

## Why the mapping mirrors the site rather than assuming symmetry

The sitemap contains zero `/data-capture-sdk/` URLs, so the crawler can only
reach that tree by following links. The 7.6.14 guides link to
`/7.6/data-capture-sdk/…`, but the guides served at the root link to the
**unversioned** `/data-capture-sdk/…` — nothing anywhere links to `/8.5/`.
Pointing the served version at `api-reference-8.5` would have pointed at a tree
the crawler never reaches, dropping the current API reference out of search a
second time.

## Preventing a repeat

- `yarn verify:search-tags` (in CI) compares the build against the live index:
  the tag a typed major routes to must be the tag the site serves; the build must
  emit every tag the config names; and content under a tag search cannot reach is
  an error. Crawler lag warns instead of failing.
- `yarn test:search-facets` (in CI) — 7 assertions on what the widget actually
  sends to Algolia, including that a legacy version gets *its* API reference and
  not the current one.

Both reproduce both bugs against the pre-fix config.