### PR TITLE
docs(react-native): add AIO components guides

### DIFF
--- a/docs/sdks/react-native/aio/get-started.md
+++ b/docs/sdks/react-native/aio/get-started.md
@@ -92,75 +92,12 @@ new value, which makes the view re-apply its settings more often than it needs t
 
 ## Navigate Between Scanning Screens
 
-This is the part most applications get wrong, so it is worth understanding before you
-build the second screen.
+Two scanning screens cannot both drive the camera. The newest view to claim it takes
+ownership, and passing each view the screen's `navigation` object suspends scanning while
+that screen is blurred.
 
-The camera has exactly one owner. The newest view to claim it takes ownership, calls from
-a superseded owner are ignored, and the camera drops to standby when nothing holds it.
-Most AIO views share the camera the provider owns. `SparkScanAioView` is the exception:
-it claims the camera exclusively and drives its own.
-
-Pass each view the screen's `navigation` object. Scanning is then suspended while the
-screen is blurred or the app is backgrounded, and resumed when it comes back:
-
-```js
-import { NavigationContainer } from '@react-navigation/native';
-import { createStackNavigator } from '@react-navigation/stack';
-import { ScanditProvider } from 'scandit-react-native-datacapture-core';
-import {
-  BarcodeCaptureAioView,
-  SparkScanAioView,
-  Symbology,
-} from 'scandit-react-native-datacapture-barcode';
-
-const SYMBOLOGIES = [Symbology.EAN13UPCA, Symbology.Code128];
-const Stack = createStackNavigator();
-
-function SparkScanScreen({ navigation }) {
-  return (
-    <SparkScanAioView
-      style={{ flex: 1 }}
-      navigation={navigation}
-      symbologies={SYMBOLOGIES}
-      didScan={(barcodes) => console.log('spark', barcodes[0]?.data)}
-    />
-  );
-}
-
-function CaptureScreen({ navigation }) {
-  return (
-    <BarcodeCaptureAioView
-      style={{ flex: 1 }}
-      navigation={navigation}
-      symbologies={SYMBOLOGIES}
-      didScan={(barcodes) => console.log('capture', barcodes[0]?.data)}
-    />
-  );
-}
-
-export default function App() {
-  return (
-    <ScanditProvider licenseKey={LICENSE_KEY}>
-      <NavigationContainer>
-        <Stack.Navigator>
-          <Stack.Screen name="Spark" component={SparkScanScreen} />
-          <Stack.Screen name="Capture" component={CaptureScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
-    </ScanditProvider>
-  );
-}
-```
-
-Moving between these two screens crosses between an exclusive claim and a shared one.
-Handing the camera over is what the ownership model exists to do, so no extra code is
-needed, but do test this path on a device, because it is where mistakes show up.
-
-:::note
-`navigation` only needs an object with an `addListener` method for `focus` and `blur`
-events. React Navigation's `navigation` prop satisfies this, and so can your own
-implementation.
-:::
+See [Navigating Between Screens](./navigating-between-screens.md) for the ownership model
+and the lifecycle props that control when each view scans.
 
 ## Camera Position and Torch
 
@@ -250,4 +187,5 @@ from your desk? Here's a [handy pdf of barcodes](https://github.com/Scandit/.git
 
 ## Where to Go Next
 
+- [Navigating Between Screens](./navigating-between-screens.md): the camera ownership model and the lifecycle props that control when each view scans.
 - [React Native samples](https://github.com/Scandit/datacapture-react-native-samples): complete applications you can build and run.

--- a/docs/sdks/react-native/aio/get-started.md
+++ b/docs/sdks/react-native/aio/get-started.md
@@ -1,0 +1,251 @@
+---
+description: "Build a scanner in React Native with the Scandit AIO components: ScanditProvider, SparkScanAioView, and navigating between scanning screens."
+sidebar_label: 'Get Started'
+title: 'Get Started'
+sidebar_position: 2
+framework: react
+keywords:
+  - react
+---
+
+# Get Started
+
+The AIO ("all-in-one") components are React scanning views that own their own capture
+mode, overlay, camera claim and lifecycle. You render one component instead of
+assembling a context, a mode, a view and an overlay by hand.
+
+In this guide you will learn step-by-step how to build a scanner with them. The
+general steps are:
+
+1. Wrap your app in `ScanditProvider`.
+2. Add a scanning view and handle the barcodes it reads.
+3. Navigate between two scanning screens.
+4. Set the camera position and torch, and handle camera permissions.
+
+## Prerequisites
+
+- The latest stable version of [React Native CLI and other related tools and dependencies](https://reactnative.dev/docs/environment-setup).
+- A valid Scandit Data Capture SDK license key. You can sign up for a free [test account](https://ssl.scandit.com/dashboard/sign-up?p=test&utm%5Fsource=documentation).
+- If you have not already done so, see [this guide](../add-sdk.md) for information on how to add the Scandit Data Capture SDK to your project.
+
+## Add the Provider
+
+[ScanditProvider](https://docs.scandit.com/data-capture-sdk/react-native/core/api/scandit-provider.html) creates the
+[DataCaptureContext](https://docs.scandit.com/data-capture-sdk/react-native/core/api/data-capture-context.html) and the single
+[Camera](https://docs.scandit.com/data-capture-sdk/react-native/core/api/camera.html) that the AIO scanning views share, and tracks camera permission.
+Every AIO view needs one above it.
+
+It ships in the core package. Mount one at the root of your app and pass your license
+key:
+
+```js
+import { ScanditProvider } from 'scandit-react-native-datacapture-core';
+
+export default function App() {
+  return (
+    <ScanditProvider licenseKey={LICENSE_KEY}>
+      <NavigationContainer>{/* your screens */}</NavigationContainer>
+    </ScanditProvider>
+  );
+}
+```
+
+That is all the setup a first scanner needs.
+
+## Add a Scanning View
+
+`SparkScanAioView` is the quickest view to start with: it brings its own scanning UI,
+including the trigger button and the mini preview.
+
+Pass the symbologies you want to read, and a `didScan` callback to receive them:
+
+```js
+import { SparkScanAioView, Symbology } from 'scandit-react-native-datacapture-barcode';
+
+const SYMBOLOGIES = [Symbology.EAN13UPCA, Symbology.Code128];
+
+function ScanScreen({ navigation }) {
+  return (
+    <SparkScanAioView
+      style={{ flex: 1 }}
+      navigation={navigation}
+      symbologies={SYMBOLOGIES}
+      didScan={(barcodes) => {
+        for (const barcode of barcodes) {
+          console.log(barcode.data);
+        }
+      }}
+    />
+  );
+}
+```
+
+`didScan` is called for each newly recognized barcode. Return a `Promise` from it to keep
+the frame alive while asynchronous work runs.
+
+:::tip
+Declare `SYMBOLOGIES` outside the component, as above. A new array on every render is a
+new value, which makes the view re-apply its settings more often than it needs to.
+:::
+
+## Navigate Between Scanning Screens
+
+This is the part most applications get wrong, so it is worth understanding before you
+build the second screen.
+
+The camera has exactly one owner. The newest view to claim it takes ownership, calls from
+a superseded owner are ignored, and the camera drops to standby when nothing holds it.
+Most AIO views share the camera the provider owns. `SparkScanAioView` is the exception:
+it claims the camera exclusively and drives its own.
+
+Pass each view the screen's `navigation` object. Scanning is then suspended while the
+screen is blurred or the app is backgrounded, and resumed when it comes back:
+
+```js
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { ScanditProvider } from 'scandit-react-native-datacapture-core';
+import {
+  BarcodeCaptureAioView,
+  SparkScanAioView,
+  Symbology,
+} from 'scandit-react-native-datacapture-barcode';
+
+const SYMBOLOGIES = [Symbology.EAN13UPCA, Symbology.Code128];
+const Stack = createStackNavigator();
+
+function SparkScanScreen({ navigation }) {
+  return (
+    <SparkScanAioView
+      style={{ flex: 1 }}
+      navigation={navigation}
+      symbologies={SYMBOLOGIES}
+      didScan={(barcodes) => console.log('spark', barcodes[0]?.data)}
+    />
+  );
+}
+
+function CaptureScreen({ navigation }) {
+  return (
+    <BarcodeCaptureAioView
+      style={{ flex: 1 }}
+      navigation={navigation}
+      symbologies={SYMBOLOGIES}
+      didScan={(barcodes) => console.log('capture', barcodes[0]?.data)}
+    />
+  );
+}
+
+export default function App() {
+  return (
+    <ScanditProvider licenseKey={LICENSE_KEY}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Spark" component={SparkScanScreen} />
+          <Stack.Screen name="Capture" component={CaptureScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ScanditProvider>
+  );
+}
+```
+
+Moving between these two screens crosses between an exclusive claim and a shared one.
+Handing the camera over is what the ownership model exists to do, so no extra code is
+needed, but do test this path on a device, because it is where mistakes show up.
+
+:::note
+`navigation` only needs an object with an `addListener` method for `focus` and `blur`
+events. React Navigation's `navigation` prop satisfies this, and so can your own
+implementation.
+:::
+
+## Camera Position and Torch
+
+For the views that share the provider's camera, set the torch and camera position on the
+provider. The outermost provider is the **root**: it creates the context and the camera,
+and disposes of both when it unmounts. `licenseKey` is required there and ignored, with a
+warning, anywhere else.
+
+A provider mounted below another is **nested**. It creates nothing, and applies its own
+`frameSourceState`, `torchState` and `cameraPosition` to the same camera the root owns.
+Nesting one around a single screen is the supported way to control the camera for that
+screen only:
+
+```js
+import { CameraPosition, TorchState } from 'scandit-react-native-datacapture-core';
+
+<ScanditProvider
+  torchState={TorchState.On}
+  cameraPosition={CameraPosition.WorldFacing}>
+  <CaptureScreen />
+</ScanditProvider>;
+```
+
+:::note
+`torchState`, `cameraPosition` and `cameraSettings` are set-only. A nested provider does
+not restore the previous values when it unmounts, so set what you need on the screen that
+needs it. `frameSourceState` behaves differently: `On` holds a camera claim only while
+that provider stays mounted, and the claim is released when it unmounts.
+:::
+
+:::warning
+These props do not reach `SparkScanAioView`, because it drives its own camera. Set its
+starting state through `SparkScanViewSettings.defaultTorchState` and
+`SparkScanViewSettings.defaultCameraPosition`, and let the user change it with the view's
+built-in controls — `torchControlVisible` and `cameraSwitchButtonVisible`.
+:::
+
+:::tip
+Please refer to [ScanditProvider](https://docs.scandit.com/data-capture-sdk/react-native/core/api/scandit-provider.html) for the full list of parameters.
+:::
+
+## Camera Permissions
+
+`useCameraPermission` reports the current permission state and asks for it:
+
+```js
+import { useCameraPermission } from 'scandit-react-native-datacapture-core';
+
+function CameraGate({ children }) {
+  const { hasPermission, requestPermission } = useCameraPermission();
+
+  useEffect(() => {
+    if (!hasPermission) {
+      void requestPermission();
+    }
+  }, [hasPermission, requestPermission]);
+
+  return hasPermission ? children : null;
+}
+```
+
+:::note
+The two platforms behave differently. On Android the hook reports the real status,
+`requestPermission()` shows the system prompt, and the status is re-checked when your app
+returns to the foreground. On iOS the system shows its own dialog the first time the
+camera is used, so the hook reports `not-determined` until that happens.
+:::
+
+## React Native Architecture Support
+
+The AIO components run on both React Native architectures.
+
+The new architecture is the default for new applications, and React Native 0.82 and later
+run it exclusively. The legacy ("Paper") architecture is also supported: every AIO view
+has been verified rendering on it, on both iOS and Android, on React Native 0.81.4 and
+0.74.7.
+
+:::note
+React Native 0.74 is the lowest version verified against this SDK. Older releases are not
+supported.
+:::
+
+## Scan Some Barcodes
+
+Now that you're up and running, go find some barcodes to scan. Don't feel like getting up
+from your desk? Here's a [handy pdf of barcodes](https://github.com/Scandit/.github/blob/main/images/PrintTheseBarcodes.pdf) you can print out.
+
+## Where to Go Next
+
+- [React Native samples](https://github.com/Scandit/datacapture-react-native-samples): complete applications you can build and run.

--- a/docs/sdks/react-native/aio/get-started.md
+++ b/docs/sdks/react-native/aio/get-started.md
@@ -1,5 +1,5 @@
 ---
-description: "Build a scanner in React Native with the Scandit AIO components: ScanditProvider, SparkScanAioView, and navigating between scanning screens."
+description: "Build a scanner in React Native with the Scandit AIO components: ScanditProvider, SparkScanAioView, camera control, and permissions."
 sidebar_label: 'Get Started'
 title: 'Get Started'
 sidebar_position: 2
@@ -16,6 +16,11 @@ assembling a context, a mode, a view and an overlay by hand.
 
 They are available from version 8.7.
 
+Use an AIO view for a standard scanning screen. Use the classic
+[Barcode Capture](../barcode-capture/get-started.md) path when you need to build the
+capture pipeline yourself, for example to drive the camera or compose overlays your own
+way. Both are supported.
+
 In this guide you will learn step-by-step how to build a scanner with them. The
 general steps are:
 
@@ -28,7 +33,8 @@ general steps are:
 
 - The latest stable version of [React Native CLI and other related tools and dependencies](https://reactnative.dev/docs/environment-setup).
 - A valid Scandit Data Capture SDK license key. You can sign up for a free [test account](https://ssl.scandit.com/dashboard/sign-up?p=test&utm%5Fsource=documentation).
-- If you have not already done so, see [this guide](../add-sdk.md) for information on how to add the Scandit Data Capture SDK to your project.
+- If you have not already done so, see [this guide](../add-sdk.md) for information on how to add the Scandit Data Capture SDK to your project. This guide imports from two packages, so install both: `scandit-react-native-datacapture-core` and `scandit-react-native-datacapture-barcode`.
+- Navigation is your own choice of library, and is not part of the Scandit SDK. The examples here use [React Navigation](https://reactnavigation.org/), which needs `@react-navigation/native` and `@react-navigation/stack`.
 
 ## Add the Provider
 
@@ -38,10 +44,13 @@ general steps are:
 Every AIO view needs one above it.
 
 It ships in the core package. Mount one at the root of your app and pass your license
-key:
+key, which is the key from your Scandit dashboard or the test account linked above:
 
 ```js
+import { NavigationContainer } from '@react-navigation/native';
 import { ScanditProvider } from 'scandit-react-native-datacapture-core';
+
+const LICENSE_KEY = 'YOUR_LICENSE_KEY_HERE';
 
 export default function App() {
   return (
@@ -70,6 +79,8 @@ function ScanScreen({ navigation }) {
   return (
     <SparkScanAioView
       style={{ flex: 1 }}
+      // Lets the view stop scanning when this screen loses focus, and start
+      // again when it comes back. See Navigate Between Scanning Screens below.
       navigation={navigation}
       symbologies={SYMBOLOGIES}
       didScan={(barcodes) => {
@@ -82,13 +93,68 @@ function ScanScreen({ navigation }) {
 }
 ```
 
-`didScan` is called for each newly recognized barcode. Return a `Promise` from it to keep
-the frame alive while asynchronous work runs.
+`EAN13UPCA` and `Code128` are two common retail symbologies. Enable whichever ones you
+need: the full list is in the
+[Symbology](https://docs.scandit.com/data-capture-sdk/react-native/barcode-capture/api/symbology.html) reference.
+
+Render the screen inside the provider from the previous section, and you have a working
+scanner:
+
+```js
+export default function App() {
+  return (
+    <ScanditProvider licenseKey={LICENSE_KEY}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Scan" component={ScanScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ScanditProvider>
+  );
+}
+```
+
+`didScan` is called for each newly recognized barcode. If you need to do asynchronous work
+before the next scan is processed, such as looking the barcode up, return a promise and
+the view waits for it:
+
+```js
+didScan={async (barcodes) => {
+  await lookupProduct(barcodes[0].data);
+}}
+```
 
 :::tip
 Declare `SYMBOLOGIES` outside the component, as above. A new array on every render is a
 new value, which makes the view re-apply its settings more often than it needs to.
 :::
+
+### Calling the View Directly
+
+Every AIO view exposes a **handle** through a `ref`. The handle carries the imperative
+methods for that view, and every AIO view has `enable()` and `disable()` on it for turning
+scanning on and off yourself:
+
+```js
+import { useRef } from 'react';
+
+function ScanScreen({ navigation }) {
+  const view = useRef(null);
+
+  return (
+    <>
+      <SparkScanAioView
+        ref={view}
+        style={{ flex: 1 }}
+        navigation={navigation}
+        symbologies={SYMBOLOGIES}
+        didScan={(barcodes) => console.log(barcodes[0]?.data)}
+      />
+      <Button title="Stop scanning" onPress={() => view.current?.disable()} />
+    </>
+  );
+}
+```
 
 ## Navigate Between Scanning Screens
 
@@ -107,32 +173,33 @@ and disposes of both when it unmounts. `licenseKey` is required there and ignore
 warning, anywhere else.
 
 A provider mounted below another is **nested**. It creates nothing, and applies its own
-`frameSourceState`, `torchState` and `cameraPosition` to the same camera the root owns.
-Nesting one around a single screen is the supported way to control the camera for that
-screen only:
+`torchState` and `cameraPosition` to the same camera the root owns. Nesting one around a
+single screen is the supported way to control the camera for that screen only:
 
 ```js
 import { CameraPosition, TorchState } from 'scandit-react-native-datacapture-core';
 
-<ScanditProvider
-  torchState={TorchState.On}
-  cameraPosition={CameraPosition.WorldFacing}>
-  <CaptureScreen />
-</ScanditProvider>;
+function TorchScreen({ navigation }) {
+  return (
+    <ScanditProvider
+      torchState={TorchState.On}
+      cameraPosition={CameraPosition.WorldFacing}>
+      <ScanScreen navigation={navigation} />
+    </ScanditProvider>
+  );
+}
 ```
 
 :::note
-`torchState`, `cameraPosition` and `cameraSettings` are set-only. A nested provider does
-not restore the previous values when it unmounts, so set what you need on the screen that
-needs it. `frameSourceState` behaves differently: `On` holds a camera claim only while
-that provider stays mounted, and the claim is released when it unmounts.
+`torchState` and `cameraPosition` are set-only. A nested provider does not restore the
+previous values when it unmounts, so set what you need on the screen that needs it.
 :::
 
 :::warning
 These props do not reach `SparkScanAioView`, because it drives its own camera. Set its
 starting state through `SparkScanViewSettings.defaultTorchState` and
 `SparkScanViewSettings.defaultCameraPosition`, and let the user change it with the view's
-built-in controls — `torchControlVisible` and `cameraSwitchButtonVisible`.
+built-in controls: `torchControlVisible` and `cameraSwitchButtonVisible`.
 :::
 
 :::tip
@@ -144,6 +211,7 @@ Please refer to [ScanditProvider](https://docs.scandit.com/data-capture-sdk/reac
 `useCameraPermission` reports the current permission state and asks for it:
 
 ```js
+import { useEffect } from 'react';
 import { useCameraPermission } from 'scandit-react-native-datacapture-core';
 
 function CameraGate({ children }) {
@@ -180,6 +248,23 @@ React Native 0.74 is the lowest version verified against this SDK. Older release
 supported.
 :::
 
+## Troubleshooting
+
+**Nothing happens when you point at a barcode.** The symbology is probably not enabled.
+Only the symbologies in the array you pass are read, so a QR code is ignored by the
+example above. Add it to `SYMBOLOGIES`, or check the
+[Symbology](https://docs.scandit.com/data-capture-sdk/react-native/barcode-capture/api/symbology.html) reference for the name you need.
+
+**The preview is black, or freezes when you come back to a screen.** Two scanning views
+are competing for the camera. Pass every view the screen's `navigation` object so that a
+blurred screen releases the camera, and read
+[Navigating Between Screens](./navigating-between-screens.md).
+
+**The camera never starts and no permission dialog appears.** On Android, call
+`requestPermission()` from `useCameraPermission`: the system prompt does not appear on its
+own. On iOS the dialog is shown the first time the camera is used, so if it never appears,
+no view has claimed the camera yet.
+
 ## Scan Some Barcodes
 
 Now that you're up and running, go find some barcodes to scan. Don't feel like getting up
@@ -188,4 +273,6 @@ from your desk? Here's a [handy pdf of barcodes](https://github.com/Scandit/.git
 ## Where to Go Next
 
 - [Navigating Between Screens](./navigating-between-screens.md): the camera ownership model and the lifecycle props that control when each view scans.
+- [ScanditProvider API reference](https://docs.scandit.com/data-capture-sdk/react-native/core/api/scandit-provider.html): every provider prop, in full.
+- [Barcode Capture](../barcode-capture/get-started.md): the classic path, for when you need to build the capture pipeline yourself.
 - [React Native samples](https://github.com/Scandit/datacapture-react-native-samples): complete applications you can build and run.

--- a/docs/sdks/react-native/aio/get-started.md
+++ b/docs/sdks/react-native/aio/get-started.md
@@ -14,6 +14,8 @@ The AIO ("all-in-one") components are React scanning views that own their own ca
 mode, overlay, camera claim and lifecycle. You render one component instead of
 assembling a context, a mode, a view and an overlay by hand.
 
+They are available from version 8.7.
+
 In this guide you will learn step-by-step how to build a scanner with them. The
 general steps are:
 

--- a/docs/sdks/react-native/aio/navigating-between-screens.md
+++ b/docs/sdks/react-native/aio/navigating-between-screens.md
@@ -14,6 +14,10 @@ A single scanning screen is straightforward. A second one is where applications 
 wrong, because two screens cannot both drive the camera. This page covers what happens
 when you navigate between AIO views.
 
+It follows on from [Get Started](./get-started.md), which covers installing the packages
+and mounting the provider. The examples below also use
+[React Navigation](https://reactnavigation.org/), which is not part of the Scandit SDK.
+
 ## The Camera Has One Owner
 
 The camera has exactly one owner at a time. The newest view to claim it takes ownership,
@@ -50,6 +54,7 @@ import {
   Symbology,
 } from 'scandit-react-native-datacapture-barcode';
 
+const LICENSE_KEY = 'YOUR_LICENSE_KEY_HERE';
 const SYMBOLOGIES = [Symbology.EAN13UPCA, Symbology.Code128];
 const Stack = createStackNavigator();
 
@@ -106,9 +111,27 @@ not the whole story:
   moves between the background and the foreground. Set it only if you manage that
   yourself.
 
-Every AIO view also exposes `enable()` and `disable()` on its handle for a single
-imperative change. Prefer `disabled` for state your render already knows about: the prop
-and the handle can otherwise disagree about whether scanning is on.
+`disabled` is a prop like any other, so drive it from state:
+
+```js
+<BarcodeCaptureAioView
+  style={{ flex: 1 }}
+  navigation={navigation}
+  disabled={isSheetOpen}
+  symbologies={SYMBOLOGIES}
+  didScan={handleScan}
+/>
+```
+
+Every AIO view also exposes `enable()` and `disable()` on its
+[handle](./get-started.md#calling-the-view-directly), for a single imperative change.
+
+:::warning
+Prefer the `disabled` prop for anything your render already knows about. The focus and
+foreground handlers read the current value of `disabled`, and an imperative `disable()`
+does not change it. So a view you disabled by hand starts scanning again at the next
+focus or foreground event, because the prop still says it is enabled.
+:::
 
 ## Where to Go Next
 

--- a/docs/sdks/react-native/aio/navigating-between-screens.md
+++ b/docs/sdks/react-native/aio/navigating-between-screens.md
@@ -1,0 +1,115 @@
+---
+description: "Navigate between Scandit AIO scanning screens in React Native: the camera ownership model and the navigation prop."
+sidebar_label: 'Navigating Between Screens'
+title: 'Navigating Between Screens'
+sidebar_position: 3
+framework: react
+keywords:
+  - react
+---
+
+# Navigating Between Screens
+
+A single scanning screen is straightforward. A second one is where applications go
+wrong, because two screens cannot both drive the camera. This page covers what happens
+when you navigate between AIO views.
+
+## The Camera Has One Owner
+
+The camera has exactly one owner at a time. The newest view to claim it takes ownership,
+calls from a superseded owner are ignored, and the camera drops to standby when nothing
+holds it.
+
+Views differ in how they claim it:
+
+- Most AIO views take a **shared** claim on the camera the provider owns:
+  `BarcodeCaptureAioView`, `BarcodeBatchAioView`, `BarcodeCountAioView`,
+  `BarcodeArAioView`, `IdCaptureAioView` and `LabelCaptureAioView`.
+- `SparkScanAioView` takes an **exclusive** claim and drives its own camera.
+
+Navigating from a shared view to `SparkScanAioView`, or back, hands the camera over.
+That handover is what the ownership model exists to do, so it needs no code from you.
+
+:::warning
+Test this path on a real device. Camera handover is the one behavior that unit tests and
+simulators will not tell you about, and it is where mistakes appear.
+:::
+
+## Pass the navigation Prop
+
+Give each view the screen's `navigation` object. Scanning is then suspended while the
+screen is blurred or the app is in the background, and resumed when it returns:
+
+```js
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { ScanditProvider } from 'scandit-react-native-datacapture-core';
+import {
+  BarcodeCaptureAioView,
+  SparkScanAioView,
+  Symbology,
+} from 'scandit-react-native-datacapture-barcode';
+
+const SYMBOLOGIES = [Symbology.EAN13UPCA, Symbology.Code128];
+const Stack = createStackNavigator();
+
+function SparkScanScreen({ navigation }) {
+  return (
+    <SparkScanAioView
+      style={{ flex: 1 }}
+      navigation={navigation}
+      symbologies={SYMBOLOGIES}
+      didScan={(barcodes) => console.log('spark', barcodes[0]?.data)}
+    />
+  );
+}
+
+function CaptureScreen({ navigation }) {
+  return (
+    <BarcodeCaptureAioView
+      style={{ flex: 1 }}
+      navigation={navigation}
+      symbologies={SYMBOLOGIES}
+      didScan={(barcodes) => console.log('capture', barcodes[0]?.data)}
+    />
+  );
+}
+
+export default function App() {
+  return (
+    <ScanditProvider licenseKey={LICENSE_KEY}>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Spark" component={SparkScanScreen} />
+          <Stack.Screen name="Capture" component={CaptureScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ScanditProvider>
+  );
+}
+```
+
+:::note
+`navigation` only needs an object with an `addListener` method for `focus` and `blur`
+events. React Navigation's `navigation` prop satisfies this, and so can your own
+implementation.
+:::
+
+## Turn Scanning Off Yourself
+
+Two more props sit alongside `navigation`, for the cases where focus and foreground are
+not the whole story:
+
+- `disabled` keeps scanning off whatever the screen's focus state is. Use it when your own
+  logic decides that scanning should stop, such as while a confirmation sheet is open.
+- `appStateHandlingDisabled` turns off the automatic suspend and resume when the app
+  moves between the background and the foreground. Set it only if you manage that
+  yourself.
+
+Every AIO view also exposes `enable()` and `disable()` on its handle for a single
+imperative change. Prefer `disabled` for state your render already knows about: the prop
+and the handle can otherwise disagree about whether scanning is on.
+
+## Where to Go Next
+
+- [Get Started](./get-started.md): mount the provider and add your first scanning view.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1114,6 +1114,12 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: [
         'sdks/react-native/core-concepts',
+        {
+          type: 'category',
+          label: 'AIO Components',
+          collapsed: true,
+          items: ['sdks/react-native/aio/get-started'],
+        },
         'sdks/react-native/system-requirements',
         {
           type: "link",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -1118,7 +1118,10 @@ const sidebars: SidebarsConfig = {
           type: 'category',
           label: 'AIO Components',
           collapsed: true,
-          items: ['sdks/react-native/aio/get-started'],
+          items: [
+            'sdks/react-native/aio/get-started',
+            'sdks/react-native/aio/navigating-between-screens',
+          ],
         },
         'sdks/react-native/system-requirements',
         {


### PR DESCRIPTION
Documents the React Native AIO components, which ship public in **8.7** with no guide. For most readers these pages are their first contact with the API.

Jira: [SDC-33129](https://scandit.atlassian.net/browse/SDC-33129) · Fix version `8.7.0-beta.1`

## What's here

A new **AIO Components** category in the React Native sidebar, with two pages.

**`aio/get-started.md`** — the linear path from an empty app to a working scanner: mounting `ScanditProvider`, adding a `SparkScanAioView` and handling results, camera position and torch, camera permissions, and the architecture support statement. The intro states that the components are available from 8.7.

**`aio/navigating-between-screens.md`** — the advanced page. Which views take a shared claim on the provider's camera and which one takes an exclusive claim, the `navigation` prop that suspends and resumes scanning on blur and focus, and the `disabled` / `appStateHandlingDisabled` props for when focus and foreground are not the whole story.

## Decisions worth reviewing

**Navigation earns its own page.** A single scanning screen is straightforward; a second one is where applications go wrong, and the material did not fit the linear shape of a getting-started guide. Get Started summarises the handover in three sentences and links onward.

**The navigation page leads with the `navigation` prop.** Passing the screen's navigation object is the concrete answer to "how do I use two scanning screens", so the ownership model is explained around it rather than on its own. The example crosses `SparkScanAioView` (exclusive claim) to `BarcodeCaptureAioView` (shared), because that transition is the one that breaks.

**No shared partial is imported.** Nine of the eleven React Native get-started pages import `_create-data-capture-context-react-native.mdx`, which builds a `DataCaptureContext` by hand. That is the work `ScanditProvider` removes, so reusing it would contradict the guide.

**Three things were deliberately left out.** `reset()` is too specific for a getting-started reader and belongs on the view reference page. Passing application data between screens is not something the SDK provides — `ScanditProvider` shares the capture context and the camera, and the only React context in the packages is internal — so that guidance would be generic React advice under Scandit's name. And a separate `ScanditProvider` page was folded into Get Started once the reference page in SDC-33126 was accounted for.

## Verification

- `yarn build` clean. `onBrokenMarkdownLinks` and `onBrokenAnchors` are both `throw`, so internal links and anchors between the two pages are verified.
- `yarn docs:gate` clean (Vale, cspell, frontmatter).
- Every identifier in every snippet is exported from the four RN packages' `ts/index.ts` on `develop`.
- Behavioural claims read from the implementation, not the TSDoc: the camera claim mode of all seven views, the nested-provider camera props, the `frameSourceState` claim release on unmount, and the Android/iOS split in `useCameraPermission`.

## Note on links

The `core/api/scandit-provider.html` links point at the reference page added by SDC-33126, which is not merged yet. They resolve once it lands.