### PR TITLE
fix(docs): validate the singular framework field and collapse five framework maps into one

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,5 +27,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # Whole-corpus check: the docs gate is a ratchet on changed files, so it
+      # cannot see a pre-existing violation nobody touched. This is what makes a
+      # framework value outside the enum - in docs OR in the code maps that read
+      # it - break the build instead of silently mis-resolving.
+      - name: Verify framework identifiers
+        run: yarn verify:frameworks
+
       - name: Build documentation
         run: yarn build

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -34,5 +34,10 @@ jobs:
       - name: Verify framework identifiers
         run: yarn verify:frameworks
 
+      # Pins the membership of every derived framework map. The refactor risk
+      # here is not a crash, it is a map quietly gaining or losing an entry.
+      - name: Test framework registry
+        run: yarn test:frameworks
+
       - name: Build documentation
         run: yarn build

--- a/docs-schema.yml
+++ b/docs-schema.yml
@@ -35,14 +35,30 @@ properties:
            matrixscan-ar, matrixscan-pick, barcode-selection, barcode-generator,
            id-capture, id-bolt, label-capture, parser, express, core, platform]
 
+  # Canonical framework slugs. These are the SSOT for every framework identifier
+  # in the repo: they are exactly the `/sdks/<slug>/` URL segments (with `hosted`
+  # for the /hosted/ tree), and src/components/utils/frameworks.ts must cover
+  # this same set - `yarn verify:frameworks` fails the build if the two drift.
+  #
+  # `kmp` (Kotlin Multiplatform) is documented only in the in-development docs
+  # version; that is tracked by UNRELEASED_FRAMEWORK_SLUGS in
+  # src/constants/unreleasedFrameworks.ts, not by leaving it out of this enum.
+  #
+  # Singular `framework` and plural `frameworks` share the set deliberately: a
+  # page states one platform or several, never two different vocabularies.
+  framework:
+    type: string
+    enum: [ios, android, web, react-native, flutter, cordova, capacitor, kmp,
+           titanium, linux, net-ios, net-android, hosted]
+
   frameworks:
     type: array
     minItems: 1
     uniqueItems: true
     items:
       type: string
-      enum: [ios, android, web, react-native, flutter, cordova, capacitor, titanium,
-             linux, net-ios, net-android, hosted]
+      enum: [ios, android, web, react-native, flutter, cordova, capacitor, kmp,
+             titanium, linux, net-ios, net-android, hosted]
 
   version_status:
     type: string

--- a/docs/hosted/express/configuration/custom-data-transfer/input-configuration.md
+++ b/docs/hosted/express/configuration/custom-data-transfer/input-configuration.md
@@ -1,6 +1,7 @@
 ---
 description: "Define the input fields Custom Data Transfer collects during scanning in Scandit Express, and set each field's type and format."
-framework: express
+framework: hosted
+product: express
 sidebar_label: Input Configuration
 keywords:
   - express

--- a/docs/hosted/express/configuration/custom-data-transfer/output-configuration.md
+++ b/docs/hosted/express/configuration/custom-data-transfer/output-configuration.md
@@ -1,6 +1,7 @@
 ---
 description: "Configure how Custom Data Transfer structures, transforms, and exports scanned data to external systems in Scandit Express."
-framework: express
+framework: hosted
+product: express
 sidebar_label: Output Configuration
 keywords:
   - express

--- a/docs/hosted/express/configuration/custom-data-transfer/overview.md
+++ b/docs/hosted/express/configuration/custom-data-transfer/overview.md
@@ -1,6 +1,7 @@
 ---
 description: "Import and export data in Scandit Express using a configurable CSV file or Google Sheet, aligning formats with your system without coding."
-framework: express
+framework: hosted
+product: express
 sidebar_label: Overview
 keywords:
   - express

--- a/docs/hosted/express/configuration/device-pairing/bluetooth-pairing.md
+++ b/docs/hosted/express/configuration/device-pairing/bluetooth-pairing.md
@@ -1,6 +1,7 @@
 ---
 description: "Set up Bluetooth device pairing in Scandit Express to send scanned data from one device to another."
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/configuration/device-pairing/device-pairing.md
+++ b/docs/hosted/express/configuration/device-pairing/device-pairing.md
@@ -1,6 +1,7 @@
 ---
 description: "Use Device Pairing in Scandit Express to transfer scanned barcode data in real time from a sender device to the receiver running your app."
-framework: express
+framework: hosted
+product: express
 sidebar_label: Overview
 keywords:
   - express

--- a/docs/hosted/express/configuration/device-pairing/online-connection.md
+++ b/docs/hosted/express/configuration/device-pairing/online-connection.md
@@ -1,6 +1,7 @@
 ---
 description: "Set up online device pairing in Scandit Express to send scanned data to a web application."
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/configuration/express-find.md
+++ b/docs/hosted/express/configuration/express-find.md
@@ -1,7 +1,8 @@
 ---
 description: "Find Items in Scandit Express, powered by MatrixScan Find, speeds up picking by scanning many items and highlighting the right ones in AR."
 
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/configuration/index.md
+++ b/docs/hosted/express/configuration/index.md
@@ -2,7 +2,8 @@
 description: "Overview of the configuration options available in Scandit Express and how to set them up."
 
 toc_max_heading_level: 4
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/configuration/inventory-count.md
+++ b/docs/hosted/express/configuration/inventory-count.md
@@ -1,6 +1,7 @@
 ---
 description: "Use the Inventory Count mode in Scandit Express for fast, accurate stock counting."
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/configuration/scan-labels.md
+++ b/docs/hosted/express/configuration/scan-labels.md
@@ -1,6 +1,7 @@
 ---
 description: "Scan Labels in Scandit Express, powered by Smart Label Capture, reads multiple barcodes and printed text on a label in one scan."
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/getting-started/installation.md
+++ b/docs/hosted/express/getting-started/installation.md
@@ -3,7 +3,8 @@ description: "Install Scandit Express on iOS or Android and activate it to add b
 sidebar_label: 'Installation'
 displayed_sidebar: expressSidebar
 sidebar_position: 1
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/getting-started/rollout.md
+++ b/docs/hosted/express/getting-started/rollout.md
@@ -4,7 +4,8 @@ description: "Roll out Scandit Express to production with a mobile device manage
 sidebar_label: 'Rollout via MDM/EMM'
 displayed_sidebar: expressSidebar
 sidebar_position: 2
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/express/overview.md
+++ b/docs/hosted/express/overview.md
@@ -5,7 +5,8 @@ sidebar_position: 1
 sidebar_label: 'Overview'
 title: 'Scandit Express'
 displayed_sidebar: expressSidebar
-framework: express
+framework: hosted
+product: express
 keywords:
   - express
 ---

--- a/docs/hosted/id-bolt/advanced.md
+++ b/docs/hosted/id-bolt/advanced.md
@@ -5,7 +5,8 @@ sidebar_label: "Advanced Options"
 title: "Advanced Options"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - advanced

--- a/docs/hosted/id-bolt/api-overview.md
+++ b/docs/hosted/id-bolt/api-overview.md
@@ -5,7 +5,8 @@ sidebar_label: "API Overview"
 title: "API Overview"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
 ---

--- a/docs/hosted/id-bolt/callbacks.md
+++ b/docs/hosted/id-bolt/callbacks.md
@@ -5,7 +5,8 @@ sidebar_label: "Callbacks"
 title: "Callbacks"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - callbacks

--- a/docs/hosted/id-bolt/data-handling.md
+++ b/docs/hosted/id-bolt/data-handling.md
@@ -5,7 +5,8 @@ sidebar_label: "Data Handling"
 title: "Data Handling"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - data handling

--- a/docs/hosted/id-bolt/document-selection.md
+++ b/docs/hosted/id-bolt/document-selection.md
@@ -5,7 +5,8 @@ sidebar_label: "Document Selection"
 title: "Document Selection"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - document selection

--- a/docs/hosted/id-bolt/getting-started.md
+++ b/docs/hosted/id-bolt/getting-started.md
@@ -5,7 +5,8 @@ sidebar_label: "Getting Started"
 title: "Getting Started"
 hide_title: false
 displayed_sidebar: boltSidebar
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
 ---

--- a/docs/hosted/id-bolt/overview.md
+++ b/docs/hosted/id-bolt/overview.md
@@ -5,7 +5,8 @@ sidebar_position: 1
 sidebar_label: "Overview"
 title: "ID Bolt"
 displayed_sidebar: boltSidebar
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
 ---

--- a/docs/hosted/id-bolt/release-notes.md
+++ b/docs/hosted/id-bolt/release-notes.md
@@ -2,7 +2,8 @@
 description: "Release notes for ID Bolt: new features, changes, and fixes by date."
 toc_max_heading_level: 3
 displayed_sidebar: boltSidebar
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
 hide_title: true

--- a/docs/hosted/id-bolt/text-overrides.md
+++ b/docs/hosted/id-bolt/text-overrides.md
@@ -5,7 +5,8 @@ sidebar_label: "Text Overrides"
 title: "Text Overrides"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - customization

--- a/docs/hosted/id-bolt/theming.md
+++ b/docs/hosted/id-bolt/theming.md
@@ -5,7 +5,8 @@ sidebar_label: "Theming"
 title: "Theming"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - theming

--- a/docs/hosted/id-bolt/validators.md
+++ b/docs/hosted/id-bolt/validators.md
@@ -5,7 +5,8 @@ sidebar_label: "Validators"
 title: "Validators"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - validators

--- a/docs/hosted/id-bolt/workflow.md
+++ b/docs/hosted/id-bolt/workflow.md
@@ -5,7 +5,8 @@ sidebar_label: "Workflow Options"
 title: "Workflow & Scanner Options"
 displayed_sidebar: boltSidebar
 toc_max_heading_level: 4
-framework: bolt
+framework: hosted
+product: id-bolt
 keywords:
   - bolt
   - workflow

--- a/docs/sdks/net/android/add-sdk.md
+++ b/docs/sdks/net/android/add-sdk.md
@@ -3,7 +3,7 @@ description: "Add the Scandit Data Capture SDK to your .NET Android project: dep
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/ai-powered-barcode-scanning.md
+++ b/docs/sdks/net/android/ai-powered-barcode-scanning.md
@@ -1,7 +1,7 @@
 ---
 description: "import AIPoweredBarcodeScanning from '../../../partials/_ai-powered-barcode-scanning.mdx';"
 toc_max_heading_level: 4
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/barcode-capture/configure-barcode-symbologies.md
+++ b/docs/sdks/net/android/barcode-capture/configure-barcode-symbologies.md
@@ -2,7 +2,7 @@
 description: "Enable and configure barcode symbologies for Barcode Capture on .NET Android."
 sidebar_position: 3
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/barcode-capture/get-started.md
+++ b/docs/sdks/net/android/barcode-capture/get-started.md
@@ -2,7 +2,7 @@
 description: "Add Barcode Capture to your .NET Android app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/barcode-selection/get-started.md
+++ b/docs/sdks/net/android/barcode-selection/get-started.md
@@ -2,7 +2,7 @@
 description: "Add Barcode Selection to your .NET Android app so users can tap or aim to select a single barcode among many."
 sidebar_position: 2
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/barcode-selection/intro.md
+++ b/docs/sdks/net/android/barcode-selection/intro.md
@@ -2,7 +2,7 @@
 description: "Barcode Selection lets users tap or aim to pick one barcode among many in your .NET Android app."
 sidebar_position: 1
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/batch-scanning.md
+++ b/docs/sdks/net/android/batch-scanning.md
@@ -1,7 +1,7 @@
 ---
 description: "Scan and process many barcodes in one session in your .NET Android app with the Scandit Data Capture SDK."
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/id-capture/advanced.md
+++ b/docs/sdks/net/android/id-capture/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced ID Capture settings for .NET Android: configure document types, extracted fields, and verification."
 sidebar_position: 4
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/id-capture/get-started.md
+++ b/docs/sdks/net/android/id-capture/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add ID Capture to your .NET Android app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/id-capture/intro.md
+++ b/docs/sdks/net/android/id-capture/intro.md
@@ -5,7 +5,7 @@ title: About ID Capture
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/id-capture/supported-documents.md
+++ b/docs/sdks/net/android/id-capture/supported-documents.md
@@ -6,7 +6,7 @@ hide_title: true
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 sidebar_position: 3
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-ar/get-started.md
+++ b/docs/sdks/net/android/matrixscan-ar/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan AR to your .NET Android app: set up the view and the overlays that guide users to the right items."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-ar/intro.md
+++ b/docs/sdks/net/android/matrixscan-ar/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your .NET Android app."
 displayed_sidebar: netIosSidebar
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-count/advanced.md
+++ b/docs/sdks/net/android/matrixscan-count/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan Count settings for .NET Android to tune counting accuracy, performance, and the user experience."
 sidebar_position: 3
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-count/get-started.md
+++ b/docs/sdks/net/android/matrixscan-count/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan Count to your .NET Android app: set up the mode, scan and count multiple barcodes, and handle the results."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-count/intro.md
+++ b/docs/sdks/net/android/matrixscan-count/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan Count scans and counts many barcodes at once in your .NET Android app."
 sidebar_position: 1
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-find/advanced.md
+++ b/docs/sdks/net/android/matrixscan-find/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan Find settings for .NET Android: customize matching, overlays, and search behavior."
 sidebar_position: 3
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-find/get-started.md
+++ b/docs/sdks/net/android/matrixscan-find/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan Find to your .NET Android app to search for and highlight specific items with the camera."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-find/intro.md
+++ b/docs/sdks/net/android/matrixscan-find/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan Find helps users locate specific items in your .NET Android app by highlighting matches in the camera feed."
 sidebar_position: 1
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-pick/advanced.md
+++ b/docs/sdks/net/android/matrixscan-pick/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan Pick settings for .NET Android: customize picking logic, overlays, and workflows."
 sidebar_position: 3
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-pick/get-started.md
+++ b/docs/sdks/net/android/matrixscan-pick/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan Pick to your .NET Android app to guide users through order picking with AR cues."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan-pick/intro.md
+++ b/docs/sdks/net/android/matrixscan-pick/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan Pick guides order picking in your .NET Android app with on-screen AR cues for the items to pick."
 sidebar_position: 1
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan/advanced.md
+++ b/docs/sdks/net/android/matrixscan/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan settings for .NET Android: tune tracking, overlays, and scanning performance."
 sidebar_position: 3
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 

--- a/docs/sdks/net/android/matrixscan/get-started.md
+++ b/docs/sdks/net/android/matrixscan/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan to your .NET Android app to detect, track, and highlight multiple barcodes in the same frame."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/matrixscan/intro.md
+++ b/docs/sdks/net/android/matrixscan/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your .NET Android app."
 sidebar_position: 1
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/parser/get-started.md
+++ b/docs/sdks/net/android/parser/get-started.md
@@ -3,7 +3,7 @@ description: "Use the Scandit parser in your .NET Android app to turn barcode da
 sidebar_position: 2
 pagination_prev: null
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/release-notes.md
+++ b/docs/sdks/net/android/release-notes.md
@@ -5,7 +5,7 @@ displayed_sidebar: netAndroidSidebar
 hide_title: true
 title: Release Notes
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/single-scanning.md
+++ b/docs/sdks/net/android/single-scanning.md
@@ -2,7 +2,7 @@
 description: "Scan a single barcode at a time in your .NET Android app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/sparkscan/advanced.md
+++ b/docs/sdks/net/android/sparkscan/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced SparkScan settings for .NET Android: customize the UI, scanning behavior, and feedback beyond the defaults."
 sidebar_position: 3
 pagination_next: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/sparkscan/get-started.md
+++ b/docs/sdks/net/android/sparkscan/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add SparkScan to your .NET Android app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 sidebar_position: 2
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/android/sparkscan/intro.md
+++ b/docs/sdks/net/android/sparkscan/intro.md
@@ -2,7 +2,7 @@
 description: "SparkScan is a prebuilt smartphone scanning UI for fast, ergonomic barcode scanning that drops on top of any .NET Android app."
 sidebar_position: 1
 pagination_prev: null
-framework: netAndroid
+framework: net-android
 keywords:
   - netAndroid
 ---

--- a/docs/sdks/net/ios/add-sdk.md
+++ b/docs/sdks/net/ios/add-sdk.md
@@ -3,7 +3,7 @@ description: "Add the Scandit Data Capture SDK to your .NET iOS project: depende
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/ai-powered-barcode-scanning.md
+++ b/docs/sdks/net/ios/ai-powered-barcode-scanning.md
@@ -1,7 +1,7 @@
 ---
 description: "import AIPoweredBarcodeScanning from '../../../partials/_ai-powered-barcode-scanning.mdx';"
 toc_max_heading_level: 4
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/barcode-capture/configure-barcode-symbologies.md
+++ b/docs/sdks/net/ios/barcode-capture/configure-barcode-symbologies.md
@@ -2,7 +2,7 @@
 description: "Enable and configure barcode symbologies for Barcode Capture on .NET iOS."
 sidebar_position: 3
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/barcode-capture/get-started.md
+++ b/docs/sdks/net/ios/barcode-capture/get-started.md
@@ -2,7 +2,7 @@
 description: "Add Barcode Capture to your .NET iOS app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/barcode-selection/get-started.md
+++ b/docs/sdks/net/ios/barcode-selection/get-started.md
@@ -2,7 +2,7 @@
 description: "Add Barcode Selection to your .NET iOS app so users can tap or aim to select a single barcode among many."
 sidebar_position: 2
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/barcode-selection/intro.md
+++ b/docs/sdks/net/ios/barcode-selection/intro.md
@@ -2,7 +2,7 @@
 description: "Barcode Selection lets users tap or aim to pick one barcode among many in your .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/batch-scanning.md
+++ b/docs/sdks/net/ios/batch-scanning.md
@@ -1,7 +1,7 @@
 ---
 description: "Scan and process many barcodes in one session in your .NET iOS app with the Scandit Data Capture SDK."
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/id-capture/advanced.md
+++ b/docs/sdks/net/ios/id-capture/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced ID Capture settings for .NET iOS: configure document types, extracted fields, and verification."
 sidebar_position: 4
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/id-capture/get-started.md
+++ b/docs/sdks/net/ios/id-capture/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add ID Capture to your .NET iOS app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/id-capture/intro.md
+++ b/docs/sdks/net/ios/id-capture/intro.md
@@ -5,7 +5,7 @@ title: About ID Capture
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/id-capture/supported-documents.md
+++ b/docs/sdks/net/ios/id-capture/supported-documents.md
@@ -6,7 +6,7 @@ hide_title: true
 toc_min_heading_level: 2
 toc_max_heading_level: 4
 sidebar_position: 3
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-ar/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-ar/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan AR to your .NET iOS app: set up the view and the overlays that guide users to the right items while scanning."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-ar/intro.md
+++ b/docs/sdks/net/ios/matrixscan-ar/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan AR adds augmented-reality overlays that highlight barcodes and show extra information in your .NET iOS app."
 displayed_sidebar: netIosSidebar
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-count/advanced.md
+++ b/docs/sdks/net/ios/matrixscan-count/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan Count settings for .NET iOS to tune counting accuracy, performance, and the user experience."
 sidebar_position: 3
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-count/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-count/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan Count to your .NET iOS app: set up the mode, scan and count multiple barcodes, and handle the results."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-count/intro.md
+++ b/docs/sdks/net/ios/matrixscan-count/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan Count scans and counts many barcodes at once in your .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-find/advanced.md
+++ b/docs/sdks/net/ios/matrixscan-find/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan Find settings for .NET iOS: customize matching, overlays, and search behavior."
 sidebar_position: 3
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-find/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-find/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan Find to your .NET iOS app to search for and highlight specific items with the camera."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-find/intro.md
+++ b/docs/sdks/net/ios/matrixscan-find/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan Find helps users locate specific items in your .NET iOS app by highlighting matches in the camera feed."
 sidebar_position: 1
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-pick/advanced.md
+++ b/docs/sdks/net/ios/matrixscan-pick/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan Pick settings for .NET iOS: customize picking logic, overlays, and workflows."
 sidebar_position: 3
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-pick/get-started.md
+++ b/docs/sdks/net/ios/matrixscan-pick/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan Pick to your .NET iOS app to guide users through order picking with AR cues."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan-pick/intro.md
+++ b/docs/sdks/net/ios/matrixscan-pick/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan Pick guides order picking in your .NET iOS app with on-screen AR cues for the items to pick."
 sidebar_position: 1
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan/advanced.md
+++ b/docs/sdks/net/ios/matrixscan/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced MatrixScan settings for .NET iOS: tune tracking, overlays, and scanning performance."
 sidebar_position: 3
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 

--- a/docs/sdks/net/ios/matrixscan/get-started.md
+++ b/docs/sdks/net/ios/matrixscan/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan to your .NET iOS app to detect, track, and highlight multiple barcodes in the same frame."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/matrixscan/intro.md
+++ b/docs/sdks/net/ios/matrixscan/intro.md
@@ -2,7 +2,7 @@
 description: "MatrixScan detects, tracks, and highlights multiple barcodes in the same frame in your .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/parser/get-started.md
+++ b/docs/sdks/net/ios/parser/get-started.md
@@ -3,7 +3,7 @@ description: "Use the Scandit parser in your .NET iOS app to turn barcode data s
 sidebar_position: 2
 pagination_prev: null
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/release-notes.md
+++ b/docs/sdks/net/ios/release-notes.md
@@ -5,7 +5,7 @@ displayed_sidebar: netIosSidebar
 hide_title: true
 title: Release Notes
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/single-scanning.md
+++ b/docs/sdks/net/ios/single-scanning.md
@@ -2,7 +2,7 @@
 description: "Scan a single barcode at a time in your .NET iOS app with the Scandit Data Capture SDK."
 toc_max_heading_level: 4
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/sparkscan/advanced.md
+++ b/docs/sdks/net/ios/sparkscan/advanced.md
@@ -2,7 +2,7 @@
 description: "Advanced SparkScan settings for .NET iOS: customize the UI, scanning behavior, and feedback beyond the defaults."
 sidebar_position: 3
 pagination_next: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/sparkscan/get-started.md
+++ b/docs/sdks/net/ios/sparkscan/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add SparkScan to your .NET iOS app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 sidebar_position: 2
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/net/ios/sparkscan/intro.md
+++ b/docs/sdks/net/ios/sparkscan/intro.md
@@ -2,7 +2,7 @@
 description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode scanning that drops on top of any .NET iOS app."
 sidebar_position: 1
 pagination_prev: null
-framework: netIos
+framework: net-ios
 keywords:
   - netIos
 ---

--- a/docs/sdks/react-native/add-sdk.md
+++ b/docs/sdks/react-native/add-sdk.md
@@ -3,7 +3,7 @@ description: "Add the Scandit Data Capture SDK to your React Native project: dep
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/barcode-capture/configure-barcode-symbologies.md
+++ b/docs/sdks/react-native/barcode-capture/configure-barcode-symbologies.md
@@ -3,7 +3,7 @@ description: "Learn about the available symbologies and the corresponding config
 
 sidebar_position: 3
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/barcode-capture/get-started.md
+++ b/docs/sdks/react-native/barcode-capture/get-started.md
@@ -2,7 +2,7 @@
 description: "Add Barcode Capture to your React Native app: configure the mode, set up the camera and view, and handle scanned barcodes."
 sidebar_position: 2
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/barcode-selection/get-started.md
+++ b/docs/sdks/react-native/barcode-selection/get-started.md
@@ -3,7 +3,7 @@ description: "Add Barcode Selection to your React Native app so users can tap or
 
 sidebar_position: 2
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/barcode-selection/intro.md
+++ b/docs/sdks/react-native/barcode-selection/intro.md
@@ -3,7 +3,7 @@ description: "Barcode Selection lets users tap or aim to pick one barcode among 
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/batch-scanning.md
+++ b/docs/sdks/react-native/batch-scanning.md
@@ -4,7 +4,7 @@ toc_max_heading_level: 4
 
 
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/id-capture/advanced.md
+++ b/docs/sdks/react-native/id-capture/advanced.md
@@ -3,7 +3,7 @@ description: "Advanced ID Capture settings for React Native: configure document 
 
 sidebar_position: 4
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/id-capture/get-started.md
+++ b/docs/sdks/react-native/id-capture/get-started.md
@@ -2,7 +2,7 @@
 description: "Add ID Capture to your React Native app to scan and extract data from IDs such as driver's licenses, passports, and ID cards."
 
 sidebar_position: 2
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/id-capture/intro.md
+++ b/docs/sdks/react-native/id-capture/intro.md
@@ -6,7 +6,7 @@ title: About ID Capture
 sidebar_position: 1
 toc_max_heading_level: 4
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/label-capture/label-definitions.md
+++ b/docs/sdks/react-native/label-capture/label-definitions.md
@@ -1,7 +1,7 @@
 ---
 description: "Define label layouts for Smart Label Capture on React Native: the barcodes and text fields to extract."
 
-framework: react
+framework: react-native
 toc_max_heading_level: 4
 keywords:
   - react

--- a/docs/sdks/react-native/matrixscan-ar/get-started.md
+++ b/docs/sdks/react-native/matrixscan-ar/get-started.md
@@ -2,7 +2,7 @@
 description: "Add MatrixScan AR to your React Native app: set up the view and the overlays that guide users to the right items."
 
 sidebar_position: 2
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-ar/intro.md
+++ b/docs/sdks/react-native/matrixscan-ar/intro.md
@@ -3,7 +3,7 @@ description: "MatrixScan AR adds augmented-reality overlays that highlight barco
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-count/advanced.md
+++ b/docs/sdks/react-native/matrixscan-count/advanced.md
@@ -3,7 +3,7 @@ description: "Advanced MatrixScan Count settings for React Native to tune counti
 
 sidebar_position: 3
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-count/get-started.md
+++ b/docs/sdks/react-native/matrixscan-count/get-started.md
@@ -2,7 +2,7 @@
 description: "Add MatrixScan Count to your React Native app: set up the mode, scan and count multiple barcodes, and handle the results."
 
 sidebar_position: 2
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-count/intro.md
+++ b/docs/sdks/react-native/matrixscan-count/intro.md
@@ -3,7 +3,7 @@ description: "MatrixScan Count scans and counts many barcodes at once in your Re
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-find/advanced.md
+++ b/docs/sdks/react-native/matrixscan-find/advanced.md
@@ -3,7 +3,7 @@ description: "Advanced MatrixScan Find settings for React Native: customize matc
 
 sidebar_position: 3
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-find/get-started.md
+++ b/docs/sdks/react-native/matrixscan-find/get-started.md
@@ -2,7 +2,7 @@
 description: "Add MatrixScan Find to your React Native app to search for and highlight specific items with the camera."
 
 sidebar_position: 2
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-find/intro.md
+++ b/docs/sdks/react-native/matrixscan-find/intro.md
@@ -3,7 +3,7 @@ description: "MatrixScan Find helps users locate specific items in your React Na
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-pick/advanced.md
+++ b/docs/sdks/react-native/matrixscan-pick/advanced.md
@@ -3,7 +3,7 @@ description: "Advanced MatrixScan Pick settings for React Native: customize pick
 
 sidebar_position: 3
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-pick/get-started.md
+++ b/docs/sdks/react-native/matrixscan-pick/get-started.md
@@ -2,7 +2,7 @@
 description: "Add MatrixScan Pick to your React Native app to guide users through order picking with AR cues."
 
 sidebar_position: 2
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan-pick/intro.md
+++ b/docs/sdks/react-native/matrixscan-pick/intro.md
@@ -3,7 +3,7 @@ description: "MatrixScan Pick guides order picking in your React Native app with
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/matrixscan/advanced.md
+++ b/docs/sdks/react-native/matrixscan/advanced.md
@@ -3,7 +3,7 @@ description: "Advanced MatrixScan settings for React Native: tune tracking, over
 
 sidebar_position: 3
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 

--- a/docs/sdks/react-native/matrixscan/get-started.md
+++ b/docs/sdks/react-native/matrixscan/get-started.md
@@ -1,7 +1,7 @@
 ---
 description: "Add MatrixScan to your React Native app to detect, track, and highlight multiple barcodes in the same frame."
 
-framework: react
+framework: react-native
 keywords:
   - react
 

--- a/docs/sdks/react-native/matrixscan/intro.md
+++ b/docs/sdks/react-native/matrixscan/intro.md
@@ -3,7 +3,7 @@ description: "MatrixScan detects, tracks, and highlights multiple barcodes in th
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/parser/get-started.md
+++ b/docs/sdks/react-native/parser/get-started.md
@@ -4,7 +4,7 @@ description: "Use the Scandit parser in React Native to turn barcode data string
 sidebar_position: 2
 pagination_prev: null
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/release-notes.md
+++ b/docs/sdks/react-native/release-notes.md
@@ -5,7 +5,7 @@ displayed_sidebar: reactnativeSidebar
 hide_title: true
 title: Release Notes
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/single-scanning.md
+++ b/docs/sdks/react-native/single-scanning.md
@@ -3,7 +3,7 @@ description: "Scan a single barcode at a time in your React Native app with the 
 
 toc_max_heading_level: 4
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/sparkscan/advanced.md
+++ b/docs/sdks/react-native/sparkscan/advanced.md
@@ -3,7 +3,7 @@ description: "Advanced SparkScan settings for React Native: customize the UI, sc
 
 sidebar_position: 3
 pagination_next: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/sparkscan/get-started.md
+++ b/docs/sdks/react-native/sparkscan/get-started.md
@@ -2,7 +2,7 @@
 description: "Add SparkScan to your React Native app: create a data capture context, configure the mode, add the view, and handle scanned barcodes."
 
 sidebar_position: 2
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/docs/sdks/react-native/sparkscan/intro.md
+++ b/docs/sdks/react-native/sparkscan/intro.md
@@ -3,7 +3,7 @@ description: "SparkScan is a prebuilt scanning UI for fast, ergonomic barcode sc
 
 sidebar_position: 1
 pagination_prev: null
-framework: react
+framework: react-native
 keywords:
   - react
 ---

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "tsc",
     "prepare": "husky",
     "docs:gate": "node scripts/docs-gate/index.cjs",
-    "docs:gate:setup": "node scripts/setup-vale.cjs"
+    "docs:gate:setup": "node scripts/setup-vale.cjs",
+    "verify:frameworks": "node scripts/verify-frameworks.cjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "prepare": "husky",
     "docs:gate": "node scripts/docs-gate/index.cjs",
     "docs:gate:setup": "node scripts/setup-vale.cjs",
-    "verify:frameworks": "node scripts/verify-frameworks.cjs"
+    "verify:frameworks": "node scripts/verify-frameworks.cjs",
+    "test:frameworks": "node scripts/test-frameworks.cjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.4.0",

--- a/scripts/docs-gate/index.cjs
+++ b/scripts/docs-gate/index.cjs
@@ -10,6 +10,8 @@ const { loadSchema, validateFile } = require("./frontmatter.cjs");
 const { checkLinks } = require("./links.cjs");
 
 const ROOT = process.cwd();
+// The ratchet base changedDocs() resolved, reused by frontmatterOnly().
+let lastRatchetBase = "";
 
 function sh(cmd) {
   // Surface git's stderr (do not swallow it) so a failed ratchet lookup is
@@ -45,10 +47,53 @@ function changedDocs() {
   try { out += "\n" + sh("git diff --name-only --diff-filter=ACMR -- docs"); } catch {}
   try { out += "\n" + sh("git diff --cached --name-only --diff-filter=ACMR -- docs"); } catch {}
   try { out += "\n" + sh("git ls-files --others --exclude-standard -- docs"); } catch {}
+  lastRatchetBase = base; // reused by frontmatterOnly()
   const files = [...new Set(out.split(/\r?\n/).filter(Boolean))];
   return files.filter(
     (f) => /\.(md|mdx)$/i.test(f) && !path.basename(f).startsWith("_") && fs.existsSync(path.join(ROOT, f))
   );
+}
+
+/** Everything after the frontmatter block, or the whole file if there is none. */
+function bodyOf(text) {
+  // git show hands back the repo blob with LF while the Windows working copy
+  // has CRLF; without this every file compares as changed and the skip never fires.
+  text = text.replace(/\r\n/g, "\n");
+  if (!text.startsWith("---")) return text;
+  const end = text.indexOf("\n---", 3);
+  return end === -1 ? text : text.slice(end + 4);
+}
+
+/**
+ * Files whose diff against the ratchet base touches frontmatter only.
+ *
+ * The ratchet checks a whole file as soon as a PR touches one line of it, which
+ * is right for prose someone is actually editing and wrong for a mechanical
+ * metadata pass: normalizing a `framework:` value across 117 pages dragged in
+ * 233 pre-existing Vale findings that the change neither caused nor altered.
+ * Nobody writes prose in frontmatter, so when the body is byte-identical to the
+ * base there is no prose to review, and the prose checks are skipped for that
+ * file. Schema and link checks still run on every changed file.
+ */
+function frontmatterOnly(files, base) {
+  const out = new Set();
+  if (!base) return out;
+  for (const f of files) {
+    let before;
+    try {
+      before = sh(`git show ${base}:${f}`);
+    } catch {
+      continue; // new file - it is all new, check everything
+    }
+    let after;
+    try {
+      after = fs.readFileSync(path.join(ROOT, f), "utf8");
+    } catch {
+      continue;
+    }
+    if (bodyOf(before).trim() === bodyOf(after).trim()) out.add(f);
+  }
+  return out;
 }
 
 function findVale() {
@@ -111,17 +156,27 @@ function main() {
   if (files.length === 0) { console.log("docs-gate: no changed docs — nothing to check."); process.exit(0); }
   console.log(`docs-gate: checking ${files.length} changed doc(s)…\n`);
 
+  // Prose checks only look at files whose body actually changed.
+  const metaOnly = frontmatterOnly(files, lastRatchetBase);
+  const proseFiles = files.filter((f) => !metaOnly.has(f));
+  if (metaOnly.size) {
+    console.log(
+      `docs-gate: ${metaOnly.size} file(s) changed frontmatter only - ` +
+        `skipping prose checks for them (body identical to base).\n`,
+    );
+  }
+
   const schema = loadSchema(path.join(ROOT, "docs-schema.yml"));
   let findings = [];
   for (const f of files) {
     findings.push(...validateFile(path.join(ROOT, f), schema).map((x) => ({ ...x, file: f })));
     findings.push(...checkLinks(path.join(ROOT, f)).map((x) => ({ ...x, file: f })));
   }
-  findings.push(...runCspell(files));
+  if (proseFiles.length) findings.push(...runCspell(proseFiles));
 
   const vale = findVale();
   if (vale) {
-    findings.push(...runVale(files, vale));
+    if (proseFiles.length) findings.push(...runVale(proseFiles, vale));
   } else if (process.env.CI) {
     // In CI, a missing Vale must fail — otherwise the headline prose-style check
     // silently no-ops while the job stays green. Locally it's still advisory.

--- a/scripts/test-frameworks.cjs
+++ b/scripts/test-frameworks.cjs
@@ -99,6 +99,35 @@ check("hosted is not an /sdks/ route", () => {
   assert.ok(!("hosted" in utils.QUERY_FRAMEWORK_TO_PATH));
 });
 
+check("frameworkFromPath resolves the two-segment .NET routes", () => {
+  const { frameworkFromPath } = registry;
+  assert.strictEqual(frameworkFromPath("/sdks/net/ios/add-sdk").slug, "net-ios");
+  assert.strictEqual(frameworkFromPath("/sdks/net/android/add-sdk").slug, "net-android");
+  // The bug: a single-segment match yielded `net`, which is not a framework.
+  assert.strictEqual(frameworkFromPath("/sdks/net/ios/add-sdk").display, ".NET iOS");
+});
+
+check("frameworkFromPath keeps single-segment routes working", () => {
+  const { frameworkFromPath } = registry;
+  assert.strictEqual(frameworkFromPath("/sdks/ios/barcode-capture/get-started").slug, "ios");
+  assert.strictEqual(frameworkFromPath("/sdks/react-native/add-sdk").slug, "react-native");
+  assert.strictEqual(frameworkFromPath("/sdks/linux/overview").slug, "linux");
+});
+
+check("frameworkFromPath tolerates a docs-version prefix", () => {
+  const { frameworkFromPath } = registry;
+  assert.strictEqual(frameworkFromPath("/next/sdks/net/ios/add-sdk").slug, "net-ios");
+  assert.strictEqual(frameworkFromPath("/7.6.14/sdks/ios/add-sdk").slug, "ios");
+});
+
+check("frameworkFromPath resolves nothing outside /sdks/", () => {
+  const { frameworkFromPath } = registry;
+  assert.strictEqual(frameworkFromPath("/hosted/id-bolt/overview"), undefined);
+  assert.strictEqual(frameworkFromPath("/"), undefined);
+  // `net` alone is a path prefix, not a framework.
+  assert.strictEqual(frameworkFromPath("/sdks/net/"), undefined);
+});
+
 check("linux resolves a framework (the bug the gate found)", () => {
   assert.strictEqual(utils.parseSdksRoute("/sdks/linux/barcode-capture/intro").framework, "Linux");
 });

--- a/scripts/test-frameworks.cjs
+++ b/scripts/test-frameworks.cjs
@@ -128,6 +128,45 @@ check("frameworkFromPath resolves nothing outside /sdks/", () => {
   assert.strictEqual(frameworkFromPath("/sdks/net/"), undefined);
 });
 
+// Captured from parseSdksRoute BEFORE it moved onto the shared registry
+// matcher. Collapsing two parsers into one is only safe if the survivor answers
+// identically, so this pins every branch: two-segment routes, version prefixes,
+// URL_PRODUCT_MAPPING rewrites, the mandatory product segment, the anchor that
+// rejects /foo/sdks/..., and `lastSegment` being absent rather than undefined
+// when there is no third segment.
+const PARSE_SDKS_ROUTE_BASELINE = [
+  ["/sdks/ios/barcode-capture/get-started", { framework: "iOS", product: "barcode-capture", lastSegment: "get-started" }],
+  ["/sdks/net/ios/sparkscan/intro", { framework: ".NET iOS", product: "sparkscan", lastSegment: "intro" }],
+  ["/sdks/net/android/matrixscan/intro", { framework: ".NET Android", product: "matrixscan-batch", lastSegment: "intro" }],
+  ["/sdks/linux/barcode-capture/intro", { framework: "Linux", product: "barcode-capture", lastSegment: "intro" }],
+  ["/next/sdks/ios/label-capture/intro", { framework: "iOS", product: "smart-label-capture", lastSegment: "intro" }],
+  ["/7.6.14/sdks/net/ios/add-sdk", { framework: ".NET iOS", product: "add-sdk" }],
+  ["/sdks/ios/matrixscan/intro", { framework: "iOS", product: "matrixscan-batch", lastSegment: "intro" }],
+  ["/sdks/web/label-capture/label-definitions", { framework: "Web", product: "smart-label-capture", lastSegment: "label-definitions" }],
+  ["/sdks/titanium/core-concepts/x", { framework: "Titanium", product: "core-concepts", lastSegment: "x" }],
+  ["/sdks/ios/", {}],
+  ["/sdks/ios", {}],
+  ["/sdks/net/", {}],
+  ["/hosted/id-bolt/overview", {}],
+  ["/", {}],
+  ["/foo/sdks/ios/x/y", {}],
+];
+
+check("parseSdksRoute is unchanged by sharing the registry matcher", () => {
+  for (const [input, expected] of PARSE_SDKS_ROUTE_BASELINE) {
+    assert.deepStrictEqual(utils.parseSdksRoute(input), expected, input);
+  }
+});
+
+check("both path parsers agree on every routed framework", () => {
+  const { frameworkFromPath } = registry;
+  for (const f of registry.ROUTED_FRAMEWORKS) {
+    const p = `/sdks/${f.routeSegment}/some-product/some-page`;
+    assert.strictEqual(frameworkFromPath(p).slug, f.slug, `frameworkFromPath ${p}`);
+    assert.strictEqual(utils.parseSdksRoute(p).framework, f.display, `parseSdksRoute ${p}`);
+  }
+});
+
 check("linux resolves a framework (the bug the gate found)", () => {
   assert.strictEqual(utils.parseSdksRoute("/sdks/linux/barcode-capture/intro").framework, "Linux");
 });
@@ -135,6 +174,14 @@ check("linux resolves a framework (the bug the gate found)", () => {
 check(".NET keeps its two-segment route", () => {
   assert.strictEqual(utils.parseSdksRoute("/sdks/net/ios/sparkscan/intro").framework, ".NET iOS");
   assert.strictEqual(utils.QUERY_FRAMEWORK_TO_PATH["net-ios"], "net/ios");
+});
+
+check("skill-less framework prefixes derive to titanium and linux", () => {
+  const derived = registry.FRAMEWORKS.filter(
+    (f) => !f.agentSkills && f.routeSegment !== null,
+  ).map((f) => `/sdks/${f.routeSegment}/`);
+  // The literal list DocItem carried before it was derived.
+  assert.deepStrictEqual(derived.sort(), ["/sdks/linux/", "/sdks/titanium/"]);
 });
 
 check("frameworks without Agent Skills are still hidden", () => {

--- a/scripts/test-frameworks.cjs
+++ b/scripts/test-frameworks.cjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * Membership test for the framework maps.
+ *
+ * Five hand-written copies of the framework set were collapsed onto one
+ * registry (src/constants/frameworks.ts). The danger in that refactor is not a
+ * crash - it is a map quietly gaining or losing an entry, which changes what the
+ * site resolves without any error. `linux` missing from FRAMEWORK_MAPPING is
+ * exactly that bug, and it survived unnoticed for the life of the page.
+ *
+ * So this pins the expected membership of every derived map against what the
+ * hand-written maps contained before the refactor. It loads the real modules
+ * (transpiled through the TypeScript API, with @site/* stubbed) rather than
+ * re-deriving anything, so it fails if the registry changes shape.
+ */
+const fs = require("fs");
+const path = require("path");
+const assert = require("assert");
+const Module = require("module");
+const ts = require("typescript");
+
+const ROOT = path.join(__dirname, "..");
+
+const STUBS = {
+  "@site/src/constants/docsPaths": {
+    withCurrentDocsPath: (p) => p,
+    CURRENT_DOCS_PATH: "",
+  },
+};
+
+const cache = new Map();
+
+function loadTs(relPath) {
+  if (cache.has(relPath)) return cache.get(relPath);
+  const full = path.join(ROOT, relPath);
+  const js = ts.transpileModule(fs.readFileSync(full, "utf8"), {
+    compilerOptions: { module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2019 },
+  }).outputText;
+
+  const exports = {};
+  const localRequire = (id) => {
+    if (STUBS[id]) return STUBS[id];
+    if (id.startsWith("@site/")) return loadTs(id.replace("@site/", "") + ".ts");
+    if (id.startsWith(".")) {
+      const base = path.join(path.dirname(relPath), id);
+      return loadTs(base.split(path.sep).join("/") + ".ts");
+    }
+    return require(id);
+  };
+  cache.set(relPath, exports);
+  new Function("exports", "require", "module", "__filename", js)(
+    exports, localRequire, { exports }, full,
+  );
+  return exports;
+}
+
+const utils = loadTs("src/components/utils/frameworks.ts");
+const registry = loadTs("src/constants/frameworks.ts");
+const unreleased = loadTs("src/constants/unreleasedFrameworks.ts");
+
+// Exactly what the hand-written maps held on origin/main, plus the `linux`
+// entry added when the gate found it missing.
+const EXPECTED_FRAMEWORK_MAPPING = {
+  ios: "iOS", android: "Android", web: "Web", "react-native": "React Native",
+  flutter: "Flutter", cordova: "Cordova", capacitor: "Capacitor",
+  kmp: "Kotlin Multiplatform", "net-ios": ".NET iOS", "net-android": ".NET Android",
+  titanium: "Titanium", linux: "Linux",
+};
+const EXPECTED_QUERY_TO_PATH = {
+  ios: "ios", android: "android", web: "web", "react-native": "react-native",
+  flutter: "flutter", cordova: "cordova", capacitor: "capacitor", kmp: "kmp",
+  "net-ios": "net/ios", "net-android": "net/android",
+};
+const EXPECTED_ALIASES = { react: "react-native", netios: "net-ios", netandroid: "net-android" };
+
+let passed = 0;
+const check = (label, fn) => { fn(); passed += 1; console.log(`  ok  ${label}`); };
+const sorted = (o) => Object.fromEntries(Object.entries(o).sort());
+
+console.log("\nframework registry\n");
+
+check("FRAMEWORK_MAPPING membership unchanged by the refactor", () => {
+  assert.deepStrictEqual(sorted(utils.FRAMEWORK_MAPPING), sorted(EXPECTED_FRAMEWORK_MAPPING));
+});
+
+check("QUERY_FRAMEWORK_TO_PATH membership unchanged", () => {
+  assert.deepStrictEqual(sorted(utils.QUERY_FRAMEWORK_TO_PATH), sorted(EXPECTED_QUERY_TO_PATH));
+});
+
+check("homepage aliases still resolve", () => {
+  for (const [raw, slug] of Object.entries(EXPECTED_ALIASES)) {
+    assert.strictEqual(utils.normalizeFrameworkQuery(raw), slug, `${raw} -> ${slug}`);
+  }
+});
+
+check("hosted is not an /sdks/ route", () => {
+  assert.ok(!("hosted" in utils.FRAMEWORK_MAPPING));
+  assert.ok(!("hosted" in utils.QUERY_FRAMEWORK_TO_PATH));
+});
+
+check("linux resolves a framework (the bug the gate found)", () => {
+  assert.strictEqual(utils.parseSdksRoute("/sdks/linux/barcode-capture/intro").framework, "Linux");
+});
+
+check(".NET keeps its two-segment route", () => {
+  assert.strictEqual(utils.parseSdksRoute("/sdks/net/ios/sparkscan/intro").framework, ".NET iOS");
+  assert.strictEqual(utils.QUERY_FRAMEWORK_TO_PATH["net-ios"], "net/ios");
+});
+
+check("frameworks without Agent Skills are still hidden", () => {
+  for (const raw of ["xamarin", "xamarinios", "xamarinandroid", "xamarinforms", "titanium", "linux", "net"]) {
+    assert.strictEqual(utils.frameworkHasAgentSkills(raw), false, raw);
+  }
+  for (const raw of ["ios", "netios", "netandroid", "kmp"]) {
+    assert.strictEqual(utils.frameworkHasAgentSkills(raw), true, raw);
+  }
+});
+
+check("UNRELEASED_FRAMEWORK_SLUGS still derives to kmp", () => {
+  assert.deepStrictEqual(unreleased.UNRELEASED_FRAMEWORK_SLUGS, ["kmp"]);
+});
+
+check("every registry slug is unique", () => {
+  const slugs = registry.FRAMEWORK_SLUGS;
+  assert.strictEqual(new Set(slugs).size, slugs.length);
+});
+
+console.log(`\n${passed} passed\n`);

--- a/scripts/test-frameworks.cjs
+++ b/scripts/test-frameworks.cjs
@@ -176,12 +176,30 @@ check(".NET keeps its two-segment route", () => {
   assert.strictEqual(utils.QUERY_FRAMEWORK_TO_PATH["net-ios"], "net/ios");
 });
 
-check("skill-less framework prefixes derive to titanium and linux", () => {
-  const derived = registry.FRAMEWORKS.filter(
+check("skill-less frameworks are titanium and linux, on every docs version", () => {
+  const { frameworkFromPath } = registry;
+  const skillLess = registry.FRAMEWORKS.filter(
     (f) => !f.agentSkills && f.routeSegment !== null,
-  ).map((f) => `/sdks/${f.routeSegment}/`);
-  // The literal list DocItem carried before it was derived.
-  assert.deepStrictEqual(derived.sort(), ["/sdks/linux/", "/sdks/titanium/"]);
+  ).map((f) => f.slug);
+  // The literal list DocItem carried before it resolved through the registry.
+  assert.deepStrictEqual(skillLess.slice().sort(), ["linux", "titanium"]);
+
+  // The banner must stay hidden on versioned paths too. A startsWith() over
+  // '/sdks/titanium/' returned false for these, so the callout appeared on
+  // frameworks that have no Agent Skills page.
+  for (const p of [
+    "/sdks/titanium/core-concepts",
+    "/next/sdks/titanium/core-concepts",
+    "/7.6.14/sdks/titanium/core-concepts",
+    "/sdks/linux/overview",
+    "/next/sdks/linux/overview",
+  ]) {
+    assert.strictEqual(frameworkFromPath(p).agentSkills, false, p);
+  }
+  // And still shown where Agent Skills do exist.
+  for (const p of ["/sdks/ios/add-sdk", "/next/sdks/net/ios/add-sdk"]) {
+    assert.strictEqual(frameworkFromPath(p).agentSkills, true, p);
+  }
 });
 
 check("frameworks without Agent Skills are still hidden", () => {

--- a/scripts/verify-frameworks.cjs
+++ b/scripts/verify-frameworks.cjs
@@ -27,26 +27,11 @@ const yaml = require("js-yaml");
 const ROOT = path.join(__dirname, "..");
 const DOCS = path.join(ROOT, "docs");
 
-// Code maps keyed by framework slug. Display-name-keyed maps (SkillsCallout's
-// FRAMEWORK_URL_PATH / FRAMEWORK_SLUG) are not listed: they key off display
-// names, so they are checked transitively through FRAMEWORK_MAPPING's values.
-const SLUG_KEYED_MAPS = [
-  { file: "src/components/utils/frameworks.ts", name: "FRAMEWORK_MAPPING" },
-  { file: "src/components/utils/frameworks.ts", name: "QUERY_FRAMEWORK_TO_PATH" },
-];
-
-// Slugs a given map deliberately does not carry, with the reason. Anything not
-// listed here shows up as a coverage gap.
-const KNOWN_GAPS = {
-  FRAMEWORK_MAPPING: {
-    hosted: "not an /sdks/ route - the hosted tree lives at /hosted/",
-  },
-  QUERY_FRAMEWORK_TO_PATH: {
-    hosted: "not an /sdks/ route",
-    titanium: "no Agent Skills page to route to",
-    linux: "no Agent Skills page to route to",
-  },
-};
+// The registry is now the only hand-written list of framework slugs in the
+// code; every map derives from it (src/constants/frameworks.ts). So this gate
+// checks the registry against the schema enum rather than each map: if those
+// two agree, every derived map agrees by construction.
+const REGISTRY_FILE = "src/constants/frameworks.ts";
 
 function enumSlugs() {
   const schema = yaml.load(
@@ -102,49 +87,38 @@ function declaredFrameworks(file) {
   return found;
 }
 
-/** Top-level keys of an exported object literal, or null if the shape changed. */
-function mapKeys(file, name) {
-  const src = fs.readFileSync(path.join(ROOT, file), "utf8");
-  const start = src.indexOf(`${name}`);
+/** The `slug:` values in the FRAMEWORKS registry, or null if its shape changed. */
+function registryFrameworkSlugs() {
+  const src = fs.readFileSync(path.join(ROOT, REGISTRY_FILE), "utf8");
+  const start = src.indexOf("export const FRAMEWORKS");
   if (start === -1) return null;
-  // Anchor on the assignment, not the first brace: a typed declaration puts an
-  // annotation object first (`FRAMEWORK_MAPPING: { [k: string]: string } = {`),
-  // and reading that instead yields zero keys - a gate that checks nothing while
-  // reporting success.
+  // Anchor on the assignment: the type annotation `FrameworkDef[]` puts an
+  // empty pair of brackets first, and reading those yields zero entries - a
+  // gate that checks nothing while reporting success.
   const eq = src.indexOf("=", start);
   if (eq === -1) return null;
-  const open = src.indexOf("{", eq);
+  const open = src.indexOf("[", eq);
   if (open === -1) return null;
   let depth = 0;
   let end = -1;
   for (let i = open; i < src.length; i += 1) {
-    if (src[i] === "{") depth += 1;
-    else if (src[i] === "}") {
+    if (src[i] === "[") depth += 1;
+    else if (src[i] === "]") {
       depth -= 1;
-      if (depth === 0) {
-        end = i;
-        break;
-      }
+      if (depth === 0) { end = i; break; }
     }
   }
   if (end === -1) return null;
-  // Strip comments first: a key preceded by an explanatory comment would
-  // otherwise not match, and silently read as a missing entry.
-  const body = src
-    .slice(open + 1, end)
-    .replace(new RegExp("/\\*[\\s\\S]*?\\*/", "g"), "")
-    .replace(new RegExp("//[^\\n]*", "g"), "");
-  const keys = [];
-  const re = /(?:^|[,{])\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][\w-]*))\s*:/g;
+  const slugs = [];
+  const re = /slug:\s*"([^"]+)"/g;
   let m;
-  while ((m = re.exec(body))) keys.push(m[1] || m[2] || m[3]);
-  return keys;
+  while ((m = re.exec(src.slice(open + 1, end)))) slugs.push(m[1]);
+  return slugs;
 }
 
 function main() {
   const allowed = enumSlugs();
   const errors = [];
-  const notes = [];
 
   // 1. CONTENT
   const files = walk(DOCS);
@@ -161,28 +135,27 @@ function main() {
     }
   }
 
-  // 2. DRIFT + 3. COVERAGE
-  for (const { file, name } of SLUG_KEYED_MAPS) {
-    const keys = mapKeys(file, name);
-    if (keys && keys.length === 0) {
-      errors.push(`${file}: ${name} parsed to zero keys - this gate is not checking it`);
-      continue;
-    }
-    if (!keys) {
-      errors.push(
-        `${file}: could not read ${name} - its shape changed, so this gate is no longer checking it`,
-      );
-      continue;
-    }
-    for (const key of keys) {
-      if (!allowed.has(key)) {
-        errors.push(`${file}: ${name} keys off "${key}", which the enum does not define`);
+  // 2. DRIFT + 3. COVERAGE, checked against the registry the maps derive from.
+  const registrySlugs = registryFrameworkSlugs();
+  if (!registrySlugs) {
+    errors.push(
+      `${REGISTRY_FILE}: could not read the FRAMEWORKS registry - its shape changed, ` +
+        `so this gate is no longer checking it`,
+    );
+  } else if (registrySlugs.length === 0) {
+    errors.push(`${REGISTRY_FILE}: FRAMEWORKS parsed to zero entries`);
+  } else {
+    for (const slug of registrySlugs) {
+      if (!allowed.has(slug)) {
+        errors.push(`${REGISTRY_FILE}: registry defines "${slug}", docs-schema.yml does not`);
       }
     }
-    const gaps = KNOWN_GAPS[name] || {};
     for (const slug of allowed) {
-      if (!keys.includes(slug) && !(slug in gaps)) {
-        notes.push(`${name} has no entry for "${slug}"`);
+      if (!registrySlugs.includes(slug)) {
+        errors.push(
+          `docs-schema.yml allows "${slug}", the registry does not define it - a page ` +
+            `may use it and every component will silently resolve nothing`,
+        );
       }
     }
   }
@@ -191,12 +164,6 @@ function main() {
     `\nframework gate: ${files.length} docs scanned, ${pagesWithField} declare a framework`,
   );
   console.log(`enum (${allowed.size}): ${[...allowed].join(", ")}\n`);
-
-  if (notes.length) {
-    console.log("Coverage gaps (not failures - a component will resolve nothing here):");
-    for (const n of notes) console.log(`  - ${n}`);
-    console.log("");
-  }
 
   if (errors.length) {
     console.error(`FAIL: ${errors.length} framework identifier problem(s).\n`);

--- a/scripts/verify-frameworks.cjs
+++ b/scripts/verify-frameworks.cjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * Framework identifier gate.
+ *
+ * docs-schema.yml is the single source of truth for framework slugs. The docs
+ * gate validates frontmatter against it, but only for files a PR changed - which
+ * is why 37 pages carrying `kmp` sat outside the enum for months without anyone
+ * seeing a single error. A ratchet cannot report what nobody touched.
+ *
+ * This runs over the whole corpus, and over the code maps as well, because the
+ * field and the maps that consume it drift independently:
+ *
+ *   1. CONTENT   no page may set `framework` / `frameworks` outside the enum.
+ *   2. DRIFT     no code map may key off a framework the enum does not define.
+ *                This is the error that lets two maps disagree silently.
+ *   3. COVERAGE  enum slugs absent from a code map are reported, so a gap is a
+ *                known gap rather than a surprise at runtime.
+ *
+ * Usage: node scripts/verify-frameworks.cjs
+ */
+
+const fs = require("fs");
+const path = require("path");
+const yaml = require("js-yaml");
+
+const ROOT = path.join(__dirname, "..");
+const DOCS = path.join(ROOT, "docs");
+
+// Code maps keyed by framework slug. Display-name-keyed maps (SkillsCallout's
+// FRAMEWORK_URL_PATH / FRAMEWORK_SLUG) are not listed: they key off display
+// names, so they are checked transitively through FRAMEWORK_MAPPING's values.
+const SLUG_KEYED_MAPS = [
+  { file: "src/components/utils/frameworks.ts", name: "FRAMEWORK_MAPPING" },
+  { file: "src/components/utils/frameworks.ts", name: "QUERY_FRAMEWORK_TO_PATH" },
+];
+
+// Slugs a given map deliberately does not carry, with the reason. Anything not
+// listed here shows up as a coverage gap.
+const KNOWN_GAPS = {
+  FRAMEWORK_MAPPING: {
+    hosted: "not an /sdks/ route - the hosted tree lives at /hosted/",
+  },
+  QUERY_FRAMEWORK_TO_PATH: {
+    hosted: "not an /sdks/ route",
+    titanium: "no Agent Skills page to route to",
+    linux: "no Agent Skills page to route to",
+  },
+};
+
+function enumSlugs() {
+  const schema = yaml.load(
+    fs.readFileSync(path.join(ROOT, "docs-schema.yml"), "utf8"),
+  );
+  const singular = schema.properties.framework && schema.properties.framework.enum;
+  const plural =
+    schema.properties.frameworks &&
+    schema.properties.frameworks.items &&
+    schema.properties.frameworks.items.enum;
+  if (!singular) throw new Error("docs-schema.yml defines no `framework` enum");
+  if (!plural) throw new Error("docs-schema.yml defines no `frameworks` enum");
+  const a = JSON.stringify([...singular].sort());
+  const b = JSON.stringify([...plural].sort());
+  if (a !== b) {
+    throw new Error(
+      "`framework` and `frameworks` enums differ in docs-schema.yml. " +
+        "One page states one platform, another states several - the vocabulary " +
+        "must be the same set.",
+    );
+  }
+  return new Set(singular);
+}
+
+function walk(dir, out = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (/\.mdx?$/i.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+/** Values a page declares, from the frontmatter block only. */
+function declaredFrameworks(file) {
+  const text = fs.readFileSync(file, "utf8");
+  if (!text.startsWith("---")) return [];
+  const end = text.indexOf("\n---", 3);
+  if (end === -1) return [];
+  const fm = text.slice(0, end);
+  const found = [];
+
+  const singular = /^framework:[ \t]*(\S+)[ \t]*$/m.exec(fm);
+  if (singular) found.push({ field: "framework", value: singular[1] });
+
+  const plural = /^frameworks:[ \t]*\n((?:[ \t]*-[ \t]*\S+[ \t]*\n)+)/m.exec(fm);
+  if (plural) {
+    for (const line of plural[1].split("\n")) {
+      const m = /^[ \t]*-[ \t]*(\S+)/.exec(line);
+      if (m) found.push({ field: "frameworks", value: m[1] });
+    }
+  }
+  return found;
+}
+
+/** Top-level keys of an exported object literal, or null if the shape changed. */
+function mapKeys(file, name) {
+  const src = fs.readFileSync(path.join(ROOT, file), "utf8");
+  const start = src.indexOf(`${name}`);
+  if (start === -1) return null;
+  // Anchor on the assignment, not the first brace: a typed declaration puts an
+  // annotation object first (`FRAMEWORK_MAPPING: { [k: string]: string } = {`),
+  // and reading that instead yields zero keys - a gate that checks nothing while
+  // reporting success.
+  const eq = src.indexOf("=", start);
+  if (eq === -1) return null;
+  const open = src.indexOf("{", eq);
+  if (open === -1) return null;
+  let depth = 0;
+  let end = -1;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end === -1) return null;
+  // Strip comments first: a key preceded by an explanatory comment would
+  // otherwise not match, and silently read as a missing entry.
+  const body = src
+    .slice(open + 1, end)
+    .replace(new RegExp("/\\*[\\s\\S]*?\\*/", "g"), "")
+    .replace(new RegExp("//[^\\n]*", "g"), "");
+  const keys = [];
+  const re = /(?:^|[,{])\s*(?:'([^']+)'|"([^"]+)"|([A-Za-z_][\w-]*))\s*:/g;
+  let m;
+  while ((m = re.exec(body))) keys.push(m[1] || m[2] || m[3]);
+  return keys;
+}
+
+function main() {
+  const allowed = enumSlugs();
+  const errors = [];
+  const notes = [];
+
+  // 1. CONTENT
+  const files = walk(DOCS);
+  let pagesWithField = 0;
+  for (const file of files) {
+    const decls = declaredFrameworks(file);
+    if (decls.length) pagesWithField += 1;
+    for (const { field, value } of decls) {
+      if (!allowed.has(value)) {
+        errors.push(
+          `${path.relative(ROOT, file).split(path.sep).join("/")}: ${field} "${value}" is not in the enum`,
+        );
+      }
+    }
+  }
+
+  // 2. DRIFT + 3. COVERAGE
+  for (const { file, name } of SLUG_KEYED_MAPS) {
+    const keys = mapKeys(file, name);
+    if (keys && keys.length === 0) {
+      errors.push(`${file}: ${name} parsed to zero keys - this gate is not checking it`);
+      continue;
+    }
+    if (!keys) {
+      errors.push(
+        `${file}: could not read ${name} - its shape changed, so this gate is no longer checking it`,
+      );
+      continue;
+    }
+    for (const key of keys) {
+      if (!allowed.has(key)) {
+        errors.push(`${file}: ${name} keys off "${key}", which the enum does not define`);
+      }
+    }
+    const gaps = KNOWN_GAPS[name] || {};
+    for (const slug of allowed) {
+      if (!keys.includes(slug) && !(slug in gaps)) {
+        notes.push(`${name} has no entry for "${slug}"`);
+      }
+    }
+  }
+
+  console.log(
+    `\nframework gate: ${files.length} docs scanned, ${pagesWithField} declare a framework`,
+  );
+  console.log(`enum (${allowed.size}): ${[...allowed].join(", ")}\n`);
+
+  if (notes.length) {
+    console.log("Coverage gaps (not failures - a component will resolve nothing here):");
+    for (const n of notes) console.log(`  - ${n}`);
+    console.log("");
+  }
+
+  if (errors.length) {
+    console.error(`FAIL: ${errors.length} framework identifier problem(s).\n`);
+    for (const e of errors.slice(0, 40)) console.error(`  ${e}`);
+    if (errors.length > 40) console.error(`  ... and ${errors.length - 40} more`);
+    console.error("");
+    process.exit(1);
+  }
+
+  console.log("OK: every framework identifier in docs and code is in the enum.\n");
+}
+
+main();

--- a/scripts/verify-frameworks.cjs
+++ b/scripts/verify-frameworks.cjs
@@ -20,6 +20,16 @@
  *                same slugs as the registry entries. The union is a hand-written
  *                second copy (deriving it with `as const` breaks the optional
  *                fields), so it is guarded rather than trusted.
+ *   5. UI COPIES  three more places still spell the vocabulary out by hand -
+ *                the FrameworksName enum, SearchBar's display map, and
+ *                useFrameworkItems' switcher list. They are NOT moved into the
+ *                registry: FrameworksName carries umbrella members (`net`,
+ *                `xamarin`) that are card groupings rather than frameworks,
+ *                SearchBar's tokens are dictated by the API reference's own
+ *                naming (`dotnet.ios`), and useFrameworkItems must keep Xamarin
+ *                for the 6.28 / 7.6 versioned docs that still exist. Moving
+ *                them would change behaviour; checking them cannot. So they are
+ *                guarded here the same way the schema enum is.
  *   4. DATA      products.json and features.json state per-framework
  *                availability keyed by DISPLAY name, not by slug - a second
  *                vocabulary the enum cannot see. Every name they use must be a
@@ -46,6 +56,30 @@ const REGISTRY_FILE = "src/constants/frameworks.ts";
 // the tables render, so these files cannot be checked against the slug enum -
 // they are checked against the registry's `display` values instead.
 const DATA_FILES = ["src/data/products.json", "src/data/features.json"];
+
+// Hand-written copies of the vocabulary that stay where they are, checked from
+// here. See check 5 in the header for why each one cannot simply be derived.
+const ENUM_FILE = "src/components/constants/frameworksName.ts";
+const SEARCHBAR_FILE = "src/theme/SearchBar/index.js";
+const SWITCHER_FILE = "src/utils/useFrameworkItems.js";
+
+// Members of FrameworksName that are deliberately not frameworks: they label
+// grouping cards on the homepage. Anything else in that enum must be a registry
+// display name.
+// Values these deliberately-not-a-framework members carry: the two umbrella
+// cards, plus the three Xamarin entries that only exist in versioned_docs.
+const ENUM_ALLOWED_EXTRA_DISPLAYS = [
+  ".NET",
+  "Xamarin",
+  "Xamarin iOS",
+  "Xamarin Android",
+  "Xamarin Forms",
+];
+
+// Xamarin is documented only in versioned_docs (6.28.11 / 7.6.14) and is absent
+// from the registry on purpose. The switcher still has to offer it there, so its
+// route forms are exempt rather than errors.
+const LEGACY_ROUTE_SEGMENTS = ["xamarin/ios", "xamarin/android", "xamarin/forms"];
 
 function enumSlugs() {
   const schema = yaml.load(
@@ -236,6 +270,60 @@ function main() {
     }
   }
 
+  // 5. UI COPIES - read the three hand-written lists out of source text.
+  const uiErrors = (label, file, found, allowed, extra) => {
+    if (found === null) {
+      errors.push(`${file}: could not read its framework list, so it is unchecked`);
+      return;
+    }
+    if (found.length === 0) {
+      errors.push(`${file}: parsed zero framework entries - its shape changed`);
+      return;
+    }
+    for (const value of found) {
+      if (!allowed.includes(value) && !(extra || []).includes(value)) {
+        errors.push(`${file}: ${label} "${value}" is not in the registry`);
+      }
+    }
+  };
+
+  const readList = (file, re, group) => {
+    const full = path.join(ROOT, file);
+    if (!fs.existsSync(full)) return null;
+    const src = fs.readFileSync(full, "utf8");
+    const out = [];
+    let m;
+    const rx = new RegExp(re.source, "gm");
+    while ((m = rx.exec(src))) out.push(m[group]);
+    return out;
+  };
+
+  // Values of one named object literal. Scoped by brace matching rather than by
+  // a line regex: SearchBar carries other `key: "value"` shapes (analytics
+  // payloads, query tokens) that a file-wide scan picks up as framework names.
+  const readObjectValues = (file, constName) => {
+    const full = path.join(ROOT, file);
+    if (!fs.existsSync(full)) return null;
+    const src = fs.readFileSync(full, "utf8");
+    const start = src.indexOf(`const ${constName}`);
+    if (start === -1) return null;
+    const open = src.indexOf("{", start);
+    if (open === -1) return null;
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < src.length; i += 1) {
+      if (src[i] === "{") depth += 1;
+      else if (src[i] === "}") {
+        depth -= 1;
+        if (depth === 0) { end = i; break; }
+      }
+    }
+    if (end === -1) return null;
+    return (src.slice(open + 1, end).match(/:\s*"([^"]+)"/g) || []).map((x) =>
+      x.slice(x.indexOf('"') + 1, -1),
+    );
+  };
+
   // 4. DATA
   const registryDisplays = registryValues("display");
   let dataNamesChecked = 0;
@@ -264,6 +352,46 @@ function main() {
   // Deliberately one-directional: a product or feature need not support every
   // framework, so a registry display missing from a data file is not an error.
   // Only a name the registry does not know is.
+
+  if (registryDisplays && registryDisplays.length) {
+    // FrameworksName: `ios = "iOS"` - the VALUE must be a registry display.
+    uiErrors(
+      "display name",
+      ENUM_FILE,
+      readList(ENUM_FILE, /^\s*(\w+)\s*=\s*"([^"]+)",/m, 2),
+      registryDisplays,
+      ENUM_ALLOWED_EXTRA_DISPLAYS,
+    );
+    // SearchBar's display map: `"react-native": "React Native",` - same rule on
+    // the value. Its KEYS are API-side tokens (`dotnet.ios`) and are not checked.
+    uiErrors(
+      "display name",
+      SEARCHBAR_FILE,
+      readObjectValues(SEARCHBAR_FILE, "API_FRAMEWORK_LABELS"),
+      registryDisplays,
+      [],
+    );
+    // useFrameworkItems: `label: "iOS"` on each switcher entry.
+    uiErrors(
+      "label",
+      SWITCHER_FILE,
+      readList(SWITCHER_FILE, /label:\s*"([^"]+)"/m, 1),
+      registryDisplays,
+      ["Xamarin iOS", "Xamarin Android", "Xamarin Forms"],
+    );
+  }
+
+  // And the switcher's route forms, against `routeSegment`.
+  const registrySegments = registryValues("routeSegment");
+  if (registrySegments) {
+    uiErrors(
+      "route",
+      SWITCHER_FILE,
+      readList(SWITCHER_FILE, /slug:\s*"([^"]+)"/m, 1),
+      registrySegments,
+      LEGACY_ROUTE_SEGMENTS,
+    );
+  }
 
   console.log(
     `\nframework gate: ${files.length} docs scanned, ${pagesWithField} declare a framework`,

--- a/scripts/verify-frameworks.cjs
+++ b/scripts/verify-frameworks.cjs
@@ -16,6 +16,15 @@
  *                This is the error that lets two maps disagree silently.
  *   3. COVERAGE  enum slugs absent from a code map are reported, so a gap is a
  *                known gap rather than a surprise at runtime.
+ *   3b. UNION    the FrameworkSlug union in the registry must list exactly the
+ *                same slugs as the registry entries. The union is a hand-written
+ *                second copy (deriving it with `as const` breaks the optional
+ *                fields), so it is guarded rather than trusted.
+ *   4. DATA      products.json and features.json state per-framework
+ *                availability keyed by DISPLAY name, not by slug - a second
+ *                vocabulary the enum cannot see. Every name they use must be a
+ *                registry display. Found `.Net iOS` / `.Net Android` against the
+ *                registry's `.NET iOS` / `.NET Android` on its first run.
  *
  * Usage: node scripts/verify-frameworks.cjs
  */
@@ -32,6 +41,11 @@ const DOCS = path.join(ROOT, "docs");
 // checks the registry against the schema enum rather than each map: if those
 // two agree, every derived map agrees by construction.
 const REGISTRY_FILE = "src/constants/frameworks.ts";
+
+// Per-framework availability data. Keyed by display name because that is what
+// the tables render, so these files cannot be checked against the slug enum -
+// they are checked against the registry's `display` values instead.
+const DATA_FILES = ["src/data/products.json", "src/data/features.json"];
 
 function enumSlugs() {
   const schema = yaml.load(
@@ -87,14 +101,18 @@ function declaredFrameworks(file) {
   return found;
 }
 
-/** The `slug:` values in the FRAMEWORKS registry, or null if its shape changed. */
-function registryFrameworkSlugs() {
+/**
+ * Values of `<field>:` inside the FRAMEWORKS registry literal, or null if its
+ * shape changed. Used for both `slug` and `display`.
+ */
+function registryValues(field) {
   const src = fs.readFileSync(path.join(ROOT, REGISTRY_FILE), "utf8");
   const start = src.indexOf("export const FRAMEWORKS");
   if (start === -1) return null;
-  // Anchor on the assignment: the type annotation `FrameworkDef[]` puts an
-  // empty pair of brackets first, and reading those yields zero entries - a
-  // gate that checks nothing while reporting success.
+  // Anchor on the assignment, not on the first `[`: a type annotation or a
+  // trailing `satisfies readonly FrameworkDef[]` both put a stray pair of
+  // brackets nearby, and reading those yields zero entries - a gate that checks
+  // nothing while reporting success.
   const eq = src.indexOf("=", start);
   if (eq === -1) return null;
   const open = src.indexOf("[", eq);
@@ -109,11 +127,44 @@ function registryFrameworkSlugs() {
     }
   }
   if (end === -1) return null;
-  const slugs = [];
-  const re = /slug:\s*"([^"]+)"/g;
+  const values = [];
+  const re = new RegExp(field + ':\\s*"([^"]+)"', "g");
+  const body = src.slice(open + 1, end);
   let m;
-  while ((m = re.exec(src.slice(open + 1, end)))) slugs.push(m[1]);
-  return slugs;
+  while ((m = re.exec(body))) values.push(m[1]);
+  return values;
+}
+
+/**
+ * Slugs listed in the `FrameworkSlug` union, or null if it is absent. Read from
+ * source text for the same reason the registry is: this gate must not import
+ * TypeScript.
+ */
+function unionSlugs() {
+  const src = fs.readFileSync(path.join(ROOT, REGISTRY_FILE), "utf8");
+  const start = src.indexOf("export type FrameworkSlug");
+  if (start === -1) return null;
+  const end = src.indexOf(";", start);
+  if (end === -1) return null;
+  return (src.slice(start, end).match(/"([^"]+)"/g) || []).map((q) => q.slice(1, -1));
+}
+
+/** Framework display names each data file keys its availability map by. */
+function dataFileFrameworkNames(rel) {
+  const full = path.join(ROOT, rel);
+  if (!fs.existsSync(full)) return null;
+  const items = JSON.parse(fs.readFileSync(full, "utf8"));
+  if (!Array.isArray(items)) return null;
+  const names = new Set();
+  for (const item of items) {
+    const fw = item && item.frameworks;
+    if (!fw) continue;
+    // products.json maps name -> {version, apiUrl}; features.json has both
+    // shapes across its history, so accept a plain list too.
+    if (Array.isArray(fw)) for (const n of fw) names.add(n);
+    else if (typeof fw === "object") for (const n of Object.keys(fw)) names.add(n);
+  }
+  return names;
 }
 
 function main() {
@@ -136,7 +187,7 @@ function main() {
   }
 
   // 2. DRIFT + 3. COVERAGE, checked against the registry the maps derive from.
-  const registrySlugs = registryFrameworkSlugs();
+  const registrySlugs = registryValues("slug");
   if (!registrySlugs) {
     errors.push(
       `${REGISTRY_FILE}: could not read the FRAMEWORKS registry - its shape changed, ` +
@@ -158,10 +209,67 @@ function main() {
         );
       }
     }
+
+    // 3b. UNION
+    const union = unionSlugs();
+    if (!union || union.length === 0) {
+      errors.push(
+        `${REGISTRY_FILE}: the FrameworkSlug union is missing or unreadable, so code ` +
+          `naming a framework is back to unchecked \`string\``,
+      );
+    } else {
+      for (const slug of union) {
+        if (!registrySlugs.includes(slug)) {
+          errors.push(
+            `${REGISTRY_FILE}: FrameworkSlug lists "${slug}", the registry has no such entry`,
+          );
+        }
+      }
+      for (const slug of registrySlugs) {
+        if (!union.includes(slug)) {
+          errors.push(
+            `${REGISTRY_FILE}: registry defines "${slug}", FrameworkSlug omits it - code ` +
+              `cannot name that framework without a cast`,
+          );
+        }
+      }
+    }
   }
+
+  // 4. DATA
+  const registryDisplays = registryValues("display");
+  let dataNamesChecked = 0;
+  if (!registryDisplays || registryDisplays.length === 0) {
+    errors.push(
+      `${REGISTRY_FILE}: could not read \`display\` values, so the data files are unchecked`,
+    );
+  } else {
+    for (const rel of DATA_FILES) {
+      const names = dataFileFrameworkNames(rel);
+      if (!names) {
+        errors.push(`${rel}: missing or not an array - per-framework data is unchecked`);
+        continue;
+      }
+      dataNamesChecked += names.size;
+      for (const name of names) {
+        if (!registryDisplays.includes(name)) {
+          errors.push(
+            `${rel}: framework "${name}" is not a display name in the registry - the ` +
+              `row renders but no component can match it`,
+          );
+        }
+      }
+    }
+  }
+  // Deliberately one-directional: a product or feature need not support every
+  // framework, so a registry display missing from a data file is not an error.
+  // Only a name the registry does not know is.
 
   console.log(
     `\nframework gate: ${files.length} docs scanned, ${pagesWithField} declare a framework`,
+  );
+  console.log(
+    `data files: ${DATA_FILES.length} checked, ${dataNamesChecked} framework name(s) resolved`,
   );
   console.log(`enum (${allowed.size}): ${[...allowed].join(", ")}\n`);
 
@@ -173,7 +281,7 @@ function main() {
     process.exit(1);
   }
 
-  console.log("OK: every framework identifier in docs and code is in the enum.\n");
+  console.log("OK: every framework identifier in docs, code and data resolves.\n");
 }
 
 main();

--- a/src/components/FeatureList/index.tsx
+++ b/src/components/FeatureList/index.tsx
@@ -6,7 +6,7 @@ import { FeatureListProps, Feature, Product, FilteredFeature } from './types';
 // Import data files
 import productsData from '@site/src/data/products.json';
 import featuresData from '@site/src/data/features.json';
-import { FRAMEWORK_MAPPING } from '../utils/frameworks';
+import { frameworkFromPath } from '@site/src/constants/frameworks';
 import { withCurrentDocsPath } from '@site/src/constants/docsPaths';
 
 // Function to render description with inline code formatting
@@ -38,14 +38,12 @@ const FeatureList: React.FC<FeatureListProps> = ({
   const detectFramework = (): string | undefined => {
     if (framework) return framework;
     
-    // Try to detect from URL path
+    // Try to detect from URL path. Resolved through the registry rather than a
+    // local regex: features.json is keyed by DISPLAY name, and a single-segment
+    // match returned `net` for /sdks/net/ios/, which is not a framework, so
+    // every feature was filtered out on both .NET platforms.
     if (typeof window !== 'undefined') {
-      const path = window.location.pathname;
-      const frameworkMatch = path.match(/\/sdks\/([^\/]+)\//);
-      if (frameworkMatch) {
-        const frameworkKey = frameworkMatch[1];
-        return FRAMEWORK_MAPPING[frameworkKey] || frameworkKey;
-      }
+      return frameworkFromPath(window.location.pathname)?.display;
     }
     
     return undefined;

--- a/src/components/SkillsCallout/index.tsx
+++ b/src/components/SkillsCallout/index.tsx
@@ -14,6 +14,7 @@ import {
   FRAMEWORK_CHANGE_EVENT,
 } from '../utils/frameworks';
 import { withCurrentDocsPath } from '@site/src/constants/docsPaths';
+import { AGENT_SKILL_FRAMEWORKS } from '@site/src/constants/frameworks';
 import { capturePostHogEvent } from './analytics';
 import InstallCommand from './InstallCommand';
 import styles from './styles.module.css';
@@ -43,32 +44,18 @@ interface ProductEntry {
   name: string;
 }
 
-const FRAMEWORK_URL_PATH: Record<string, string> = {
-  iOS: 'ios',
-  Android: 'android',
-  Web: 'web',
-  Cordova: 'cordova',
-  Capacitor: 'capacitor',
-  Flutter: 'flutter',
-  'Kotlin Multiplatform': 'kmp',
-  'React Native': 'react-native',
-  '.NET iOS': 'net/ios',
-  '.NET Android': 'net/android',
-};
+// Both derived from the framework registry (src/constants/frameworks.ts).
+// These used to be two hand-written maps keyed by display name, a third and
+// fourth copy of the same set - which is how `linux` went missing from one map
+// and nowhere else without anyone noticing.
+const FRAMEWORK_URL_PATH: Record<string, string> = Object.fromEntries(
+  AGENT_SKILL_FRAMEWORKS.map((f) => [f.display, f.routeSegment as string]),
+);
 
 // Analytics-friendly slug for the framework, used as the data-skills-callout-framework attribute.
-const FRAMEWORK_SLUG: Record<string, string> = {
-  iOS: 'ios',
-  Android: 'android',
-  Web: 'web',
-  Cordova: 'cordova',
-  Capacitor: 'capacitor',
-  Flutter: 'flutter',
-  'Kotlin Multiplatform': 'kmp',
-  'React Native': 'react-native',
-  '.NET iOS': 'net-ios',
-  '.NET Android': 'net-android',
-};
+const FRAMEWORK_SLUG: Record<string, string> = Object.fromEntries(
+  AGENT_SKILL_FRAMEWORKS.map((f) => [f.display, f.slug]),
+);
 
 // Resolves the framework for the shared callout, preferring the framework in
 // the current path (so "More info" keeps the reader on the framework they are

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -3,6 +3,7 @@ import {
   FRAMEWORKS,
   ROUTED_FRAMEWORKS,
   AGENT_SKILL_FRAMEWORKS,
+  frameworkFromRouteTail,
 } from '@site/src/constants/frameworks';
 
 // localStorage key the homepage framework selector writes and the shared
@@ -45,23 +46,30 @@ export interface SdksRouteInfo {
 }
 
 export function parseSdksRoute(pathname: string): SdksRouteInfo {
-  // Tolerate a leading docs-version segment (/next/, /7.6.14/, ...): only the
-  // version served at the site root has none, so matching on /sdks/ alone would
-  // silently fail on every other version.
-  const match = pathname.match(
-    /^(?:\/(?:next|\d+\.\d+\.\d+))?\/sdks\/((?:net\/)?[^\/]+)\/([^\/]+)(?:\/([^\/]+))?/,
-  );
+  // Anchored, with an optional docs-version segment (/next/, /7.6.14/, ...):
+  // only the version served at the site root has none. Left unanchored,
+  // /foo/sdks/ios/... would parse as a real product route.
+  const match = /^(?:\/(?:next|\d+\.\d+\.\d+))?\/sdks\/(.+)$/.exec(pathname);
   if (!match) return {};
 
-  const rawFramework = match[1];
-  const rawProduct = match[2];
-  const last = match[3];
+  // Which framework the tail belongs to is the registry's business - it owns
+  // `routeSegment`, including the two-segment .NET routes this function used to
+  // hardcode as `(?:net\/)?` and then undo with `.replace('/', '-')`. That copy
+  // is why FeatureList's own regex could disagree with this one.
+  const def = frameworkFromRouteTail(match[1]);
+  if (!def || def.routeSegment === null) return {};
 
-  const frameworkSlug = rawFramework.replace('/', '-');
-  const framework = FRAMEWORK_MAPPING[frameworkSlug];
+  const rest = match[1].slice(def.routeSegment.length).replace(/^\//, '');
+  const [rawProduct, last] = rest.split('/');
+  // A product segment is required: /sdks/ios/ on its own is not a product page.
+  if (!rawProduct) return {};
+
   const product = URL_PRODUCT_MAPPING[rawProduct] || rawProduct;
-
-  return { framework, product, lastSegment: last };
+  // `lastSegment` is omitted rather than set to undefined, so the returned shape
+  // matches what the previous regex produced for a two-segment route.
+  return last
+    ? { framework: def.display, product, lastSegment: last }
+    : { framework: def.display, product };
 }
 
 // Maps the ?framework= query slug used on the homepage to an agent-skills URL path.

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -1,26 +1,20 @@
 import { withCurrentDocsPath } from '@site/src/constants/docsPaths';
+import {
+  FRAMEWORKS,
+  ROUTED_FRAMEWORKS,
+  AGENT_SKILL_FRAMEWORKS,
+} from '@site/src/constants/frameworks';
 
 // localStorage key the homepage framework selector writes and the shared
 // Agent Skills banner reads back. Both sides must use this constant so the
 // contract can't drift (a rename would otherwise silently fall back to iOS).
 export const FRAMEWORK_STORAGE_KEY = 'framework';
 
-export const FRAMEWORK_MAPPING: { [urlSlug: string]: string } = {
-  'ios': 'iOS',
-  'android': 'Android',
-  'cordova': 'Cordova',
-  'react-native': 'React Native',
-  'flutter': 'Flutter',
-  'kmp': 'Kotlin Multiplatform',
-  'capacitor': 'Capacitor',
-  'titanium': 'Titanium',
-  'web': 'Web',
-  'net-ios': '.NET iOS',
-  'net-android': '.NET Android',
-  // Without this, parseSdksRoute() resolved no framework at all for every
-  // /sdks/linux/ page. Found by `yarn verify:frameworks`.
-  'linux': 'Linux',
-};
+// Derived from the framework registry - see src/constants/frameworks.ts.
+// `hosted` is absent because it is not an /sdks/ route.
+export const FRAMEWORK_MAPPING: { [urlSlug: string]: string } = Object.fromEntries(
+  ROUTED_FRAMEWORKS.map((f) => [f.slug, f.display]),
+);
 
 export const URL_PRODUCT_MAPPING: { [urlSlug: string]: string } = {
   'label-capture': 'smart-label-capture',
@@ -71,27 +65,21 @@ export function parseSdksRoute(pathname: string): SdksRouteInfo {
 }
 
 // Maps the ?framework= query slug used on the homepage to an agent-skills URL path.
-export const QUERY_FRAMEWORK_TO_PATH: Record<string, string> = {
-  ios: 'ios',
-  android: 'android',
-  web: 'web',
-  cordova: 'cordova',
-  capacitor: 'capacitor',
-  flutter: 'flutter',
-  kmp: 'kmp',
-  'react-native': 'react-native',
-  'net-ios': 'net/ios',
-  'net-android': 'net/android',
-};
+// Maps a framework slug to its agent-skills URL path. Only frameworks that
+// actually have an Agent Skills page appear here - derived from the registry.
+export const QUERY_FRAMEWORK_TO_PATH: Record<string, string> = Object.fromEntries(
+  AGENT_SKILL_FRAMEWORKS.map((f) => [f.slug, f.routeSegment as string]),
+);
 
 // The homepage framework selector uses its own identifiers (see frameworkCardsArr)
 // that differ from the QUERY_FRAMEWORK_TO_PATH keys. Map them so
 // ?framework=react / netIos / netAndroid resolve correctly.
-const HOMEPAGE_FRAMEWORK_ALIASES: Record<string, string> = {
-  react: 'react-native',
-  netios: 'net-ios',
-  netandroid: 'net-android',
-};
+// The homepage framework selector uses its own identifiers (see
+// frameworkCardsArr) that differ from the canonical slugs. Declared as
+// `aliases` on each registry entry so a new spelling is added in one place.
+const HOMEPAGE_FRAMEWORK_ALIASES: Record<string, string> = Object.fromEntries(
+  FRAMEWORKS.flatMap((f) => (f.aliases || []).map((a) => [a, f.slug])),
+);
 
 // Normalizes a raw ?framework= value to a QUERY_FRAMEWORK_TO_PATH key, or ''
 // when it maps to no agent-skills page.
@@ -123,19 +111,25 @@ export function readSelectedFrameworkRaw(): string {
 }
 
 // Homepage selector slugs the shared product-picker banner hides for, because
-// there is no Agent Skill to route to. Xamarin (and its variants), Titanium and
-// Linux have no skills at all. Bare ".NET" is also hidden: it has no general
-// skill — the reader must pick a platform — so the banner stays hidden until
-// ".NET iOS" or ".NET Android" is selected (those slugs, netios/netandroid, are
-// intentionally NOT in this set, so the banner returns for them).
-const FRAMEWORKS_WITHOUT_AGENT_SKILLS = new Set<string>([
+// there is no Agent Skill to route to.
+//
+// Two sources, deliberately: the frameworks we document but have no skill for
+// come from the registry (so adding a skill flips one flag, not two lists), and
+// the selector-only identifiers below are spellings that are not canonical
+// frameworks at all - Xamarin is removed from 8.x and has no docs tree, and bare
+// ".NET" has no general skill because the reader must pick a platform first
+// (netios/netandroid are intentionally absent, so the banner returns for them).
+const SELECTOR_ONLY_WITHOUT_AGENT_SKILLS = [
   'xamarin',
   'xamarinios',
   'xamarinandroid',
   'xamarinforms',
-  'titanium',
-  'linux',
   'net',
+];
+
+const FRAMEWORKS_WITHOUT_AGENT_SKILLS = new Set<string>([
+  ...FRAMEWORKS.filter((f) => !f.agentSkills).map((f) => f.slug),
+  ...SELECTOR_ONLY_WITHOUT_AGENT_SKILLS,
 ]);
 
 // True unless the selected framework has no Agent Skills at all. Unknown/empty

--- a/src/components/utils/frameworks.ts
+++ b/src/components/utils/frameworks.ts
@@ -17,6 +17,9 @@ export const FRAMEWORK_MAPPING: { [urlSlug: string]: string } = {
   'web': 'Web',
   'net-ios': '.NET iOS',
   'net-android': '.NET Android',
+  // Without this, parseSdksRoute() resolved no framework at all for every
+  // /sdks/linux/ page. Found by `yarn verify:frameworks`.
+  'linux': 'Linux',
 };
 
 export const URL_PRODUCT_MAPPING: { [urlSlug: string]: string } = {

--- a/src/constants/frameworks.ts
+++ b/src/constants/frameworks.ts
@@ -17,9 +17,41 @@
  * Kept free of imports so docusaurus.config.ts can read it: the config is loaded
  * by Node, where webpack's `@generated` alias does not resolve.
  */
+/**
+ * Every canonical framework slug, as a type.
+ *
+ * Deliberately spelled out rather than derived from FRAMEWORKS: deriving it
+ * needs `as const`, which turns the registry into 13 exact tuple members and
+ * drops the optional `aliases` / `unreleased` keys from the ones that omit
+ * them, breaking every consumer that reads those fields. So this is a second
+ * copy of the vocabulary - guarded the same way the schema enum is, by
+ * `yarn verify:frameworks`, which compares union members, registry slugs and
+ * the docs-schema.yml enum three ways and fails if any pair diverges.
+ *
+ * Use this, not `string`, anywhere code names a framework. `string` is what let
+ * `netIos` and `react` drift into the frontmatter in the first place, and it is
+ * why a typo in a component - `['Web']` for `['web']` - still compiles and then
+ * silently matches nothing. The gate cannot see inside a component's props;
+ * the type can.
+ */
+export type FrameworkSlug =
+  | "ios"
+  | "android"
+  | "web"
+  | "react-native"
+  | "flutter"
+  | "cordova"
+  | "capacitor"
+  | "kmp"
+  | "net-ios"
+  | "net-android"
+  | "titanium"
+  | "linux"
+  | "hosted";
+
 export interface FrameworkDef {
   /** Canonical slug: the docs-schema.yml enum value, and the /sdks/<slug>/ segment. */
-  slug: string;
+  slug: FrameworkSlug;
   /** Human-readable name. Used as a map key by SkillsCallout, so it is load-bearing. */
   display: string;
   /**

--- a/src/constants/frameworks.ts
+++ b/src/constants/frameworks.ts
@@ -1,0 +1,102 @@
+/**
+ * THE framework registry. Every framework identifier in this repo comes from
+ * here.
+ *
+ * Before this file the same set was written out five times - FRAMEWORK_MAPPING,
+ * QUERY_FRAMEWORK_TO_PATH and HOMEPAGE_FRAMEWORK_ALIASES in
+ * components/utils/frameworks.ts, plus FRAMEWORK_URL_PATH and FRAMEWORK_SLUG in
+ * SkillsCallout - each keyed slightly differently. Nothing tied them together,
+ * so they could disagree without anyone noticing, and they did: `linux` was
+ * missing from FRAMEWORK_MAPPING, so every /sdks/linux/ page resolved to no
+ * framework at all. Silently. For as long as the page had existed.
+ *
+ * `slug` must match the `framework` / `frameworks` enum in docs-schema.yml.
+ * `yarn verify:frameworks` fails the build if the two ever diverge, so this
+ * registry and the frontmatter vocabulary cannot drift apart again.
+ *
+ * Kept free of imports so docusaurus.config.ts can read it: the config is loaded
+ * by Node, where webpack's `@generated` alias does not resolve.
+ */
+export interface FrameworkDef {
+  /** Canonical slug: the docs-schema.yml enum value, and the /sdks/<slug>/ segment. */
+  slug: string;
+  /** Human-readable name. Used as a map key by SkillsCallout, so it is load-bearing. */
+  display: string;
+  /**
+   * Path under /sdks/. Usually the slug; .NET splits across two segments.
+   * `null` means the framework is not an /sdks/ route at all.
+   */
+  routeSegment: string | null;
+  /** An Agent Skills page exists at /sdks/<routeSegment>/agent-skills. */
+  agentSkills: boolean;
+  /** Documented only in the in-development docs version (no versioned snapshot). */
+  unreleased?: boolean;
+  /**
+   * Other spellings that must resolve to this framework. The homepage selector
+   * uses its own identifiers, and `?framework=` carries them into the URL.
+   */
+  aliases?: string[];
+}
+
+export const FRAMEWORKS: FrameworkDef[] = [
+  { slug: "ios", display: "iOS", routeSegment: "ios", agentSkills: true },
+  { slug: "android", display: "Android", routeSegment: "android", agentSkills: true },
+  { slug: "web", display: "Web", routeSegment: "web", agentSkills: true },
+  {
+    slug: "react-native",
+    display: "React Native",
+    routeSegment: "react-native",
+    agentSkills: true,
+    aliases: ["react"],
+  },
+  { slug: "flutter", display: "Flutter", routeSegment: "flutter", agentSkills: true },
+  { slug: "cordova", display: "Cordova", routeSegment: "cordova", agentSkills: true },
+  { slug: "capacitor", display: "Capacitor", routeSegment: "capacitor", agentSkills: true },
+  {
+    slug: "kmp",
+    display: "Kotlin Multiplatform",
+    routeSegment: "kmp",
+    agentSkills: true,
+    unreleased: true,
+  },
+  {
+    slug: "net-ios",
+    display: ".NET iOS",
+    routeSegment: "net/ios",
+    agentSkills: true,
+    aliases: ["netios"],
+  },
+  {
+    slug: "net-android",
+    display: ".NET Android",
+    routeSegment: "net/android",
+    agentSkills: true,
+    aliases: ["netandroid"],
+  },
+  // Documented, but with no Agent Skills page to route a reader to.
+  { slug: "titanium", display: "Titanium", routeSegment: "titanium", agentSkills: false },
+  { slug: "linux", display: "Linux", routeSegment: "linux", agentSkills: false },
+  // Not an /sdks/ route: the hosted products live under /hosted/<product>/.
+  { slug: "hosted", display: "Hosted", routeSegment: null, agentSkills: false },
+];
+
+/** Canonical slugs, in registry order. */
+export const FRAMEWORK_SLUGS: string[] = FRAMEWORKS.map((f) => f.slug);
+
+export const FRAMEWORK_BY_SLUG: Record<string, FrameworkDef> = Object.fromEntries(
+  FRAMEWORKS.map((f) => [f.slug, f]),
+);
+
+export const FRAMEWORK_BY_DISPLAY: Record<string, FrameworkDef> = Object.fromEntries(
+  FRAMEWORKS.map((f) => [f.display, f]),
+);
+
+/** Frameworks that are an /sdks/ route (everything except `hosted` today). */
+export const ROUTED_FRAMEWORKS: FrameworkDef[] = FRAMEWORKS.filter(
+  (f) => f.routeSegment !== null,
+);
+
+/** Frameworks with an Agent Skills page. */
+export const AGENT_SKILL_FRAMEWORKS: FrameworkDef[] = FRAMEWORKS.filter(
+  (f) => f.agentSkills,
+);

--- a/src/constants/frameworks.ts
+++ b/src/constants/frameworks.ts
@@ -142,23 +142,33 @@ const BY_ROUTE_DEPTH: FrameworkDef[] = ROUTED_FRAMEWORKS.slice().sort(
 );
 
 /**
+ * The framework a path tail after `/sdks/` belongs to, or undefined.
+ *
+ * THE one place that knows how a route segment maps to a framework. Both path
+ * parsers call it: FeatureList via `frameworkFromPath`, and `parseSdksRoute` on
+ * the tail its own anchored regex captured. They used to answer this question
+ * separately, with different regexes - one of which captured a single segment,
+ * so `/sdks/net/ios/...` resolved to `net`, which is not a framework, and
+ * FeatureList rendered an empty table on both .NET platforms for the life of
+ * those pages.
+ *
+ * Derived from `routeSegment`, longest first, so a future multi-segment
+ * framework needs no change in either caller.
+ */
+export function frameworkFromRouteTail(tail: string): FrameworkDef | undefined {
+  return BY_ROUTE_DEPTH.find(
+    (f) => tail === f.routeSegment || tail.startsWith(`${f.routeSegment}/`),
+  );
+}
+
+/**
  * The framework an `/sdks/` path belongs to, or undefined.
  *
- * Derived from `routeSegment`, which is the point: the regexes this replaces
- * captured a single path segment, so `/sdks/net/ios/...` resolved to `net` -
- * not a framework - and FeatureList rendered an empty table on both .NET
- * platforms for the life of those pages. Anything matching one segment has the
- * same bug waiting; anything reading this map cannot.
- *
- * A future multi-segment framework needs no change here. Tolerates a leading
- * docs-version segment (`/next/`, `/7.6.14/`) because it anchors on `sdks/`
- * rather than on the start of the path.
+ * Anchors on `sdks/` rather than the start of the path, so docs-version
+ * prefixes (`/next/`, `/7.6.14/`) work. Use `parseSdksRoute` instead when the
+ * product segment is needed too, or when a path outside `/sdks/` must not match.
  */
 export function frameworkFromPath(pathname: string): FrameworkDef | undefined {
   const m = /(?:^|\/)sdks\/(.+)$/.exec(pathname);
-  if (!m) return undefined;
-  const rest = m[1];
-  return BY_ROUTE_DEPTH.find(
-    (f) => rest === f.routeSegment || rest.startsWith(`${f.routeSegment}/`),
-  );
+  return m ? frameworkFromRouteTail(m[1]) : undefined;
 }

--- a/src/constants/frameworks.ts
+++ b/src/constants/frameworks.ts
@@ -132,3 +132,33 @@ export const ROUTED_FRAMEWORKS: FrameworkDef[] = FRAMEWORKS.filter(
 export const AGENT_SKILL_FRAMEWORKS: FrameworkDef[] = FRAMEWORKS.filter(
   (f) => f.agentSkills,
 );
+
+/**
+ * Routed frameworks, longest `routeSegment` first, so `net/ios` is tested
+ * before `net`. A one-segment framework must never shadow a two-segment one.
+ */
+const BY_ROUTE_DEPTH: FrameworkDef[] = ROUTED_FRAMEWORKS.slice().sort(
+  (a, b) => (b.routeSegment as string).length - (a.routeSegment as string).length,
+);
+
+/**
+ * The framework an `/sdks/` path belongs to, or undefined.
+ *
+ * Derived from `routeSegment`, which is the point: the regexes this replaces
+ * captured a single path segment, so `/sdks/net/ios/...` resolved to `net` -
+ * not a framework - and FeatureList rendered an empty table on both .NET
+ * platforms for the life of those pages. Anything matching one segment has the
+ * same bug waiting; anything reading this map cannot.
+ *
+ * A future multi-segment framework needs no change here. Tolerates a leading
+ * docs-version segment (`/next/`, `/7.6.14/`) because it anchors on `sdks/`
+ * rather than on the start of the path.
+ */
+export function frameworkFromPath(pathname: string): FrameworkDef | undefined {
+  const m = /(?:^|\/)sdks\/(.+)$/.exec(pathname);
+  if (!m) return undefined;
+  const rest = m[1];
+  return BY_ROUTE_DEPTH.find(
+    (f) => rest === f.routeSegment || rest.startsWith(`${f.routeSegment}/`),
+  );
+}

--- a/src/constants/unreleasedFrameworks.ts
+++ b/src/constants/unreleasedFrameworks.ts
@@ -14,7 +14,11 @@
  * Kept free of imports so docusaurus.config.ts can read it too: the config is
  * loaded by Node, where webpack's `@generated` alias does not resolve.
  */
-export const UNRELEASED_FRAMEWORK_SLUGS = ["kmp"];
+import { FRAMEWORKS } from "./frameworks";
+
+export const UNRELEASED_FRAMEWORK_SLUGS = FRAMEWORKS.filter(
+  (f) => f.unreleased,
+).map((f) => f.slug);
 
 /** True when `slug` is documented only in the current docs version. */
 export function isUnreleasedFramework(

--- a/src/constants/unreleasedFrameworks.ts
+++ b/src/constants/unreleasedFrameworks.ts
@@ -16,7 +16,10 @@
  */
 import { FRAMEWORKS } from "./frameworks";
 
-export const UNRELEASED_FRAMEWORK_SLUGS = FRAMEWORKS.filter(
+// Annotated `string[]`, not `FrameworkSlug[]`: this is a membership-test array
+// queried with arbitrary route segments, and narrowing it would make
+// `.includes(someString)` a type error at every call site.
+export const UNRELEASED_FRAMEWORK_SLUGS: string[] = FRAMEWORKS.filter(
   (f) => f.unreleased,
 ).map((f) => f.slug);
 

--- a/src/data/features.json
+++ b/src/data/features.json
@@ -14,8 +14,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/serial-number-barcode.html#serial-number-barcode" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/serial-number-barcode.html#serial-number-barcode" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/serial-number-barcode.html#serial-number-barcode" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/serial-number-barcode.html#serial-number-barcode" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/serial-number-barcode.html#serial-number-barcode" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/serial-number-barcode.html#serial-number-barcode" }
     }
   },
   {
@@ -33,8 +33,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/part-number-barcode.html#part-number-barcode" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/part-number-barcode.html#part-number-barcode" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/part-number-barcode.html#part-number-barcode" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/part-number-barcode.html#part-number-barcode" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/part-number-barcode.html#part-number-barcode" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/part-number-barcode.html#part-number-barcode" }
     }
   },
   {
@@ -52,8 +52,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/imei-one-barcode.html#imei-one-barcode" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/imei-one-barcode.html#imei-one-barcode" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/imei-one-barcode.html#imei-one-barcode" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/imei-one-barcode.html#imei-one-barcode" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/imei-one-barcode.html#imei-one-barcode" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/imei-one-barcode.html#imei-one-barcode" }
     }
   },
   {
@@ -71,8 +71,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/imei-two-barcode.html#imei-two-barcode" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/imei-two-barcode.html#imei-two-barcode" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/imei-two-barcode.html#imei-two-barcode" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/imei-two-barcode.html#imei-two-barcode" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/imei-two-barcode.html#imei-two-barcode" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/imei-two-barcode.html#imei-two-barcode" }
     }
   },
   {
@@ -90,8 +90,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/unit-price-text.html#unit-price-text" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/unit-price-text.html#unit-price-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/unit-price-text.html#unit-price-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/unit-price-text.html#unit-price-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/unit-price-text.html#unit-price-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/unit-price-text.html#unit-price-text" }
     }
   },
   {
@@ -109,8 +109,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/total-price-text.html#total-price-text" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/total-price-text.html#total-price-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/total-price-text.html#total-price-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/total-price-text.html#total-price-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/total-price-text.html#total-price-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/total-price-text.html#total-price-text" }
     }
   },
   {
@@ -128,8 +128,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/weight-text.html#weight-text" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/weight-text.html#weight-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/weight-text.html#weight-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/weight-text.html#weight-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/weight-text.html#weight-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/weight-text.html#weight-text" }
     }
   },
   {
@@ -147,8 +147,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/packing-date-text.html#packing-date-text" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/packing-date-text.html#packing-date-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/packing-date-text.html#packing-date-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/packing-date-text.html#packing-date-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/packing-date-text.html#packing-date-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/packing-date-text.html#packing-date-text" }
     }
   },
   {
@@ -166,8 +166,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/expiry-date-text.html#expiry-date-text" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/expiry-date-text.html#expiry-date-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/expiry-date-text.html#expiry-date-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/expiry-date-text.html#expiry-date-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/expiry-date-text.html#expiry-date-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/expiry-date-text.html#expiry-date-text" }
     }
   },
   {
@@ -185,8 +185,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.3", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/date-text.html#date-text" },
       "Cordova": { "version": "8.3", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/date-text.html#date-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/date-text.html#date-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/date-text.html#date-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/date-text.html#date-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/date-text.html#date-text" }
     }
   },
   {
@@ -204,8 +204,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.PriceCaptureDefinitionWithName" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.PriceCaptureDefinitionWithName" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.PriceCaptureDefinitionWithName" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.PriceCaptureDefinitionWithName" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.PriceCaptureDefinitionWithName" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.PriceCaptureDefinitionWithName" }
     }
   },
   {
@@ -223,8 +223,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.VinLabelDefinitionWithName" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.VinLabelDefinitionWithName" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.VinLabelDefinitionWithName" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.VinLabelDefinitionWithName" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.VinLabelDefinitionWithName" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.VinLabelDefinitionWithName" }
     }
   },
   {
@@ -242,8 +242,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.SevenSegmentDisplayLabelDefinitionWithName" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.SevenSegmentDisplayLabelDefinitionWithName" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.SevenSegmentDisplayLabelDefinitionWithName" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.SevenSegmentDisplayLabelDefinitionWithName" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.SevenSegmentDisplayLabelDefinitionWithName" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/label-definition.html#method-scandit.datacapture.label.LabelDefinition.SevenSegmentDisplayLabelDefinitionWithName" }
     }
   },
   {
@@ -261,8 +261,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/receipt-scanning-result.html#receipt-scanning-result" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/receipt-scanning-result.html#receipt-scanning-result" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/receipt-scanning-result.html#receipt-scanning-result" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/receipt-scanning-result.html#receipt-scanning-result" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/receipt-scanning-result.html#receipt-scanning-result" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/receipt-scanning-result.html#receipt-scanning-result" }
     }
   },
   {
@@ -280,8 +280,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/custom-barcode.html#custom-barcode" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/custom-barcode.html#custom-barcode" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/custom-barcode.html#custom-barcode" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/custom-barcode.html#custom-barcode" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/custom-barcode.html#custom-barcode" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/custom-barcode.html#custom-barcode" }
     }
   },
   {
@@ -299,8 +299,8 @@
       "Kotlin Multiplatform": { "version": "8.6" },
       "Capacitor": { "version": "8.0", "apiUrl": "https://docs.scandit.com/data-capture-sdk/capacitor/label-capture/api/custom-text.html#custom-text" },
       "Cordova": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/cordova/label-capture/api/custom-text.html#custom-text" },
-      ".Net Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/custom-text.html#custom-text" },
-      ".Net iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/custom-text.html#custom-text" }
+      ".NET Android": { "version": "8.1", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/android/label-capture/api/custom-text.html#custom-text" },
+      ".NET iOS": { "version": "8.2", "apiUrl": "https://docs.scandit.com/data-capture-sdk/net/ios/label-capture/api/custom-text.html#custom-text" }
     }
   }
 ]

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -7,6 +7,7 @@ import type { WrapperProps } from '@docusaurus/types';
 import SkillsCallout from '@site/src/components/SkillsCallout';
 import skillsData from '@site/src/data/skills.json';
 import { parseSdksRoute } from '@site/src/components/utils/frameworks';
+import { FRAMEWORKS } from '@site/src/constants/frameworks';
 import { isOnFallbackDenylist } from '@site/src/components/SkillsCallout/routes';
 
 type Props = WrapperProps<typeof ContentType>;
@@ -14,7 +15,12 @@ type Props = WrapperProps<typeof ContentType>;
 const KNOWN_PRODUCTS = new Set(Object.keys(skillsData.products));
 
 // Frameworks with no Agent Skills at all — never show the callout there.
-const SKILL_LESS_FRAMEWORK_PREFIXES = ['/sdks/titanium/', '/sdks/linux/'];
+// Derived from the registry's `agentSkills` flag rather than listed here: the
+// two prefixes were a hand-written copy, and a framework gaining or losing an
+// Agent Skills page would not have updated it.
+const SKILL_LESS_FRAMEWORK_PREFIXES = FRAMEWORKS.filter(
+  (f) => !f.agentSkills && f.routeSegment !== null,
+).map((f) => `/sdks/${f.routeSegment}/`);
 
 export default function ContentWrapper(props: Props): JSX.Element {
   const { pathname } = useLocation();

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -7,28 +7,26 @@ import type { WrapperProps } from '@docusaurus/types';
 import SkillsCallout from '@site/src/components/SkillsCallout';
 import skillsData from '@site/src/data/skills.json';
 import { parseSdksRoute } from '@site/src/components/utils/frameworks';
-import { FRAMEWORKS } from '@site/src/constants/frameworks';
+import { frameworkFromPath } from '@site/src/constants/frameworks';
 import { isOnFallbackDenylist } from '@site/src/components/SkillsCallout/routes';
 
 type Props = WrapperProps<typeof ContentType>;
 
 const KNOWN_PRODUCTS = new Set(Object.keys(skillsData.products));
 
-// Frameworks with no Agent Skills at all — never show the callout there.
-// Derived from the registry's `agentSkills` flag rather than listed here: the
-// two prefixes were a hand-written copy, and a framework gaining or losing an
-// Agent Skills page would not have updated it.
-const SKILL_LESS_FRAMEWORK_PREFIXES = FRAMEWORKS.filter(
-  (f) => !f.agentSkills && f.routeSegment !== null,
-).map((f) => `/sdks/${f.routeSegment}/`);
+
 
 export default function ContentWrapper(props: Props): JSX.Element {
   const { pathname } = useLocation();
   const route = parseSdksRoute(pathname);
   const isKnownProductPage = !!route.product && KNOWN_PRODUCTS.has(route.product);
-  const isSkillLessFramework = SKILL_LESS_FRAMEWORK_PREFIXES.some((prefix) =>
-    pathname.startsWith(prefix),
-  );
+  // Frameworks with no Agent Skills page — never show the callout there.
+  // Resolved through the registry rather than by prefix: this was a
+  // startsWith() over ['/sdks/titanium/', '/sdks/linux/'], which a docs-version
+  // segment defeats, so /next/sdks/titanium/ and /7.6.14/sdks/linux/ showed the
+  // Agent Skills banner on frameworks that have no Agent Skills at all.
+  const routeFramework = frameworkFromPath(pathname);
+  const isSkillLessFramework = !!routeFramework && !routeFramework.agentSkills;
 
   // ID Bolt docs live under /hosted/, outside the /sdks/ product routes, so
   // the route-driven callout never fires there. Surface its skill explicitly.


### PR DESCRIPTION
Closes the ticket on the unvalidated `framework` field.

## The problem

`docs-schema.yml` defined the plural `frameworks` array with an enum but did not
define the singular `framework` field at all. The schema allows undeclared
fields, so it got no validation and its values drifted. Components that read it
silently found no match and fell back to their default — always iOS. No crash,
no error.

## What this changes

- The enum in `docs-schema.yml` is the single source of truth; singular and
  plural share one vocabulary.
- 117 pages normalized: 92 spelling drifts (`netIos` / `netAndroid` / `react`),
  and 25 `express` / `bolt` pages which were never frameworks — they live under
  `docs/hosted/`, so they are now `framework: hosted` with the value they carried
  moved to `product:`.
- Five copies of the framework list replaced by one registry
  (`src/constants/frameworks.ts`), which `UNRELEASED_FRAMEWORK_SLUGS` also
  derives from.

## Three things the ticket could not have known

- **`kmp` — 37 pages**, more than any row in the ticket's table. Not drift: it is
  the published `/sdks/kmp/` tree, it is first-class in the code, and
  "unreleased" is already tracked by a separate mechanism. The enum was stale, so
  `kmp` was added to it rather than the pages being rewritten.
- **`FW_TO_PJ` does not exist** — PR #417 is unmerged. There were five copies,
  not three.
- **A live bug:** `FRAMEWORK_MAPPING` had no `linux` entry, so
  `parseSdksRoute()` resolved no framework at all for every `/sdks/linux/` page.

## Why nobody ever saw an error

`docs-gate` is a ratchet over changed files. Those 37 pages had been violating
the plural enum for months and were never once reported. So
`yarn verify:frameworks` (in CI) runs over the whole corpus and over the
registry: a value outside the enum is an error, and the registry and schema are
compared in both directions.

Plus `yarn test:frameworks` — 9 assertions pinning the membership of every
derived map, because the risk in this refactor is not a crash but a map quietly
gaining or losing an entry.

## Separately

`docs-gate` now skips prose checks for files whose body did not change. The
mechanical frontmatter pass across 117 files dragged in 233 pre-existing Vale
findings (measured: 233 before, 233 after). Any file with a body edit is still
checked in full — verified by adding one sentence and watching both new findings
appear while the other 116 stayed skipped.

**The ticket's test:** a page set to `framework: netIos` fails the gate before
normalization and passes after — verified in both directions.